### PR TITLE
feature: Sound suppression settings (focus/visibility modes)

### DIFF
--- a/ClaudeIsland.xcodeproj/project.pbxproj
+++ b/ClaudeIsland.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		FD0F42E72EE7ABA400980302 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = FD0F42E62EE7ABA400980302 /* Mixpanel */; };
 		FDA49F7D2EE11E3C00F9612E /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = FD33FD722EDF32D7002A6548 /* Markdown */; };
 		FDA49F7E2EE11E3C00F9612E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = FDA49F7F2EE11E3C00F9612E /* Sparkle */; };
+		FDOCCLUS012EEF0A0000001 /* OcclusionKit in Frameworks */ = {isa = PBXBuildFile; productRef = FDOCCLUS022EEF0A0000002 /* OcclusionKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,6 +46,7 @@
 				FD0F42E72EE7ABA400980302 /* Mixpanel in Frameworks */,
 				FDA49F7D2EE11E3C00F9612E /* Markdown in Frameworks */,
 				FDA49F7E2EE11E3C00F9612E /* Sparkle in Frameworks */,
+				FDOCCLUS012EEF0A0000001 /* OcclusionKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,6 +92,7 @@
 				FD33FD722EDF32D7002A6548 /* Markdown */,
 				FDA49F7F2EE11E3C00F9612E /* Sparkle */,
 				FD0F42E62EE7ABA400980302 /* Mixpanel */,
+				FDOCCLUS022EEF0A0000002 /* OcclusionKit */,
 			);
 			productName = ClaudeIsland;
 			productReference = FD33FD5D2EDF32D7002A6548 /* Claude Island.app */;
@@ -123,6 +126,7 @@
 				FD33FD712EDF32D7002A6548 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 				FDA49F802EE11E3C00F9612E /* XCRemoteSwiftPackageReference "Sparkle" */,
 				FD0F42E52EE7ABA400980302 /* XCRemoteSwiftPackageReference "mixpanel-swift" */,
+				FDOCCLUS032EEF0A0000003 /* XCLocalSwiftPackageReference "OcclusionKit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = FD33FD5E2EDF32D7002A6548 /* Products */;
@@ -393,7 +397,16 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		FDOCCLUS032EEF0A0000003 /* XCRemoteSwiftPackageReference "OcclusionKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/akdoan1/OcclusionKit";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
+
 
 /* Begin XCSwiftPackageProductDependency section */
 		FD0F42E62EE7ABA400980302 /* Mixpanel */ = {
@@ -410,6 +423,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = FDA49F802EE11E3C00F9612E /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		FDOCCLUS022EEF0A0000002 /* OcclusionKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FDOCCLUS032EEF0A0000003 /* XCRemoteSwiftPackageReference "OcclusionKit" */;
+			productName = OcclusionKit;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -50,6 +50,7 @@ class NotchViewModel: ObservableObject {
 
     private let screenSelector = ScreenSelector.shared
     private let soundSelector = SoundSelector.shared
+    private let suppressionSelector = SuppressionSelector.shared
 
     // MARK: - Geometry
 
@@ -74,7 +75,7 @@ class NotchViewModel: ObservableObject {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
+                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight + suppressionSelector.expandedPickerHeight
             )
         case .instances:
             return CGSize(
@@ -115,6 +116,10 @@ class NotchViewModel: ObservableObject {
             .store(in: &cancellables)
 
         soundSelector.$isPickerExpanded
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        suppressionSelector.$isPickerExpanded
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
     }

--- a/ClaudeIsland/Core/Settings.swift
+++ b/ClaudeIsland/Core/Settings.swift
@@ -31,6 +31,21 @@ enum NotificationSound: String, CaseIterable {
     }
 }
 
+/// Sound suppression modes
+enum SoundSuppression: String, CaseIterable {
+    case never = "Never"
+    case whenFocused = "When Focused"
+    case whenVisible = "When Visible"
+
+    var description: String {
+        switch self {
+        case .never: return "Always play sounds"
+        case .whenFocused: return "Suppress when app or session is active"
+        case .whenVisible: return "Suppress when app or session is visible"
+        }
+    }
+}
+
 enum AppSettings {
     private static let defaults = UserDefaults.standard
 
@@ -38,6 +53,7 @@ enum AppSettings {
 
     private enum Keys {
         static let notificationSound = "notificationSound"
+        static let soundSuppression = "soundSuppression"
     }
 
     // MARK: - Notification Sound
@@ -53,6 +69,22 @@ enum AppSettings {
         }
         set {
             defaults.set(newValue.rawValue, forKey: Keys.notificationSound)
+        }
+    }
+
+    // MARK: - Sound Suppression
+
+    /// When to suppress notification sounds based on app visibility/focus
+    static var soundSuppression: SoundSuppression {
+        get {
+            guard let rawValue = defaults.string(forKey: Keys.soundSuppression),
+                  let value = SoundSuppression(rawValue: rawValue) else {
+                return .whenFocused // Default
+            }
+            return value
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: Keys.soundSuppression)
         }
     }
 }

--- a/ClaudeIsland/Core/SuppressionSelector.swift
+++ b/ClaudeIsland/Core/SuppressionSelector.swift
@@ -1,0 +1,36 @@
+//
+//  SuppressionSelector.swift
+//  ClaudeIsland
+//
+//  Manages sound suppression selection state for the settings menu
+//
+
+import Combine
+import Foundation
+
+@MainActor
+class SuppressionSelector: ObservableObject {
+    static let shared = SuppressionSelector()
+
+    // MARK: - Published State
+
+    @Published var isPickerExpanded: Bool = false
+
+    // MARK: - Constants
+
+    /// Number of suppression options (Never, When Focused, When Visible)
+    private let optionCount = 3
+
+    /// Height per option row (taller for descriptions)
+    private let rowHeight: CGFloat = 44
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Extra height needed when picker is expanded
+    var expandedPickerHeight: CGFloat {
+        guard isPickerExpanded else { return 0 }
+        return CGFloat(optionCount) * rowHeight + 8 // +8 for padding
+    }
+}

--- a/ClaudeIsland/UI/Components/SuppressionPickerRow.swift
+++ b/ClaudeIsland/UI/Components/SuppressionPickerRow.swift
@@ -1,0 +1,133 @@
+//
+//  SuppressionPickerRow.swift
+//  ClaudeIsland
+//
+//  Sound suppression mode selection picker for settings menu
+//
+
+import SwiftUI
+
+struct SuppressionPickerRow: View {
+    @ObservedObject var suppressionSelector: SuppressionSelector
+    @State private var isHovered = false
+    @State private var selectedSuppression: SoundSuppression = AppSettings.soundSuppression
+
+    private var isExpanded: Bool {
+        suppressionSelector.isPickerExpanded
+    }
+
+    private func setExpanded(_ value: Bool) {
+        suppressionSelector.isPickerExpanded = value
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Main row - shows current selection
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    setExpanded(!isExpanded)
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "bell.slash")
+                        .font(.system(size: 12))
+                        .foregroundColor(textColor)
+                        .frame(width: 16)
+
+                    Text("Sound Suppression")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(textColor)
+
+                    Spacer()
+
+                    Text(selectedSuppression.rawValue)
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.4))
+                        .lineLimit(1)
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+
+            // Expanded suppression list
+            if isExpanded {
+                VStack(spacing: 2) {
+                    ForEach(SoundSuppression.allCases, id: \.self) { suppression in
+                        SuppressionOptionRow(
+                            suppression: suppression,
+                            isSelected: selectedSuppression == suppression
+                        ) {
+                            selectedSuppression = suppression
+                            AppSettings.soundSuppression = suppression
+                        }
+                    }
+                }
+                .padding(.leading, 28)
+                .padding(.top, 4)
+            }
+        }
+        .onAppear {
+            selectedSuppression = AppSettings.soundSuppression
+        }
+    }
+
+    private var textColor: Color {
+        .white.opacity(isHovered ? 1.0 : 0.7)
+    }
+}
+
+// MARK: - Suppression Option Row
+
+private struct SuppressionOptionRow: View {
+    let suppression: SoundSuppression
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(isSelected ? TerminalColors.green : Color.white.opacity(0.2))
+                    .frame(width: 6, height: 6)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(suppression.rawValue)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.7))
+
+                    Text(suppression.description)
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(TerminalColors.green)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -18,6 +18,7 @@ struct NotchMenuView: View {
     @ObservedObject private var updateManager = UpdateManager.shared
     @ObservedObject private var screenSelector = ScreenSelector.shared
     @ObservedObject private var soundSelector = SoundSelector.shared
+    @ObservedObject private var suppressionSelector = SuppressionSelector.shared
     @State private var hooksInstalled: Bool = false
     @State private var launchAtLogin: Bool = false
 
@@ -38,6 +39,7 @@ struct NotchMenuView: View {
             // Appearance settings
             ScreenPickerRow(screenSelector: screenSelector)
             SoundPickerRow(soundSelector: soundSelector)
+            SuppressionPickerRow(suppressionSelector: suppressionSelector)
 
             Divider()
                 .background(Color.white.opacity(0.08))

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -419,10 +419,17 @@ struct NotchView: View {
         let currentIds = Set(sessions.map { $0.stableId })
         let newPendingIds = currentIds.subtracting(previousPendingIds)
 
-        if !newPendingIds.isEmpty &&
-           viewModel.status == .closed &&
-           !TerminalVisibilityDetector.isTerminalVisibleOnCurrentSpace() {
-            viewModel.notchOpen(reason: .notification)
+        if !newPendingIds.isEmpty && viewModel.status == .closed {
+            // Get the new pending sessions and check if any of their terminals are NOT visible
+            let newPendingSessions = sessions.filter { newPendingIds.contains($0.stableId) }
+            let anySessionTerminalNotVisible = newPendingSessions.contains { session in
+                guard let pid = session.pid else { return true }
+                return !TerminalVisibilityDetector.isSessionTerminalVisible(sessionPid: pid)
+            }
+
+            if anySessionTerminalNotVisible {
+                viewModel.notchOpen(reason: .notification)
+            }
         }
 
         previousPendingIds = currentIds
@@ -484,18 +491,25 @@ struct NotchView: View {
     }
 
     /// Determine if notification sound should play for the given sessions
-    /// Returns true if ANY session is not actively focused
+    /// Returns true if sound should play, false if suppressed
     private func shouldPlayNotificationSound(for sessions: [SessionState]) async -> Bool {
-        for session in sessions {
-            guard let pid = session.pid else {
-                // No PID means we can't check focus, assume not focused
-                return true
-            }
+        let mode = AppSettings.soundSuppression
 
-            let isFocused = await TerminalVisibilityDetector.isSessionFocused(sessionPid: pid)
-            if !isFocused {
-                return true
-            }
+        // Never suppress - always play
+        if mode == .never { return true }
+
+        // Suppress if Claude Island is active (menu/chat open)
+        if NSApplication.shared.isActive { return false }
+
+        // Check each triggering session - play if ANY is not visible/focused
+        for session in sessions {
+            guard let pid = session.pid else { return true }
+
+            let shouldSuppress = mode == .whenVisible
+                ? TerminalVisibilityDetector.isSessionTerminalVisible(sessionPid: pid)
+                : await TerminalVisibilityDetector.isSessionFocused(sessionPid: pid)
+
+            if !shouldSuppress { return true }
         }
 
         return false

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -422,13 +422,27 @@ struct NotchView: View {
         if !newPendingIds.isEmpty && viewModel.status == .closed {
             // Get the new pending sessions and check if any of their terminals are NOT visible
             let newPendingSessions = sessions.filter { newPendingIds.contains($0.stableId) }
-            let anySessionTerminalNotVisible = newPendingSessions.contains { session in
-                guard let pid = session.pid else { return true }
-                return !TerminalVisibilityDetector.isSessionTerminalVisible(sessionPid: pid)
-            }
 
-            if anySessionTerminalNotVisible {
-                viewModel.notchOpen(reason: .notification)
+            // Check visibility asynchronously
+            Task {
+                var anySessionTerminalNotVisible = false
+                for session in newPendingSessions {
+                    guard let pid = session.pid else {
+                        anySessionTerminalNotVisible = true
+                        break
+                    }
+                    let isVisible = await TerminalVisibilityDetector.isSessionTerminalVisible(sessionPid: pid)
+                    if !isVisible {
+                        anySessionTerminalNotVisible = true
+                        break
+                    }
+                }
+
+                if anySessionTerminalNotVisible {
+                    await MainActor.run {
+                        viewModel.notchOpen(reason: .notification)
+                    }
+                }
             }
         }
 
@@ -506,7 +520,7 @@ struct NotchView: View {
             guard let pid = session.pid else { return true }
 
             let shouldSuppress = mode == .whenVisible
-                ? TerminalVisibilityDetector.isSessionTerminalVisible(sessionPid: pid)
+                ? await TerminalVisibilityDetector.isSessionTerminalVisible(sessionPid: pid)
                 : await TerminalVisibilityDetector.isSessionFocused(sessionPid: pid)
 
             if !shouldSuppress { return true }

--- a/ClaudeIsland/Utilities/TerminalVisibilityDetector.swift
+++ b/ClaudeIsland/Utilities/TerminalVisibilityDetector.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import CoreGraphics
+import OcclusionKit
 
 struct TerminalVisibilityDetector {
     /// Check if the frontmost (active) application is a terminal
@@ -22,65 +23,32 @@ struct TerminalVisibilityDetector {
     /// Check if a Claude session's terminal window is visible on the current space
     /// - Parameter sessionPid: The PID of the Claude process
     /// - Returns: true if the session's terminal has a visible, unobscured window on the current space
-    static func isSessionTerminalVisible(sessionPid: Int) -> Bool {
+    static func isSessionTerminalVisible(sessionPid: Int) async -> Bool {
         let tree = ProcessTreeBuilder.shared.buildTree()
 
-        // Get all on-screen windows (returned in front-to-back z-order)
-        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
-        guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+        // Get all on-screen windows using OcclusionKit
+        guard let windows = try? OcclusionKit.allWindows() else {
             return false
         }
 
         // Find the terminal window for this session and check if it's visible
-        var windowsAbove: [CGRect] = []
-
-        for window in windowList {
-            guard let ownerPid = window[kCGWindowOwnerPID as String] as? Int,
-                  let layer = window[kCGWindowLayer as String] as? Int,
-                  let boundsDict = window[kCGWindowBounds as String] as? [String: CGFloat],
-                  layer == 0 else { continue }
-
-            let bounds = CGRect(
-                x: boundsDict["X"] ?? 0,
-                y: boundsDict["Y"] ?? 0,
-                width: boundsDict["Width"] ?? 0,
-                height: boundsDict["Height"] ?? 0
-            )
+        for window in windows where window.isNormalLayer {
+            let ownerPid = Int(window.processID)
 
             // Check if this window belongs to the session's terminal
             if ProcessTreeBuilder.shared.isDescendant(targetPid: sessionPid, ofAncestor: ownerPid, tree: tree) {
-                // Found the terminal window - check if it's mostly visible
-                return !isWindowMostlyObscured(windowBounds: bounds, windowsAbove: windowsAbove)
+                // Found the terminal window - check if it's mostly visible using OcclusionKit
+                // OcclusionKit uses accurate region subtraction (no overcounting)
+                do {
+                    let isOccluded = try await OcclusionKit.isOccluded(window.id, threshold: 0.5)
+                    return !isOccluded
+                } catch {
+                    return false
+                }
             }
-
-            // Track windows we've seen (they're in front of windows we haven't seen yet)
-            windowsAbove.append(bounds)
         }
 
         return false
-    }
-
-    /// Check if a window is mostly obscured by windows above it
-    /// - Parameters:
-    ///   - windowBounds: The bounds of the window to check
-    ///   - windowsAbove: Array of bounds for windows in front of this one
-    /// - Returns: true if more than 50% of the window is covered
-    private static func isWindowMostlyObscured(windowBounds: CGRect, windowsAbove: [CGRect]) -> Bool {
-        let windowArea = windowBounds.width * windowBounds.height
-        guard windowArea > 0 else { return true }
-
-        // Calculate total overlap from windows above
-        // Note: This is a simplified calculation that may overcount if covering windows overlap each other
-        var coveredArea: CGFloat = 0
-        for aboveBounds in windowsAbove {
-            let intersection = windowBounds.intersection(aboveBounds)
-            if !intersection.isNull {
-                coveredArea += intersection.width * intersection.height
-            }
-        }
-
-        // Consider obscured if >50% covered
-        return coveredArea / windowArea > 0.5
     }
 
     /// Check if a Claude session is currently focused (user is looking at it)

--- a/ClaudeIsland/Utilities/TerminalVisibilityDetector.swift
+++ b/ClaudeIsland/Utilities/TerminalVisibilityDetector.swift
@@ -9,27 +9,6 @@ import AppKit
 import CoreGraphics
 
 struct TerminalVisibilityDetector {
-    /// Check if any terminal window is visible on the current space
-    static func isTerminalVisibleOnCurrentSpace() -> Bool {
-        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
-
-        guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
-            return false
-        }
-
-        for window in windowList {
-            guard let ownerName = window[kCGWindowOwnerName as String] as? String,
-                  let layer = window[kCGWindowLayer as String] as? Int,
-                  layer == 0 else { continue }
-
-            if TerminalAppRegistry.isTerminal(ownerName) {
-                return true
-            }
-        }
-
-        return false
-    }
-
     /// Check if the frontmost (active) application is a terminal
     static func isTerminalFrontmost() -> Bool {
         guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
@@ -38,6 +17,70 @@ struct TerminalVisibilityDetector {
         }
 
         return TerminalAppRegistry.isTerminalBundle(bundleId)
+    }
+
+    /// Check if a Claude session's terminal window is visible on the current space
+    /// - Parameter sessionPid: The PID of the Claude process
+    /// - Returns: true if the session's terminal has a visible, unobscured window on the current space
+    static func isSessionTerminalVisible(sessionPid: Int) -> Bool {
+        let tree = ProcessTreeBuilder.shared.buildTree()
+
+        // Get all on-screen windows (returned in front-to-back z-order)
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return false
+        }
+
+        // Find the terminal window for this session and check if it's visible
+        var windowsAbove: [CGRect] = []
+
+        for window in windowList {
+            guard let ownerPid = window[kCGWindowOwnerPID as String] as? Int,
+                  let layer = window[kCGWindowLayer as String] as? Int,
+                  let boundsDict = window[kCGWindowBounds as String] as? [String: CGFloat],
+                  layer == 0 else { continue }
+
+            let bounds = CGRect(
+                x: boundsDict["X"] ?? 0,
+                y: boundsDict["Y"] ?? 0,
+                width: boundsDict["Width"] ?? 0,
+                height: boundsDict["Height"] ?? 0
+            )
+
+            // Check if this window belongs to the session's terminal
+            if ProcessTreeBuilder.shared.isDescendant(targetPid: sessionPid, ofAncestor: ownerPid, tree: tree) {
+                // Found the terminal window - check if it's mostly visible
+                return !isWindowMostlyObscured(windowBounds: bounds, windowsAbove: windowsAbove)
+            }
+
+            // Track windows we've seen (they're in front of windows we haven't seen yet)
+            windowsAbove.append(bounds)
+        }
+
+        return false
+    }
+
+    /// Check if a window is mostly obscured by windows above it
+    /// - Parameters:
+    ///   - windowBounds: The bounds of the window to check
+    ///   - windowsAbove: Array of bounds for windows in front of this one
+    /// - Returns: true if more than 50% of the window is covered
+    private static func isWindowMostlyObscured(windowBounds: CGRect, windowsAbove: [CGRect]) -> Bool {
+        let windowArea = windowBounds.width * windowBounds.height
+        guard windowArea > 0 else { return true }
+
+        // Calculate total overlap from windows above
+        // Note: This is a simplified calculation that may overcount if covering windows overlap each other
+        var coveredArea: CGFloat = 0
+        for aboveBounds in windowsAbove {
+            let intersection = windowBounds.intersection(aboveBounds)
+            if !intersection.isNull {
+                coveredArea += intersection.width * intersection.height
+            }
+        }
+
+        // Consider obscured if >50% covered
+        return coveredArea / windowArea > 0.5
     }
 
     /// Check if a Claude session is currently focused (user is looking at it)
@@ -56,13 +99,15 @@ struct TerminalVisibilityDetector {
             // For tmux sessions, check if the session's pane is active
             return await TmuxTargetFinder.shared.isSessionPaneActive(claudePid: sessionPid)
         } else {
-            // For non-tmux sessions, check if the session's terminal app is frontmost
-            guard let sessionTerminalPid = ProcessTreeBuilder.shared.findTerminalPid(forProcess: sessionPid, tree: tree),
-                  let frontmostApp = NSWorkspace.shared.frontmostApplication else {
+            // For non-tmux sessions, check if the session is a descendant of the frontmost app
+            // This handles terminal architectures where child processes (like iTermServer or Warp's
+            // terminal-server) run the shell, but the main app process is what's reported as frontmost
+            guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
                 return false
             }
 
-            return sessionTerminalPid == Int(frontmostApp.processIdentifier)
+            let frontmostPid = Int(frontmostApp.processIdentifier)
+            return ProcessTreeBuilder.shared.isDescendant(targetPid: sessionPid, ofAncestor: frontmostPid, tree: tree)
         }
     }
 }


### PR DESCRIPTION
## Summary
Add a setting to suppress notification sounds based on terminal/app focus or visibility state.

<img width="455" height="655" alt="image" src="https://github.com/user-attachments/assets/b4ce0738-1d3e-4e94-b843-7f5c56277c57" />


Fixes #38

## Changes
- Add three-way "Sound Suppression" picker: Never, When Focused, When Visible
- Fix terminal focus detection for iTerm/Warp child process architecture
- Add accurate window occlusion detection using [OcclusionKit](https://github.com/akdoan1/OcclusionKit)

### Dependencies
- [OcclusionKit](https://github.com/akdoan1/OcclusionKit) - Swift library for macOS window occlusion detection (added as Swift Package dependency)

## New Files
- `ClaudeIsland/Core/SuppressionSelector.swift` - Picker state management
- `ClaudeIsland/UI/Components/SuppressionPickerRow.swift` - Picker UI component

## Modified Files
- `Settings.swift` - Add SoundSuppression enum and setting
- `NotchViewModel.swift` - Observe suppression selector
- `NotchMenuView.swift` - Add picker to menu
- `NotchView.swift` - Update sound logic
- `TerminalVisibilityDetector.swift` - Fix focus detection, add occlusion detection via OcclusionKit

## Test plan
- [x] Never mode: Sound always plays
- [x] When Focused + Claude Island focused: Suppressed
- [x] When Focused + Terminal focused: Suppressed  
- [x] When Visible + Terminal visible: Suppressed
- [x] When Visible + Terminal minimized: Sound plays
- [x] When Visible + Terminal on different desktop: Sound plays
- [x] When Visible + Terminal >50% covered: Sound plays
- [x] When Visible + Terminal ≤50% covered: Suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)