### PR TITLE
Add screen selection setting for multi-monitor support

### DIFF
--- a/ClaudeIsland.xcodeproj/project.pbxproj
+++ b/ClaudeIsland.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.celestial.ClaudeIsland;
 				PRODUCT_NAME = "Claude Island";
 				REGISTER_APP_GROUPS = YES;
@@ -332,7 +332,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.celestial.ClaudeIsland;
 				PRODUCT_NAME = "Claude Island";
 				REGISTER_APP_GROUPS = YES;

--- a/ClaudeIsland/App/WindowManager.swift
+++ b/ClaudeIsland/App/WindowManager.swift
@@ -16,10 +16,11 @@ class WindowManager {
 
     /// Set up or recreate the notch window
     func setupNotchWindow() -> NotchWindowController? {
-        // Find the screen with the notch (built-in display), or fallback to main
-        let screen = NSScreen.builtin ?? NSScreen.main
+        // Use ScreenSelector for screen selection
+        let screenSelector = ScreenSelector.shared
+        screenSelector.refreshScreens()
 
-        guard let screen = screen else {
+        guard let screen = screenSelector.selectedScreen else {
             logger.warning("No screen found")
             return nil
         }

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -26,14 +26,12 @@ enum NotchOpenReason {
 enum NotchContentType: Equatable {
     case instances
     case menu
-    case soundSelection
     case chat(SessionState)
 
     var id: String {
         switch self {
         case .instances: return "instances"
         case .menu: return "menu"
-        case .soundSelection: return "soundSelection"
         case .chat(let session): return "chat-\(session.sessionId)"
         }
     }
@@ -51,6 +49,7 @@ class NotchViewModel: ObservableObject {
     // MARK: - Dependencies
 
     private let screenSelector = ScreenSelector.shared
+    private let soundSelector = SoundSelector.shared
 
     // MARK: - Geometry
 
@@ -75,13 +74,7 @@ class NotchViewModel: ObservableObject {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 420 + screenSelector.expandedPickerHeight
-            )
-        case .soundSelection:
-            // Taller size for sound selection list
-            return CGSize(
-                width: min(screenRect.width * 0.4, 480),
-                height: 500
+                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
             )
         case .instances:
             return CGSize(
@@ -113,11 +106,15 @@ class NotchViewModel: ObservableObject {
         )
         self.hasPhysicalNotch = hasPhysicalNotch
         setupEventHandlers()
-        observeScreenSelector()
+        observeSelectors()
     }
 
-    private func observeScreenSelector() {
+    private func observeSelectors() {
         screenSelector.$isPickerExpanded
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        soundSelector.$isPickerExpanded
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
     }

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -48,6 +48,10 @@ class NotchViewModel: ObservableObject {
     @Published var contentType: NotchContentType = .instances
     @Published var isHovering: Bool = false
 
+    // MARK: - Dependencies
+
+    private let screenSelector = ScreenSelector.shared
+
     // MARK: - Geometry
 
     let geometry: NotchGeometry
@@ -71,7 +75,7 @@ class NotchViewModel: ObservableObject {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 420
+                height: 420 + screenSelector.expandedPickerHeight
             )
         case .soundSelection:
             // Taller size for sound selection list
@@ -109,6 +113,13 @@ class NotchViewModel: ObservableObject {
         )
         self.hasPhysicalNotch = hasPhysicalNotch
         setupEventHandlers()
+        observeScreenSelector()
+    }
+
+    private func observeScreenSelector() {
+        screenSelector.$isPickerExpanded
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
     }
 
     // MARK: - Event Handling

--- a/ClaudeIsland/Core/ScreenSelector.swift
+++ b/ClaudeIsland/Core/ScreenSelector.swift
@@ -1,0 +1,150 @@
+//
+//  ScreenSelector.swift
+//  ClaudeIsland
+//
+//  Manages screen selection state and persistence
+//
+
+import AppKit
+import Combine
+import Foundation
+
+/// Strategy for selecting which screen to use
+enum ScreenSelectionMode: String, Codable {
+    case automatic       // Prefer built-in display, fall back to main
+    case specificScreen  // User selected a specific screen
+}
+
+/// Persistent identifier for a screen
+struct ScreenIdentifier: Codable, Equatable, Hashable {
+    let displayID: CGDirectDisplayID?
+    let localizedName: String
+
+    /// Create identifier from NSScreen
+    init(screen: NSScreen) {
+        if let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID {
+            self.displayID = screenNumber
+        } else {
+            self.displayID = nil
+        }
+        self.localizedName = screen.localizedName
+    }
+
+    /// Check if this identifier matches a given screen
+    func matches(_ screen: NSScreen) -> Bool {
+        guard let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID else {
+            return localizedName == screen.localizedName
+        }
+        // Primary match: displayID (most reliable when connected)
+        if let savedID = displayID, savedID == screenNumber {
+            return true
+        }
+        // Fallback: name match (for reconnected displays with new IDs)
+        return localizedName == screen.localizedName
+    }
+}
+
+@MainActor
+class ScreenSelector: ObservableObject {
+    static let shared = ScreenSelector()
+
+    // MARK: - Published State
+    @Published private(set) var availableScreens: [NSScreen] = []
+    @Published private(set) var selectedScreen: NSScreen?
+    @Published var selectionMode: ScreenSelectionMode = .automatic
+    @Published var isPickerExpanded: Bool = false
+
+    // MARK: - UserDefaults Keys
+    private let modeKey = "screenSelectionMode"
+    private let screenIdentifierKey = "selectedScreenIdentifier"
+
+    // MARK: - Private State
+    private var savedIdentifier: ScreenIdentifier?
+
+    private init() {
+        loadPreferences()
+        refreshScreens()
+    }
+
+    // MARK: - Public API
+
+    /// Refresh the available screens list
+    func refreshScreens() {
+        availableScreens = NSScreen.screens
+        selectedScreen = resolveSelectedScreen()
+    }
+
+    /// Select a specific screen
+    func selectScreen(_ screen: NSScreen) {
+        selectionMode = .specificScreen
+        savedIdentifier = ScreenIdentifier(screen: screen)
+        selectedScreen = screen
+        savePreferences()
+    }
+
+    /// Reset to automatic selection
+    func selectAutomatic() {
+        selectionMode = .automatic
+        savedIdentifier = nil
+        selectedScreen = resolveSelectedScreen()
+        savePreferences()
+    }
+
+    /// Check if a screen is currently selected
+    func isSelected(_ screen: NSScreen) -> Bool {
+        guard let selected = selectedScreen else { return false }
+        return screenID(of: screen) == screenID(of: selected)
+    }
+
+    /// Extra height needed when picker is expanded
+    var expandedPickerHeight: CGFloat {
+        guard isPickerExpanded else { return 0 }
+        // +1 for "Automatic" option
+        return CGFloat(availableScreens.count + 1) * 40
+    }
+
+    // MARK: - Private Methods
+
+    private func screenID(of screen: NSScreen) -> CGDirectDisplayID? {
+        screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+    }
+
+    private func resolveSelectedScreen() -> NSScreen? {
+        switch selectionMode {
+        case .automatic:
+            return NSScreen.builtin ?? NSScreen.main
+
+        case .specificScreen:
+            // Try to find the saved screen
+            if let identifier = savedIdentifier,
+               let match = availableScreens.first(where: { identifier.matches($0) }) {
+                return match
+            }
+            // Saved screen not found - fall back to automatic
+            return NSScreen.builtin ?? NSScreen.main
+        }
+    }
+
+    private func loadPreferences() {
+        if let modeString = UserDefaults.standard.string(forKey: modeKey),
+           let mode = ScreenSelectionMode(rawValue: modeString) {
+            selectionMode = mode
+        }
+
+        if let data = UserDefaults.standard.data(forKey: screenIdentifierKey),
+           let identifier = try? JSONDecoder().decode(ScreenIdentifier.self, from: data) {
+            savedIdentifier = identifier
+        }
+    }
+
+    private func savePreferences() {
+        UserDefaults.standard.set(selectionMode.rawValue, forKey: modeKey)
+
+        if let identifier = savedIdentifier,
+           let data = try? JSONEncoder().encode(identifier) {
+            UserDefaults.standard.set(data, forKey: screenIdentifierKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: screenIdentifierKey)
+        }
+    }
+}

--- a/ClaudeIsland/Core/SoundSelector.swift
+++ b/ClaudeIsland/Core/SoundSelector.swift
@@ -1,0 +1,38 @@
+//
+//  SoundSelector.swift
+//  ClaudeIsland
+//
+//  Manages sound selection state for the settings menu
+//
+
+import Combine
+import Foundation
+
+@MainActor
+class SoundSelector: ObservableObject {
+    static let shared = SoundSelector()
+
+    // MARK: - Published State
+
+    @Published var isPickerExpanded: Bool = false
+
+    // MARK: - Constants
+
+    /// Maximum number of sound options to show before scrolling
+    private let maxVisibleOptions = 6
+
+    /// Height per sound option row
+    private let rowHeight: CGFloat = 32
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Extra height needed when picker is expanded (capped for scrolling)
+    var expandedPickerHeight: CGFloat {
+        guard isPickerExpanded else { return 0 }
+        let totalOptions = NotificationSound.allCases.count
+        let visibleOptions = min(totalOptions, maxVisibleOptions)
+        return CGFloat(visibleOptions) * rowHeight + 8 // +8 for padding
+    }
+}

--- a/ClaudeIsland/UI/Components/ScreenPickerRow.swift
+++ b/ClaudeIsland/UI/Components/ScreenPickerRow.swift
@@ -1,0 +1,186 @@
+//
+//  ScreenPickerRow.swift
+//  ClaudeIsland
+//
+//  Screen selection picker for settings menu
+//
+
+import SwiftUI
+
+struct ScreenPickerRow: View {
+    @ObservedObject var screenSelector: ScreenSelector
+    @State private var isHovered = false
+
+    private var isExpanded: Bool {
+        get { screenSelector.isPickerExpanded }
+    }
+
+    private func setExpanded(_ value: Bool) {
+        screenSelector.isPickerExpanded = value
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Main row - shows current selection
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    setExpanded(!isExpanded)
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "display")
+                        .font(.system(size: 12))
+                        .foregroundColor(textColor)
+                        .frame(width: 16)
+
+                    Text("Screen")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(textColor)
+
+                    Spacer()
+
+                    Text(currentSelectionLabel)
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.4))
+                        .lineLimit(1)
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+
+            // Expanded screen list
+            if isExpanded {
+                VStack(spacing: 2) {
+                    // Automatic option
+                    ScreenOptionRow(
+                        label: "Automatic",
+                        sublabel: "Built-in or Main",
+                        isSelected: screenSelector.selectionMode == .automatic
+                    ) {
+                        screenSelector.selectAutomatic()
+                        triggerWindowRecreation()
+                        collapseAfterDelay()
+                    }
+
+                    // Individual screens
+                    ForEach(screenSelector.availableScreens, id: \.self) { screen in
+                        ScreenOptionRow(
+                            label: screen.localizedName,
+                            sublabel: screenSublabel(for: screen),
+                            isSelected: screenSelector.selectionMode == .specificScreen &&
+                                       screenSelector.isSelected(screen)
+                        ) {
+                            screenSelector.selectScreen(screen)
+                            triggerWindowRecreation()
+                            collapseAfterDelay()
+                        }
+                    }
+                }
+                .padding(.leading, 28)
+                .padding(.top, 4)
+            }
+        }
+    }
+
+    private var currentSelectionLabel: String {
+        switch screenSelector.selectionMode {
+        case .automatic:
+            return "Auto"
+        case .specificScreen:
+            if let screen = screenSelector.selectedScreen {
+                return screen.localizedName
+            }
+            return "Auto"
+        }
+    }
+
+    private var textColor: Color {
+        .white.opacity(isHovered ? 1.0 : 0.7)
+    }
+
+    private func screenSublabel(for screen: NSScreen) -> String? {
+        var parts: [String] = []
+        if screen.isBuiltinDisplay {
+            parts.append("Built-in")
+        }
+        if screen == NSScreen.main {
+            parts.append("Main")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+
+    private func triggerWindowRecreation() {
+        // Notify to recreate the window
+        NotificationCenter.default.post(
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+    }
+
+    private func collapseAfterDelay() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                setExpanded(false)
+            }
+        }
+    }
+}
+
+// MARK: - Screen Option Row
+
+private struct ScreenOptionRow: View {
+    let label: String
+    let sublabel: String?
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(isSelected ? TerminalColors.green : Color.white.opacity(0.2))
+                    .frame(width: 6, height: 6)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(label)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.7))
+
+                    if let sublabel = sublabel {
+                        Text(sublabel)
+                            .font(.system(size: 10))
+                            .foregroundColor(.white.opacity(0.4))
+                    }
+                }
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(TerminalColors.green)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}

--- a/ClaudeIsland/UI/Components/SoundPickerRow.swift
+++ b/ClaudeIsland/UI/Components/SoundPickerRow.swift
@@ -1,0 +1,135 @@
+//
+//  SoundPickerRow.swift
+//  ClaudeIsland
+//
+//  Notification sound selection picker for settings menu
+//
+
+import AppKit
+import SwiftUI
+
+struct SoundPickerRow: View {
+    @ObservedObject var soundSelector: SoundSelector
+    @State private var isHovered = false
+    @State private var selectedSound: NotificationSound = AppSettings.notificationSound
+
+    private var isExpanded: Bool {
+        soundSelector.isPickerExpanded
+    }
+
+    private func setExpanded(_ value: Bool) {
+        soundSelector.isPickerExpanded = value
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Main row - shows current selection
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    setExpanded(!isExpanded)
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "speaker.wave.2")
+                        .font(.system(size: 12))
+                        .foregroundColor(textColor)
+                        .frame(width: 16)
+
+                    Text("Notification Sound")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(textColor)
+
+                    Spacer()
+
+                    Text(selectedSound.rawValue)
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.4))
+                        .lineLimit(1)
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+
+            // Expanded sound list
+            if isExpanded {
+                ScrollView {
+                    VStack(spacing: 2) {
+                        ForEach(NotificationSound.allCases, id: \.self) { sound in
+                            SoundOptionRowInline(
+                                sound: sound,
+                                isSelected: selectedSound == sound
+                            ) {
+                                // Play preview sound
+                                if let soundName = sound.soundName {
+                                    NSSound(named: soundName)?.play()
+                                }
+                                selectedSound = sound
+                                AppSettings.notificationSound = sound
+                            }
+                        }
+                    }
+                }
+                .frame(maxHeight: CGFloat(min(NotificationSound.allCases.count, 6)) * 32)
+                .padding(.leading, 28)
+                .padding(.top, 4)
+            }
+        }
+        .onAppear {
+            selectedSound = AppSettings.notificationSound
+        }
+    }
+
+    private var textColor: Color {
+        .white.opacity(isHovered ? 1.0 : 0.7)
+    }
+}
+
+// MARK: - Sound Option Row (Inline version)
+
+private struct SoundOptionRowInline: View {
+    let sound: NotificationSound
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(isSelected ? TerminalColors.green : Color.white.opacity(0.2))
+                    .frame(width: 6, height: 6)
+
+                Text(sound.rawValue)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.7))
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(TerminalColors.green)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -11,60 +11,13 @@ import SwiftUI
 import ServiceManagement
 import Sparkle
 
-// MARK: - SoundSelectionView
-
-struct SoundSelectionView: View {
-    @ObservedObject var viewModel: NotchViewModel
-    @State private var selectedSound: NotificationSound = AppSettings.notificationSound
-
-    var body: some View {
-        VStack(spacing: 4) {
-            // Back button
-            MenuRow(
-                icon: "chevron.left",
-                label: "Back"
-            ) {
-                viewModel.contentType = .menu
-            }
-
-            Divider()
-                .background(Color.white.opacity(0.08))
-                .padding(.vertical, 4)
-
-            // Sound options
-            ScrollView {
-                VStack(spacing: 2) {
-                    ForEach(NotificationSound.allCases, id: \.self) { sound in
-                        SoundOptionRow(
-                            sound: sound,
-                            isSelected: selectedSound == sound
-                        ) {
-                            // Play preview sound
-                            if let soundName = sound.soundName {
-                                NSSound(named: soundName)?.play()
-                            }
-                            selectedSound = sound
-                            AppSettings.notificationSound = sound
-                        }
-                    }
-                }
-            }
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 8)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .onAppear {
-            selectedSound = AppSettings.notificationSound
-        }
-    }
-}
-
 // MARK: - NotchMenuView
 
 struct NotchMenuView: View {
     @ObservedObject var viewModel: NotchViewModel
     @ObservedObject private var updateManager = UpdateManager.shared
     @ObservedObject private var screenSelector = ScreenSelector.shared
+    @ObservedObject private var soundSelector = SoundSelector.shared
     @State private var hooksInstalled: Bool = false
     @State private var launchAtLogin: Bool = false
 
@@ -82,28 +35,15 @@ struct NotchMenuView: View {
                 .background(Color.white.opacity(0.08))
                 .padding(.vertical, 4)
 
-            // Accessibility permission row - check live every render
-            AccessibilityRow(isEnabled: AXIsProcessTrusted())
-
-            // Screen picker
+            // Appearance settings
             ScreenPickerRow(screenSelector: screenSelector)
+            SoundPickerRow(soundSelector: soundSelector)
 
-            // Hooks toggle
-            MenuToggleRow(
-                icon: "arrow.triangle.2.circlepath",
-                label: "Hooks",
-                isOn: hooksInstalled
-            ) {
-                if hooksInstalled {
-                    HookInstaller.uninstall()
-                    hooksInstalled = false
-                } else {
-                    HookInstaller.installIfNeeded()
-                    hooksInstalled = true
-                }
-            }
+            Divider()
+                .background(Color.white.opacity(0.08))
+                .padding(.vertical, 4)
 
-            // Launch at Login toggle
+            // System settings
             MenuToggleRow(
                 icon: "power",
                 label: "Launch at Login",
@@ -122,20 +62,29 @@ struct NotchMenuView: View {
                 }
             }
 
-            // Notification sound - navigates to sound selection
-            MenuNavigationRow(
-                icon: "speaker.wave.2",
-                label: "Notification Sound",
-                value: AppSettings.notificationSound.rawValue
+            MenuToggleRow(
+                icon: "arrow.triangle.2.circlepath",
+                label: "Hooks",
+                isOn: hooksInstalled
             ) {
-                viewModel.contentType = .soundSelection
+                if hooksInstalled {
+                    HookInstaller.uninstall()
+                    hooksInstalled = false
+                } else {
+                    HookInstaller.installIfNeeded()
+                    hooksInstalled = true
+                }
             }
+
+            AccessibilityRow(isEnabled: AXIsProcessTrusted())
 
             Divider()
                 .background(Color.white.opacity(0.08))
                 .padding(.vertical, 4)
 
-            // GitHub link
+            // About
+            UpdateRow(updateManager: updateManager)
+
             MenuRow(
                 icon: "star",
                 label: "Star on GitHub"
@@ -144,9 +93,6 @@ struct NotchMenuView: View {
                     NSWorkspace.shared.open(url)
                 }
             }
-
-            // Update row
-            UpdateRow(updateManager: updateManager)
 
             Divider()
                 .background(Color.white.opacity(0.08))
@@ -576,83 +522,5 @@ struct MenuToggleRow: View {
 
     private var textColor: Color {
         .white.opacity(isHovered ? 1.0 : 0.7)
-    }
-}
-
-struct MenuNavigationRow: View {
-    let icon: String
-    let label: String
-    let value: String
-    let action: () -> Void
-
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 10) {
-                Image(systemName: icon)
-                    .font(.system(size: 12))
-                    .foregroundColor(textColor)
-                    .frame(width: 16)
-
-                Text(label)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(textColor)
-
-                Spacer()
-
-                Text(value)
-                    .font(.system(size: 11))
-                    .foregroundColor(.white.opacity(0.4))
-
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 10))
-                    .foregroundColor(.white.opacity(0.4))
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
-            )
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-    }
-
-    private var textColor: Color {
-        .white.opacity(isHovered ? 1.0 : 0.7)
-    }
-}
-
-struct SoundOptionRow: View {
-    let sound: NotificationSound
-    let isSelected: Bool
-    let action: () -> Void
-
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Circle()
-                    .fill(isSelected ? TerminalColors.green : Color.white.opacity(0.2))
-                    .frame(width: 6, height: 6)
-
-                Text(sound.rawValue)
-                    .font(.system(size: 12))
-                    .foregroundColor(isSelected ? .white : .white.opacity(0.6))
-
-                Spacer()
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
-            )
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
     }
 }

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -64,6 +64,7 @@ struct SoundSelectionView: View {
 struct NotchMenuView: View {
     @ObservedObject var viewModel: NotchViewModel
     @ObservedObject private var updateManager = UpdateManager.shared
+    @ObservedObject private var screenSelector = ScreenSelector.shared
     @State private var hooksInstalled: Bool = false
     @State private var launchAtLogin: Bool = false
 
@@ -83,6 +84,9 @@ struct NotchMenuView: View {
 
             // Accessibility permission row - check live every render
             AccessibilityRow(isEnabled: AXIsProcessTrusted())
+
+            // Screen picker
+            ScreenPickerRow(screenSelector: screenSelector)
 
             // Hooks toggle
             MenuToggleRow(
@@ -172,6 +176,7 @@ struct NotchMenuView: View {
     private func refreshStates() {
         hooksInstalled = HookInstaller.isInstalled()
         launchAtLogin = SMAppService.mainApp.status == .enabled
+        screenSelector.refreshScreens()
     }
 }
 

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -356,8 +356,6 @@ struct NotchView: View {
                 )
             case .menu:
                 NotchMenuView(viewModel: viewModel)
-            case .soundSelection:
-                SoundSelectionView(viewModel: viewModel)
             case .chat(let session):
                 ChatView(
                     sessionId: session.sessionId,


### PR DESCRIPTION
Hi Farouq!
First of all: amazing app! Love it so much!

I'm coming with a feature, as I'd love to see the notch on my main screen, which is not the one with the notch. This PR allows users to select the screen on which to see the island.

## Summary
- Add screen picker in settings menu to select which display shows the island
- Support automatic mode (built-in or main screen) and specific screen selection
- Persist screen preference across app sessions via UserDefaults

## Demo
Link to recording (too big to attach in PR): https://drive.google.com/file/d/11rtHrJoRb8vQDwdRrv9YgKsCxmou_vYe/view?usp=sharing