### PR TITLE
fix(menu): increase menu height so Quit button is interactive

### DIFF
--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -74,7 +74,7 @@ class NotchViewModel: ObservableObject {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
+                height: 500 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
             )
         case .instances:
             return CGSize(


### PR DESCRIPTION
## Summary

- Fixes the Quit button being unresponsive in the settings menu
- The menu content exceeded the 420px height allocation, causing the Quit button at the bottom to be outside the interactive area (no hover highlight, clicks ignored)
- Increased menu height from 420px to 500px

Fixes #20

## Test plan

- [ ] Open Claude Island settings menu (hamburger icon)
- [ ] Verify Quit button highlights on hover
- [ ] Verify clicking Quit closes the application