### PR TITLE
fix(notch): use full visual size for accurate click detection

### DIFF
--- a/ClaudeIsland/Core/NotchGeometry.swift
+++ b/ClaudeIsland/Core/NotchGeometry.swift
@@ -26,14 +26,12 @@ struct NotchGeometry: Sendable {
 
     /// The opened panel rect in screen coordinates for a given size
     func openedScreenRect(for size: CGSize) -> CGRect {
-        // Match the actual rendered panel size (tuned to match visual output)
-        let width = size.width - 6
-        let height = size.height - 30
+        // Use the full visual size for accurate click detection
         return CGRect(
-            x: screenRect.midX - width / 2,
-            y: screenRect.maxY - height,
-            width: width,
-            height: height
+            x: screenRect.midX - size.width / 2,
+            y: screenRect.maxY - size.height,
+            width: size.width,
+            height: size.height
         )
     }
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,57 @@
+.EXPORT_ALL_VARIABLES:
+NAME = claude-island
+
+.PHONY: build
+## Build claude island
+build:
+	@echo "building claude island... 🐙"
+	@xcodebuild -scheme ClaudeIsland -configuration Release build
+
+.PHONY: clean
+## Remove build files and caches
+clean:
+	@echo "Cleaning Xcode build artifacts..."
+	@xcodebuild clean -scheme ClaudeIsland -configuration Release 2>/dev/null || true
+	@rm -rf ~/Library/Developer/Xcode/DerivedData/ClaudeIsland-* 2>/dev/null || true
+	@echo "Cleaned build artifacts and caches"
+
+.DEFAULT_GOAL := help
+
+help:
+	@echo "$$(tput bold)Available rules:$$(tput sgr0)"
+	@echo
+	@sed -n -e "/^## / { \
+		h; \
+		s/.*//; \
+		:doc" \
+		-e "H; \
+		n; \
+		s/^## //; \
+		t doc" \
+		-e "s/:.*//; \
+		G; \
+		s/\\n## /---/; \
+		s/\\n/ /g; \
+		p; \
+	}" ${MAKEFILE_LIST} \
+	| LC_ALL='C' sort --ignore-case \
+	| awk -F '---' \
+		-v ncol=$$(tput cols) \
+		-v indent=19 \
+		-v col_on="$$(tput setaf 6)" \
+		-v col_off="$$(tput sgr0)" \
+	'{ \
+		printf "%s%*s%s ", col_on, -indent, $$1, col_off; \
+		n = split($$2, words, " "); \
+		line_length = ncol - indent; \
+		for (i = 1; i <= n; i++) { \
+			line_length -= length(words[i]) + 1; \
+			if (line_length <= 0) { \
+				line_length = ncol - indent - length(words[i]) - 1; \
+				printf "\n%*s ", -indent, " "; \
+			} \
+			printf "%s ", words[i]; \
+		} \
+		printf "\n"; \
+	}' \
+	| more $(shell test $(shell uname) = Darwin && echo '--no-init --raw-control-chars')


### PR DESCRIPTION
This commit updates the notch geometry calculation to use the full visual size instead of adjusted dimensions, improving click detection accuracy. The main changes are grouped below.

**Notch Geometry Update:**
* Modified `openedScreenRect(for:)` method in `ClaudeIsland/Core/NotchGeometry.swift` to use the full visual size (`size.width` and `size.height`) instead of adjusted dimensions (`size.width - 6` and `size.height - 30`), ensuring accurate click detection for the opened panel rect in screen coordinates.
* Removed manual width and height adjustments that were previously tuned to match visual output but caused click detection issues.

**Build Configuration:**
* Added a new `makefile` to the project root for fast build automation and task management.