### PR TITLE
fix: enable single-click to open chat rows

### DIFF
--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -278,7 +278,7 @@ struct InstanceRow: View {
         .padding(.trailing, 14)
         .padding(.vertical, 10)
         .contentShape(Rectangle())
-        .onTapGesture(count: 2) {
+        .onTapGesture {
             onChat()
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isWaitingForApproval)


### PR DESCRIPTION
Hey really love this project and wanted to fix an issue thats causing me to click one more time than I'd like to be. Not sure if this was intentional for some reason or a design decision pls lmk!

## Description
- Chat rows now open with a single click instead of requiring double-click
- Buttons inside rows (chat, focus, archive, approve/deny) still work correctly since SwiftUI `Button` views intercept taps before parent gesture handlers

## Test plan
- [ ] Single-click on a chat row opens the chat view
- [ ] Clicking the chat bubble button still works
- [ ] Clicking the archive button still works
- [ ] Clicking approve/deny buttons still works