### PR TITLE
fix(screen): prevent window flicker when waking from sleep

### DIFF
--- a/ClaudeIsland/App/ScreenObserver.swift
+++ b/ClaudeIsland/App/ScreenObserver.swift
@@ -10,6 +10,11 @@ import AppKit
 class ScreenObserver {
     private var observer: Any?
     private let onScreenChange: () -> Void
+    private var pendingWork: DispatchWorkItem?
+
+    /// Debounce interval to coalesce rapid screen change notifications
+    /// (e.g., when waking from sleep, displays reconnect in stages)
+    private let debounceInterval: TimeInterval = 0.5
 
     init(onScreenChange: @escaping () -> Void) {
         self.onScreenChange = onScreenChange
@@ -26,11 +31,26 @@ class ScreenObserver {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.onScreenChange()
+            self?.scheduleScreenChange()
         }
     }
 
+    private func scheduleScreenChange() {
+        pendingWork?.cancel()
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.onScreenChange()
+        }
+        pendingWork = work
+
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + debounceInterval,
+            execute: work
+        )
+    }
+
     private func stopObserving() {
+        pendingWork?.cancel()
         if let observer = observer {
             NotificationCenter.default.removeObserver(observer)
         }

--- a/ClaudeIsland/UI/Window/NotchWindowController.swift
+++ b/ClaudeIsland/UI/Window/NotchWindowController.swift
@@ -14,7 +14,7 @@ class NotchWindowController: NSWindowController {
     private let screen: NSScreen
     private var cancellables = Set<AnyCancellable>()
 
-    init(screen: NSScreen) {
+    init(screen: NSScreen, animateOnLaunch: Bool = true) {
         self.screen = screen
 
         let screenFrame = screen.frame
@@ -86,9 +86,11 @@ class NotchWindowController: NSWindowController {
         // Start with ignoring mouse events (closed state)
         notchWindow.ignoresMouseEvents = true
 
-        // Perform boot animation after a brief delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.viewModel.performBootAnimation()
+        // Perform boot animation after a brief delay (only on initial launch)
+        if animateOnLaunch {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                self?.viewModel.performBootAnimation()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the window expanding and retracting multiple times when waking from sleep.

### Changes

1. **Debounce screen change notifications** (500ms) - Coalesces rapid `didChangeScreenParametersNotification` events that fire when displays reconnect after wake

2. **Skip boot animation on screen changes** - Only play the expand/retract animation on initial app launch, not when recreating the window due to screen changes

3. **Skip redundant window recreation** - If the selected screen's frame hasn't changed, skip recreating the window entirely

Fixes #22

## Test plan

- [ ] Launch app and verify boot animation plays normally
- [ ] Put Mac to sleep and wake it
- [ ] Verify window remains stable without expand/retract cycles
- [ ] Change display arrangement in System Settings
- [ ] Verify window properly repositions to selected screen