### PR TITLE
fix: prevent collapsed spinner/checkmark from clipping into notch

### DIFF
--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -284,11 +284,13 @@ struct NotchView: View {
                     ProcessingSpinner()
                         .matchedGeometryEffect(id: "spinner", in: activityNamespace, isSource: showClosedActivity)
                         .frame(width: viewModel.status == .opened ? 20 : sideWidth)
+                        .padding(.trailing, viewModel.status == .opened ? 0 : 4)
                 } else if hasWaitingForInput {
                     // Checkmark for waiting-for-input on the right side
                     ReadyForInputIndicatorIcon(size: 14, color: TerminalColors.green)
                         .matchedGeometryEffect(id: "spinner", in: activityNamespace, isSource: showClosedActivity)
                         .frame(width: viewModel.status == .opened ? 20 : sideWidth)
+                        .padding(.trailing, viewModel.status == .opened ? 0 : 4)
                 }
             }
         }


### PR DESCRIPTION
## Summary

When the island is collapsed and showing activity (processing spinner or waiting-for-input checkmark), the right-side indicator was getting clipped by the physical notch boundary on MacBooks.

The `NotchShape` curves inward at the top corners, and the right-side content was positioned too close to this edge. This caused the spinner/checkmark to get partially cut off.

Added 4px trailing padding to the right-side indicators when in closed state, keeping them safely within the visible area.

## Test plan

- [ ] Run Claude in terminal to trigger processing state
- [ ] Verify spinner on right side of collapsed island is fully visible
- [ ] Wait for Claude to finish and show checkmark
- [ ] Verify checkmark is also fully visible and not clipped