### PR TITLE
Add status fallback and periodic session recheck

### DIFF
--- a/ClaudeIsland/Models/SessionState.swift
+++ b/ClaudeIsland/Models/SessionState.swift
@@ -179,6 +179,11 @@ struct SessionState: Equatable, Identifiable, Sendable {
         conversationInfo.lastUserMessageDate
     }
 
+    /// Token usage for this session
+    var usage: UsageInfo {
+        conversationInfo.usage
+    }
+
     /// Whether the session can be interacted with
     var canInteract: Bool {
         phase.needsAttention

--- a/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
+++ b/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
@@ -31,6 +31,11 @@ class ClaudeSessionMonitor: ObservableObject {
     // MARK: - Monitoring Lifecycle
 
     func startMonitoring() {
+        // Start periodic status rechecking
+        Task {
+            await SessionStore.shared.startPeriodicStatusCheck()
+        }
+
         HookSocketServer.shared.start(
             onEvent: { event in
                 Task {
@@ -72,6 +77,9 @@ class ClaudeSessionMonitor: ObservableObject {
 
     func stopMonitoring() {
         HookSocketServer.shared.stop()
+        Task {
+            await SessionStore.shared.stopPeriodicStatusCheck()
+        }
     }
 
     // MARK: - Permission Handling

--- a/ClaudeIsland/Services/Session/ConversationParser.swift
+++ b/ClaudeIsland/Services/Session/ConversationParser.swift
@@ -9,6 +9,29 @@
 import Foundation
 import os.log
 
+/// Token usage information from a session
+struct UsageInfo: Equatable {
+    var inputTokens: Int = 0
+    var outputTokens: Int = 0
+    var cacheReadTokens: Int = 0
+    var cacheCreationTokens: Int = 0
+
+    var totalTokens: Int {
+        inputTokens + outputTokens
+    }
+
+    /// Formatted string for display (e.g., "12.5K tokens")
+    var formattedTotal: String {
+        let total = totalTokens
+        if total >= 1_000_000 {
+            return String(format: "%.1fM", Double(total) / 1_000_000)
+        } else if total >= 1_000 {
+            return String(format: "%.1fK", Double(total) / 1_000)
+        }
+        return "\(total)"
+    }
+}
+
 struct ConversationInfo: Equatable {
     let summary: String?
     let lastMessage: String?
@@ -16,6 +39,7 @@ struct ConversationInfo: Equatable {
     let lastToolName: String?  // Tool name if lastMessageRole is "tool"
     let firstUserMessage: String?  // Fallback title when no summary
     let lastUserMessageDate: Date?  // Timestamp of last user message (for stable sorting)
+    var usage: UsageInfo = UsageInfo()  // Token usage stats
 }
 
 actor ConversationParser {
@@ -107,9 +131,27 @@ actor ConversationParser {
         var lastToolName: String?
         var firstUserMessage: String?
         var lastUserMessageDate: Date?
+        var usage = UsageInfo()
 
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        // First pass: collect usage from all assistant messages
+        for line in lines {
+            guard let lineData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+                continue
+            }
+
+            if json["type"] as? String == "assistant",
+               let message = json["message"] as? [String: Any],
+               let usageDict = message["usage"] as? [String: Any] {
+                usage.inputTokens += usageDict["input_tokens"] as? Int ?? 0
+                usage.outputTokens += usageDict["output_tokens"] as? Int ?? 0
+                usage.cacheReadTokens += usageDict["cache_read_input_tokens"] as? Int ?? 0
+                usage.cacheCreationTokens += usageDict["cache_creation_input_tokens"] as? Int ?? 0
+            }
+        }
 
         for line in lines {
             guard let lineData = line.data(using: .utf8),
@@ -201,7 +243,8 @@ actor ConversationParser {
             lastMessageRole: lastMessageRole,
             lastToolName: lastToolName,
             firstUserMessage: firstUserMessage,
-            lastUserMessageDate: lastUserMessageDate
+            lastUserMessageDate: lastUserMessageDate,
+            usage: usage
         )
     }
 

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -30,6 +30,12 @@ actor SessionStore {
     /// Sync debounce interval (100ms)
     private let syncDebounceNs: UInt64 = 100_000_000
 
+    /// Periodic status check task
+    private var statusCheckTask: Task<Void, Never>?
+
+    /// Status check interval (3 seconds)
+    private let statusCheckIntervalSeconds: UInt64 = 3
+
     // MARK: - Published State (for UI)
 
     /// Publisher for session state changes (nonisolated for Combine subscription from any context)
@@ -958,6 +964,72 @@ actor SessionStore {
     private func cancelPendingSync(sessionId: String) {
         pendingSyncs[sessionId]?.cancel()
         pendingSyncs.removeValue(forKey: sessionId)
+    }
+
+    // MARK: - Periodic Status Check
+
+    /// Start periodic status checking for all sessions
+    func startPeriodicStatusCheck() {
+        guard statusCheckTask == nil else { return }
+
+        let intervalSeconds = statusCheckIntervalSeconds
+        statusCheckTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: intervalSeconds * 1_000_000_000)
+                guard !Task.isCancelled else { break }
+                await self?.recheckAllSessions()
+            }
+        }
+        Self.logger.info("Started periodic status check (every \(intervalSeconds)s)")
+    }
+
+    /// Stop periodic status checking
+    func stopPeriodicStatusCheck() {
+        statusCheckTask?.cancel()
+        statusCheckTask = nil
+        Self.logger.info("Stopped periodic status check")
+    }
+
+    /// Recheck status of all active sessions
+    private func recheckAllSessions() {
+        for (sessionId, session) in sessions {
+            // Skip ended sessions
+            guard session.phase != .ended else { continue }
+
+            // Check if process is still running
+            if let pid = session.pid {
+                let isRunning = isProcessRunning(pid: pid)
+                if !isRunning {
+                    // Process died - mark session as ended
+                    Self.logger.info("Process \(pid) no longer running, ending session \(sessionId.prefix(8))")
+                    var updatedSession = session
+                    if updatedSession.phase.canTransition(to: .ended) {
+                        updatedSession.phase = .ended
+                        sessions[sessionId] = updatedSession
+                        publishState()
+                    }
+                    continue
+                }
+            }
+
+            // For active sessions, trigger a file sync to refresh state
+            let needsSync: Bool
+            switch session.phase {
+            case .processing, .waitingForApproval:
+                needsSync = true
+            default:
+                needsSync = false
+            }
+            if needsSync {
+                scheduleFileSync(sessionId: sessionId, cwd: session.cwd)
+            }
+        }
+    }
+
+    /// Check if a process is still running
+    private nonisolated func isProcessRunning(pid: Int) -> Bool {
+        // kill(pid, 0) returns 0 if process exists, -1 otherwise
+        return kill(Int32(pid), 0) == 0
     }
 
     // MARK: - State Publishing

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -145,6 +145,24 @@ struct InstanceRow: View {
         return toolName == "AskUserQuestion"
     }
 
+    /// Status text based on session phase (fallback when no other content)
+    private var phaseStatusText: String {
+        switch session.phase {
+        case .processing:
+            return "Processing..."
+        case .compacting:
+            return "Compacting..."
+        case .waitingForInput:
+            return "Ready"
+        case .waitingForApproval:
+            return "Waiting for approval"
+        case .idle:
+            return "Idle"
+        case .ended:
+            return "Ended"
+        }
+    }
+
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
             // State indicator on left
@@ -218,6 +236,12 @@ struct InstanceRow: View {
                     }
                 } else if let lastMsg = session.lastMessage {
                     Text(lastMsg)
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.4))
+                        .lineLimit(1)
+                } else {
+                    // Fallback: show phase-based status when no other content
+                    Text(phaseStatusText)
                         .font(.system(size: 11))
                         .foregroundColor(.white.opacity(0.4))
                         .lineLimit(1)

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -171,10 +171,19 @@ struct InstanceRow: View {
 
             // Text content
             VStack(alignment: .leading, spacing: 2) {
-                Text(session.displayTitle)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.white)
-                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(session.displayTitle)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+
+                    // Token usage indicator
+                    if session.usage.totalTokens > 0 {
+                        Text(session.usage.formattedTotal)
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundColor(.white.opacity(0.3))
+                    }
+                }
 
                 // Show tool call when waiting for approval, otherwise last activity
                 if isWaitingForApproval, let toolName = session.pendingToolName {


### PR DESCRIPTION
## Summary
- Show phase-based status text ("Processing...", "Ready", "Idle") when no message content exists, preventing empty/"?" status in instances list
- Add periodic status check every 3 seconds to keep session state fresh and detect ended processes

## Test plan
- [ ] Open Claude Island with no sessions - verify no "?" appears
- [ ] Start a new Claude Code session - verify status shows correctly immediately
- [ ] Kill a Claude process - verify session is marked as ended within ~3 seconds
- [ ] Check that active sessions refresh state periodically

🤖 Generated with [Claude Code](https://claude.com/claude-code)