### PR TITLE
Fix: Don't trigger alert when context resumes

### DIFF
--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -449,7 +449,22 @@ struct NotchView: View {
         // Bounce the notch when a session newly enters waitingForInput state
         if !newWaitingIds.isEmpty {
             // Get the sessions that just entered waitingForInput
-            let newlyWaitingSessions = waitingForInputSessions.filter { newWaitingIds.contains($0.stableId) }
+            // Filter out context resume messages - these aren't "done" states
+            let newlyWaitingSessions = waitingForInputSessions.filter { session in
+                guard newWaitingIds.contains(session.stableId) else { return false }
+                // Don't alert for context resume (ran out of context window)
+                if let lastMessage = session.lastMessage,
+                   lastMessage.hasPrefix("This session is being continued from a previous conversation") {
+                    return false
+                }
+                return true
+            }
+
+            // Skip all alerts if only context resumes remain
+            guard !newlyWaitingSessions.isEmpty else {
+                previousWaitingForInputIds = currentIds
+                return
+            }
 
             // Play notification sound if the session is not actively focused
             if let soundName = AppSettings.notificationSound.soundName {


### PR DESCRIPTION
When Claude Code runs out of context and resumes, the hook sends waiting_for_input status. This was incorrectly triggering the notification sound and UI bounce.

Filter out sessions where lastMessage starts with the context resume prefix before triggering alerts.