### PR TITLE
Fix: Re-detect archived sessions when hook events continue to arrive

### DIFF
--- a/ClaudeIsland/Models/SessionEvent.swift
+++ b/ClaudeIsland/Models/SessionEvent.swift
@@ -67,8 +67,12 @@ enum SessionEvent: Sendable {
 
     // MARK: - Session Lifecycle
 
-    /// Session has ended
+    /// Session has ended (from Claude's SessionEnd hook - terminal process actually terminated)
     case sessionEnded(sessionId: String)
+
+    /// Session was archived by user (dismissed from UI, but terminal process may still be running)
+    /// These sessions can be re-detected if hook events continue to arrive
+    case sessionArchived(sessionId: String)
 
     /// Request to load initial history from file
     case loadHistory(sessionId: String, cwd: String)
@@ -199,6 +203,8 @@ extension SessionEvent: CustomStringConvertible {
             return "clearDetected(session: \(sessionId.prefix(8)))"
         case .sessionEnded(let sessionId):
             return "sessionEnded(session: \(sessionId.prefix(8)))"
+        case .sessionArchived(let sessionId):
+            return "sessionArchived(session: \(sessionId.prefix(8)))"
         case .loadHistory(let sessionId, _):
             return "loadHistory(session: \(sessionId.prefix(8)))"
         case .historyLoaded(let sessionId, let messages, _, _, _, _):

--- a/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
+++ b/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
@@ -26,6 +26,23 @@ class ClaudeSessionMonitor: ObservableObject {
             .store(in: &cancellables)
 
         InterruptWatcherManager.shared.delegate = self
+
+        // Register callback for when archived sessions are re-detected
+        // This restarts the interrupt watcher when a user continues working in terminal
+        // after archiving the session from the app
+        Task {
+            await SessionStore.shared.setArchivedSessionRedetectedCallback { [weak self] sessionId, cwd in
+                Task { @MainActor in
+                    self?.handleArchivedSessionRedetected(sessionId: sessionId, cwd: cwd)
+                }
+            }
+        }
+    }
+
+    /// Handle re-detection of an archived session
+    /// Restart interrupt watcher since the user is continuing to work in terminal
+    private func handleArchivedSessionRedetected(sessionId: String, cwd: String) {
+        InterruptWatcherManager.shared.startWatching(sessionId: sessionId, cwd: cwd)
     }
 
     // MARK: - Monitoring Lifecycle
@@ -114,10 +131,13 @@ class ClaudeSessionMonitor: ObservableObject {
     }
 
     /// Archive (remove) a session from the instances list
+    /// The session can be re-detected if hook events continue to arrive from the terminal
     func archiveSession(sessionId: String) {
         Task {
-            await SessionStore.shared.process(.sessionEnded(sessionId: sessionId))
+            await SessionStore.shared.process(.sessionArchived(sessionId: sessionId))
         }
+        // Stop watching interrupts for archived session
+        InterruptWatcherManager.shared.stopWatching(sessionId: sessionId)
     }
 
     // MARK: - State Update

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -24,11 +24,18 @@ actor SessionStore {
     /// All sessions keyed by sessionId
     private var sessions: [String: SessionState] = [:]
 
+    /// Archived session IDs (user dismissed from UI, but terminal process may still be running)
+    /// These can be re-detected if hook events continue to arrive
+    private var archivedSessionIds: Set<String> = []
+
     /// Pending file syncs (debounced)
     private var pendingSyncs: [String: Task<Void, Never>] = [:]
 
     /// Sync debounce interval (100ms)
     private let syncDebounceNs: UInt64 = 100_000_000
+
+    /// Callback for when an archived session is re-detected (for restarting watchers)
+    private var onArchivedSessionRedetected: ((String, String) -> Void)?
 
     // MARK: - Published State (for UI)
 
@@ -75,6 +82,9 @@ actor SessionStore {
         case .sessionEnded(let sessionId):
             await processSessionEnd(sessionId: sessionId)
 
+        case .sessionArchived(let sessionId):
+            await processSessionArchived(sessionId: sessionId)
+
         case .loadHistory(let sessionId, let cwd):
             await loadHistoryFromFile(sessionId: sessionId, cwd: cwd)
 
@@ -118,11 +128,20 @@ actor SessionStore {
     private func processHookEvent(_ event: HookEvent) async {
         let sessionId = event.sessionId
         let isNewSession = sessions[sessionId] == nil
+        let wasArchived = archivedSessionIds.contains(sessionId)
         var session = sessions[sessionId] ?? createSession(from: event)
 
-        // Track new session in Mixpanel
-        if isNewSession {
+        // Track new session in Mixpanel (but not re-detected archived sessions)
+        if isNewSession && !wasArchived {
             Mixpanel.mainInstance().track(event: "Session Started")
+        }
+
+        // If this was an archived session being re-detected, remove from archived set
+        // and notify callback to restart watchers
+        if wasArchived {
+            archivedSessionIds.remove(sessionId)
+            Self.logger.info("Re-detected archived session: \(sessionId.prefix(8), privacy: .public)")
+            onArchivedSessionRedetected?(sessionId, event.cwd)
         }
 
         session.pid = event.pid
@@ -841,9 +860,20 @@ actor SessionStore {
 
     // MARK: - Session End Processing
 
+    /// Process a true session end (from Claude's SessionEnd hook - terminal process terminated)
     private func processSessionEnd(sessionId: String) async {
         sessions.removeValue(forKey: sessionId)
+        archivedSessionIds.remove(sessionId)  // Also remove from archived if present
         cancelPendingSync(sessionId: sessionId)
+    }
+
+    /// Process a session archive (user dismissed from UI, but terminal process may still be running)
+    /// The session is tracked so it can be re-detected if hook events continue to arrive
+    private func processSessionArchived(sessionId: String) async {
+        archivedSessionIds.insert(sessionId)
+        sessions.removeValue(forKey: sessionId)
+        cancelPendingSync(sessionId: sessionId)
+        Self.logger.info("Session archived (can be re-detected): \(sessionId.prefix(8), privacy: .public)")
     }
 
     // MARK: - History Loading
@@ -986,5 +1016,13 @@ actor SessionStore {
     /// Get all current sessions
     func allSessions() -> [SessionState] {
         Array(sessions.values)
+    }
+
+    // MARK: - Callback Registration
+
+    /// Set callback for when an archived session is re-detected
+    /// The callback receives (sessionId, cwd) and can be used to restart watchers
+    func setArchivedSessionRedetectedCallback(_ callback: @escaping (String, String) -> Void) {
+        onArchivedSessionRedetected = callback
     }
 }


### PR DESCRIPTION
## Summary
- Fixes the bug where archiving a session from the app breaks sync with a still-running terminal session
- When a user archives a session, the app now tracks it so it can be re-detected if hook events continue to arrive
- Automatically restarts the interrupt watcher when an archived session is re-detected

## Problem
When a user archives (closes) a session from the app, the underlying terminal Claude Code process continues running. Previously, if the user continued working in the terminal after archiving, the app would never sync again because:
1. Archive called `sessionEnded`, which removed the session entirely
2. File watchers were cancelled
3. No mechanism existed to re-associate the running session with the app

## Solution
- Added a new `sessionArchived` event that tracks archived session IDs separately from truly ended sessions
- When hook events arrive for an archived session, the app re-adds it to active sessions and restarts watchers
- True session ends (from Claude's `SessionEnd` hook) still permanently remove sessions

## Test plan
- [ ] Start the Claude Island app
- [ ] Start a Claude Code session in terminal
- [ ] Verify the session appears in the app
- [ ] Archive/close the session from the app
- [ ] Continue working in the terminal session
- [ ] Verify the session reappears in the app and syncs correctly

Fixes #27