### PR TITLE
feature: add session state dots to minimized island bar

### DIFF
--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -888,6 +888,16 @@ actor SessionStore {
         // Update conversationInfo (summary, lastMessage, etc.)
         session.conversationInfo = conversationInfo
 
+        // Infer phase from conversation state when loading history
+        // If Claude was the last to respond, the session is waiting for user input
+        if session.phase == .idle {
+            if let lastRole = conversationInfo.lastMessageRole,
+               lastRole == "assistant" || lastRole == "tool" {
+                session.phase = .waitingForInput
+                Self.logger.debug("History loaded: inferred phase .waitingForInput from lastMessageRole=\(lastRole, privacy: .public)")
+            }
+        }
+
         // Convert messages to chat items
         let existingIds = Set(session.chatItems.map { $0.id })
 

--- a/ClaudeIsland/UI/Views/NotchHeaderView.swift
+++ b/ClaudeIsland/UI/Views/NotchHeaderView.swift
@@ -130,6 +130,67 @@ struct PermissionIndicatorIcon: View {
     }
 }
 
+// Session state dots - shows colored dots for each session's state
+struct SessionStateDots: View {
+    let sessions: [SessionState]
+
+    private let dotSize: CGFloat = 6
+    private let maxDots: Int = 8
+    private let claudeOrange = Color(red: 0.85, green: 0.47, blue: 0.34)
+
+    /// Filter to only active/attention-needed sessions and sort by priority
+    private var sortedSessions: [SessionState] {
+        sessions
+            .filter { $0.phase != .ended && $0.phase != .idle }
+            .sorted { a, b in
+                priority(for: a.phase) < priority(for: b.phase)
+            }
+    }
+
+    /// Lower number = higher priority (shows first/left)
+    private func priority(for phase: SessionPhase) -> Int {
+        switch phase {
+        case .waitingForApproval: return 0
+        case .processing, .compacting: return 1
+        case .waitingForInput: return 2
+        case .idle, .ended: return 3
+        }
+    }
+
+    /// Color for each session phase
+    private func color(for phase: SessionPhase) -> Color {
+        switch phase {
+        case .waitingForApproval:
+            return TerminalColors.blue
+        case .processing, .compacting:
+            return claudeOrange
+        case .waitingForInput:
+            return TerminalColors.green
+        case .idle, .ended:
+            return Color.white.opacity(0.25)
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            let displaySessions = Array(sortedSessions.prefix(maxDots))
+            let overflow = sessions.count - maxDots
+
+            ForEach(displaySessions) { session in
+                Circle()
+                    .fill(color(for: session.phase))
+                    .frame(width: dotSize, height: dotSize)
+            }
+
+            if overflow > 0 {
+                Text("+\(overflow)")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundColor(.white.opacity(0.4))
+            }
+        }
+    }
+}
+
 // Pixel art "ready for input" indicator icon (checkmark/done shape)
 struct ReadyForInputIndicatorIcon: View {
     let size: CGFloat

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -54,6 +54,16 @@ struct NotchView: View {
         }
     }
 
+    /// Sessions that are active (not idle/ended) - used for dots display
+    private var activeSessions: [SessionState] {
+        sessionMonitor.instances.filter { $0.phase != .ended && $0.phase != .idle }
+    }
+
+    /// Whether we have multiple active sessions to show dots for
+    private var hasMultipleActiveSessions: Bool {
+        activeSessions.count > 1
+    }
+
     // MARK: - Sizing
 
     private var closedNotchSize: CGSize {
@@ -213,9 +223,9 @@ struct NotchView: View {
         activityCoordinator.expandingActivity.show && activityCoordinator.expandingActivity.type == .claude
     }
 
-    /// Whether to show the expanded closed state (processing, pending permission, or waiting for input)
+    /// Whether to show the expanded closed state (processing, pending permission, waiting for input, or multiple active sessions)
     private var showClosedActivity: Bool {
-        isProcessing || hasPendingPermission || hasWaitingForInput
+        isProcessing || hasPendingPermission || hasWaitingForInput || hasMultipleActiveSessions
     }
 
     @ViewBuilder
@@ -262,6 +272,12 @@ struct NotchView: View {
                 .padding(.leading, viewModel.status == .opened ? 8 : 0)
             }
 
+            // Session state dots (only when closed with multiple active/attention-needed sessions)
+            if viewModel.status != .opened && hasMultipleActiveSessions {
+                SessionStateDots(sessions: activeSessions)
+                    .padding(.leading, 6)
+            }
+
             // Center content
             if viewModel.status == .opened {
                 // Opened: show header content
@@ -273,9 +289,11 @@ struct NotchView: View {
                     .frame(width: closedNotchSize.width - 20)
             } else {
                 // Closed with activity: black spacer (with optional bounce)
+                // Reduce spacer when showing session dots
+                let dotsWidth: CGFloat = hasMultipleActiveSessions ? CGFloat(min(activeSessions.count, 8) * 10 + 6) : 0
                 Rectangle()
                     .fill(.black)
-                    .frame(width: closedNotchSize.width - cornerRadiusInsets.closed.top + (isBouncing ? 16 : 0))
+                    .frame(width: max(20, closedNotchSize.width - cornerRadiusInsets.closed.top - dotsWidth) + (isBouncing ? 16 : 0))
             }
 
             // Right side - spinner when processing/pending, checkmark when waiting for input

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -406,7 +406,7 @@ struct NotchView: View {
             // Don't hide on non-notched devices - users need a visible target
             if viewModel.status == .closed && viewModel.hasPhysicalNotch {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    if !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && viewModel.status == .closed {
+                    if !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !hasMultipleActiveSessions && viewModel.status == .closed {
                         isVisible = false
                     }
                 }
@@ -426,7 +426,7 @@ struct NotchView: View {
             // Don't hide on non-notched devices - users need a visible target
             guard viewModel.hasPhysicalNotch else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                if viewModel.status == .closed && !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !activityCoordinator.expandingActivity.show {
+                if viewModel.status == .closed && !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !hasMultipleActiveSessions && !activityCoordinator.expandingActivity.show {
                     isVisible = false
                 }
             }


### PR DESCRIPTION
## Summary
- Show colored dots for each active session's state when multiple sessions are running
- Dots appear between the crab icon and the activity spinner (blue=approval, orange=processing, green=ready)
- Infer session phase from conversation history when loading, so sessions show correct state
- Fix visibility bug where dots would disappear after opening/closing the notch

**Example 1: One session asking for approval, one session processing, one session ready/complete**
<img width="306" height="31" alt="Screenshot 2026-01-14 at 4 51 27 PM" src="https://github.com/user-attachments/assets/49e03023-31a6-4ce2-b34a-53ab42b45704" />

**Example 2: Two sessions ready/complete**
<img width="307" height="31" alt="Screenshot 2026-01-14 at 4 51 53 PM" src="https://github.com/user-attachments/assets/698abf40-dfc9-4e54-83c5-08cafd5a7eb1" />

### Note
There is a minor bug related to session management, reported across a few issues (https://github.com/farouqaldori/claude-island/issues/29, https://github.com/farouqaldori/claude-island/issues/11), which seem to have an impact on the dots appearing on app start. However, the general functionality works when engaging actively with Claude Code, even when it's minimized.

## Test plan
- [x] Start multiple Claude sessions in different terminals
- [x] Verify dots appear in minimized bar showing each session's state
- [x] Verify dot colors match session states (blue/orange/green)
- [x] Verify dots persist after opening/closing the notch
- [ ] Verify dots disappear when sessions end or become idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)