### PR TITLE
feat(notch): add notch style customization with neat mode

### DIFF
--- a/ClaudeIsland/App/AppDelegate.swift
+++ b/ClaudeIsland/App/AppDelegate.swift
@@ -4,6 +4,10 @@ import Mixpanel
 import Sparkle
 import SwiftUI
 
+extension Notification.Name {
+    static let notchStyleChanged = Notification.Name("notchStyleChanged")
+}
+
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var windowManager: WindowManager?
     private var screenObserver: ScreenObserver?
@@ -77,6 +81,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.handleScreenChange()
         }
 
+        NotificationCenter.default.addObserver(
+            forName: .notchStyleChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleNotchStyleChange()
+        }
+
         if updater.canCheckForUpdates {
             updater.checkForUpdates()
         }
@@ -89,6 +101,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleScreenChange() {
         _ = windowManager?.setupNotchWindow()
+    }
+
+    private func handleNotchStyleChange() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            _ = self?.windowManager?.setupNotchWindow()
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/ClaudeIsland/Core/Ext+NSScreen.swift
+++ b/ClaudeIsland/Core/Ext+NSScreen.swift
@@ -7,27 +7,65 @@
 
 import AppKit
 
+enum NotchStyle: String, Codable, CaseIterable {
+    case `default`
+    case neat
+
+    var displayName: String {
+        switch self {
+        case .default: return "Default"
+        case .neat: return "Neat"
+        }
+    }
+
+    var sublabel: String {
+        switch self {
+        case .default: return "Physical Notch"
+        case .neat: return "Menu Bar Height"
+        }
+    }
+}
+
 extension NSScreen {
+    static let menuBarHeight: CGFloat = 25
+
     /// Returns the size of the notch on this screen (pixel-perfect using macOS APIs)
     var notchSize: CGSize {
-        guard safeAreaInsets.top > 0 else {
-            // Fallback for non-notch displays (matches typical MacBook notch)
-            return CGSize(width: 224, height: 38)
+        notchSize(for: .default)
+    }
+
+    /// Returns the size of the notch for a given style
+    func notchSize(for style: NotchStyle) -> CGSize {
+        switch style {
+        case .neat:
+            let fullWidth = frame.width
+            let leftPadding = auxiliaryTopLeftArea?.width ?? 0
+            let rightPadding = auxiliaryTopRightArea?.width ?? 0
+
+            if leftPadding > 0, rightPadding > 0 {
+                let notchWidth = fullWidth - leftPadding - rightPadding + 4
+                return CGSize(width: notchWidth, height: NSScreen.menuBarHeight)
+            } else {
+                return CGSize(width: 180, height: NSScreen.menuBarHeight)
+            }
+
+        case .default:
+            guard safeAreaInsets.top > 0 else {
+                return CGSize(width: 224, height: 38)
+            }
+
+            let notchHeight = safeAreaInsets.top
+            let fullWidth = frame.width
+            let leftPadding = auxiliaryTopLeftArea?.width ?? 0
+            let rightPadding = auxiliaryTopRightArea?.width ?? 0
+
+            guard leftPadding > 0, rightPadding > 0 else {
+                return CGSize(width: 180, height: notchHeight)
+            }
+
+            let notchWidth = fullWidth - leftPadding - rightPadding + 4
+            return CGSize(width: notchWidth, height: notchHeight)
         }
-
-        let notchHeight = safeAreaInsets.top
-        let fullWidth = frame.width
-        let leftPadding = auxiliaryTopLeftArea?.width ?? 0
-        let rightPadding = auxiliaryTopRightArea?.width ?? 0
-
-        guard leftPadding > 0, rightPadding > 0 else {
-            // Fallback if auxiliary areas unavailable
-            return CGSize(width: 180, height: notchHeight)
-        }
-
-        // +4 to match boring.notch's calculation for proper alignment
-        let notchWidth = fullWidth - leftPadding - rightPadding + 4
-        return CGSize(width: notchWidth, height: notchHeight)
     }
 
     /// Whether this is the built-in display

--- a/ClaudeIsland/Core/NotchStyleSelector.swift
+++ b/ClaudeIsland/Core/NotchStyleSelector.swift
@@ -1,0 +1,25 @@
+//
+//  NotchStyleSelector.swift
+//  ClaudeIsland
+//
+//  Manages notch style selection state for the settings menu
+//
+
+import Combine
+import Foundation
+
+@MainActor
+class NotchStyleSelector: ObservableObject {
+    static let shared = NotchStyleSelector()
+
+    @Published var isPickerExpanded: Bool = false
+
+    private let rowHeight: CGFloat = 40
+
+    private init() {}
+
+    var expandedPickerHeight: CGFloat {
+        guard isPickerExpanded else { return 0 }
+        return CGFloat(NotchStyle.allCases.count) * rowHeight + 4
+    }
+}

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -50,6 +50,7 @@ class NotchViewModel: ObservableObject {
 
     private let screenSelector = ScreenSelector.shared
     private let soundSelector = SoundSelector.shared
+    private let notchStyleSelector = NotchStyleSelector.shared
 
     // MARK: - Geometry
 
@@ -74,7 +75,7 @@ class NotchViewModel: ObservableObject {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
+                height: 420 + notchStyleSelector.expandedPickerHeight + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
             )
         case .instances:
             return CGSize(
@@ -110,6 +111,10 @@ class NotchViewModel: ObservableObject {
     }
 
     private func observeSelectors() {
+        notchStyleSelector.$isPickerExpanded
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
         screenSelector.$isPickerExpanded
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)

--- a/ClaudeIsland/Core/Settings.swift
+++ b/ClaudeIsland/Core/Settings.swift
@@ -38,6 +38,7 @@ enum AppSettings {
 
     private enum Keys {
         static let notificationSound = "notificationSound"
+        static let notchStyle = "notchStyle"
     }
 
     // MARK: - Notification Sound
@@ -47,12 +48,28 @@ enum AppSettings {
         get {
             guard let rawValue = defaults.string(forKey: Keys.notificationSound),
                   let sound = NotificationSound(rawValue: rawValue) else {
-                return .pop // Default to Pop
+                return .pop
             }
             return sound
         }
         set {
             defaults.set(newValue.rawValue, forKey: Keys.notificationSound)
+        }
+    }
+
+    // MARK: - Notch Style
+
+    /// The visual style of the notch (default physical notch or neat menu bar height)
+    static var notchStyle: NotchStyle {
+        get {
+            guard let rawValue = defaults.string(forKey: Keys.notchStyle),
+                  let style = NotchStyle(rawValue: rawValue) else {
+                return .neat
+            }
+            return style
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: Keys.notchStyle)
         }
     }
 }

--- a/ClaudeIsland/UI/Components/NotchStylePickerRow.swift
+++ b/ClaudeIsland/UI/Components/NotchStylePickerRow.swift
@@ -1,0 +1,161 @@
+//
+//  NotchStylePickerRow.swift
+//  ClaudeIsland
+//
+//  Notch style selection for settings menu
+//
+
+import SwiftUI
+
+struct NotchStylePickerRow: View {
+    @ObservedObject var notchStyleSelector: NotchStyleSelector
+    @State private var selectedStyle: NotchStyle = AppSettings.notchStyle
+    @State private var isHovered = false
+
+    private var isExpanded: Bool {
+        notchStyleSelector.isPickerExpanded
+    }
+
+    private func setExpanded(_ value: Bool) {
+        notchStyleSelector.isPickerExpanded = value
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Main row - shows current selection
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    setExpanded(!isExpanded)
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "rectangle.topthird.inset.filled")
+                        .font(.system(size: 12))
+                        .foregroundColor(textColor)
+                        .frame(width: 16)
+
+                    Text("Notch Style")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(textColor)
+
+                    Spacer()
+
+                    Text(currentSelectionLabel)
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.4))
+                        .lineLimit(1)
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+
+            // Expanded style list
+            if isExpanded {
+                VStack(spacing: 2) {
+                    NotchStyleOptionRow(
+                        style: .default,
+                        isSelected: selectedStyle == .default
+                    ) {
+                        selectStyle(.default)
+                    }
+
+                    NotchStyleOptionRow(
+                        style: .neat,
+                        isSelected: selectedStyle == .neat
+                    ) {
+                        selectStyle(.neat)
+                    }
+                }
+                .padding(.leading, 28)
+                .padding(.top, 4)
+            }
+        }
+        .onAppear {
+            selectedStyle = AppSettings.notchStyle
+        }
+    }
+
+    private var currentSelectionLabel: String {
+        switch selectedStyle {
+        case .default:
+            return "Default"
+        case .neat:
+            return "Neat"
+        }
+    }
+
+    private var textColor: Color {
+        .white.opacity(isHovered ? 1.0 : 0.7)
+    }
+
+    private func selectStyle(_ style: NotchStyle) {
+        selectedStyle = style
+        AppSettings.notchStyle = style
+        NotificationCenter.default.post(name: .notchStyleChanged, object: nil)
+        collapseAfterDelay()
+    }
+
+    private func collapseAfterDelay() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                setExpanded(false)
+            }
+        }
+    }
+}
+
+// MARK: - Notch Style Option Row
+
+private struct NotchStyleOptionRow: View {
+    let style: NotchStyle
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(isSelected ? TerminalColors.green : Color.white.opacity(0.2))
+                    .frame(width: 6, height: 6)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(style.displayName)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.7))
+
+                    Text(style.sublabel)
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(TerminalColors.green)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -16,6 +16,7 @@ import Sparkle
 struct NotchMenuView: View {
     @ObservedObject var viewModel: NotchViewModel
     @ObservedObject private var updateManager = UpdateManager.shared
+    @ObservedObject private var notchStyleSelector = NotchStyleSelector.shared
     @ObservedObject private var screenSelector = ScreenSelector.shared
     @ObservedObject private var soundSelector = SoundSelector.shared
     @State private var hooksInstalled: Bool = false
@@ -36,6 +37,7 @@ struct NotchMenuView: View {
                 .padding(.vertical, 4)
 
             // Appearance settings
+            NotchStylePickerRow(notchStyleSelector: notchStyleSelector)
             ScreenPickerRow(screenSelector: screenSelector)
             SoundPickerRow(soundSelector: soundSelector)
 

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -9,10 +9,16 @@ import AppKit
 import CoreGraphics
 import SwiftUI
 
-// Corner radius constants
-private let cornerRadiusInsets = (
+// Corner radius constants for default (physical notch)
+private let cornerRadiusInsetsDefault = (
     opened: (top: CGFloat(19), bottom: CGFloat(24)),
     closed: (top: CGFloat(6), bottom: CGFloat(14))
+)
+
+// Corner radius constants for neat (menu bar height)
+private let cornerRadiusInsetsNeat = (
+    opened: (top: CGFloat(19), bottom: CGFloat(24)),
+    closed: (top: CGFloat(4), bottom: CGFloat(8))
 )
 
 struct NotchView: View {
@@ -108,6 +114,10 @@ struct NotchView: View {
 
     // MARK: - Corner Radii
 
+    private var cornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), closed: (top: CGFloat, bottom: CGFloat)) {
+        AppSettings.notchStyle == .neat ? cornerRadiusInsetsNeat : cornerRadiusInsetsDefault
+    }
+
     private var topCornerRadius: CGFloat {
         viewModel.status == .opened
             ? cornerRadiusInsets.opened.top
@@ -176,11 +186,6 @@ struct NotchView: View {
                     .onHover { hovering in
                         withAnimation(.spring(response: 0.38, dampingFraction: 0.8)) {
                             isHovering = hovering
-                        }
-                    }
-                    .onTapGesture {
-                        if viewModel.status != .opened {
-                            viewModel.notchOpen(reason: .click)
                         }
                     }
             }

--- a/ClaudeIsland/UI/Window/NotchWindowController.swift
+++ b/ClaudeIsland/UI/Window/NotchWindowController.swift
@@ -18,7 +18,8 @@ class NotchWindowController: NSWindowController {
         self.screen = screen
 
         let screenFrame = screen.frame
-        let notchSize = screen.notchSize
+        let notchStyle = AppSettings.notchStyle
+        let notchSize = screen.notchSize(for: notchStyle)
 
         // Window covers full width at top, tall enough for largest content (chat view)
         let windowHeight: CGFloat = 750


### PR DESCRIPTION
This pull request adds a new notch style customization feature that allows users to choose between the default physical notch appearance and a neat menu bar height style. The main changes include new style selection UI and automatic notch window refresh when the style changes.

**Notch Style Selection Feature:**
* Added a new `NotchStyle` enum in `Ext+NSScreen.swift` with two options: `default` (physical notch) and `neat` (menu bar height), each with display names and sublabels for the UI.
* Extended `NSScreen` with a `notchSize(for:)` method that calculates the appropriate notch dimensions based on the selected style, using menu bar height (25pt) for neat mode.
* Created `NotchStyleSelector.swift` to manage notch style selection state with picker expansion support, following the same pattern as screen and sound selectors.
* Added `NotchStylePickerRow.swift` component to display the notch style picker in the settings menu.
* Updated `Settings.swift` to persist the user's notch style preference with a default value of `.neat`.

**Notch Window Refresh on Style Change:**
* Added a new `notchStyleChanged` notification in `AppDelegate.swift` to trigger notch window updates when the style changes.
* Implemented `handleNotchStyleChange()` method in `AppDelegate` that rebuilds the notch window with a small delay to ensure smooth transitions.
* Updated `NotchWindowController.swift` to use the selected notch style when initializing the window frame.

**UI Updates:**
* Integrated `NotchStylePickerRow` into `NotchMenuView.swift` to display the style picker in the settings section.
* Updated `NotchView.swift` to use different corner radius values for neat mode (4pt/8pt) versus default mode (6pt/14pt) when closed, providing appropriate visual styling for each mode.
* Modified `NotchViewModel.swift` to include the notch style selector's expanded state in height calculations for the settings menu.