### PR TITLE
fix: notification sound playing when subagents complete

### DIFF
--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -176,8 +176,8 @@ def main():
         state["status"] = "waiting_for_input"
 
     elif event == "SubagentStop":
-        # SubagentStop fires when a subagent completes - usually means back to waiting
-        state["status"] = "waiting_for_input"
+        # SubagentStop fires when a subagent completes - main session continues processing
+        state["status"] = "processing"
 
     elif event == "SessionStart":
         # New session starts waiting for user input


### PR DESCRIPTION
## Summary
- Fix notification sound incorrectly triggered when subagents (Task tools) complete
- Changed `SubagentStop` to report `status="processing"` instead of `"waiting_for_input"`

## Problem
The notification sound was playing each time a subagent completed, even though the main Claude session was still processing. This happened because `SubagentStop` incorrectly set `status="waiting_for_input"`.

## Solution
When a subagent completes, the main session continues processing (receives the result and keeps going). Changed to report `status="processing"` which correctly reflects this state.

## Test plan
- [x] Verified release version plays sound on each subagent completion (bug)
- [x] Verified fixed version only plays sound when main session finishes
- [x] Verified normal session completion still triggers sound correctly

Fixes #36

🤖 Generated with [Claude Code](https://claude.ai/code)