### PR TITLE
Add pill-shaped mode for external displays

### DIFF
--- a/ClaudeIsland/Core/Ext+NSScreen.swift
+++ b/ClaudeIsland/Core/Ext+NSScreen.swift
@@ -8,11 +8,17 @@
 import AppKit
 
 extension NSScreen {
-    /// Returns the size of the notch on this screen (pixel-perfect using macOS APIs)
+    /// The menu bar height on this screen
+    var menuBarHeight: CGFloat {
+        frame.maxY - visibleFrame.maxY
+    }
+
+    /// Returns the size of the notch on this screen (pixel-perfect using macOS APIs).
+    /// On non-notch displays, returns a pill-sized rect matching the menu bar height.
     var notchSize: CGSize {
-        guard safeAreaInsets.top > 0 else {
-            // Fallback for non-notch displays (matches typical MacBook notch)
-            return CGSize(width: 224, height: 38)
+        guard hasPhysicalNotch else {
+            // Pill dimensions for non-notch displays — compact to fit in menu bar
+            return CGSize(width: 180, height: 22)
         }
 
         let notchHeight = safeAreaInsets.top
@@ -46,8 +52,9 @@ extension NSScreen {
         return NSScreen.main
     }
 
-    /// Whether this screen has a physical notch (camera housing)
+    /// Whether this screen has a physical notch (camera housing).
+    /// Only the built-in display can have a physical notch.
     var hasPhysicalNotch: Bool {
-        safeAreaInsets.top > 0
+        isBuiltinDisplay && safeAreaInsets.top > 0
     }
 }

--- a/ClaudeIsland/Core/NotchGeometry.swift
+++ b/ClaudeIsland/Core/NotchGeometry.swift
@@ -41,7 +41,7 @@ struct NotchGeometry: Sendable {
     /// Check if a point is in the notch area (with padding for easier interaction).
     /// Pill mode uses larger padding since the pill is smaller than the notch.
     func isPointInNotch(_ point: CGPoint) -> Bool {
-        let dx: CGFloat = isPillMode ? -15 : -10
+        let dx: CGFloat = isPillMode ? -60 : -10
         let dy: CGFloat = isPillMode ? -8 : -5
         return notchScreenRect.insetBy(dx: dx, dy: dy).contains(point)
     }

--- a/ClaudeIsland/Core/NotchGeometry.swift
+++ b/ClaudeIsland/Core/NotchGeometry.swift
@@ -13,6 +13,7 @@ struct NotchGeometry: Sendable {
     let deviceNotchRect: CGRect
     let screenRect: CGRect
     let windowHeight: CGFloat
+    let isPillMode: Bool
 
     /// The notch rect in screen coordinates (for hit testing with global mouse position)
     var notchScreenRect: CGRect {
@@ -37,9 +38,12 @@ struct NotchGeometry: Sendable {
         )
     }
 
-    /// Check if a point is in the notch area (with padding for easier interaction)
+    /// Check if a point is in the notch area (with padding for easier interaction).
+    /// Pill mode uses larger padding since the pill is smaller than the notch.
     func isPointInNotch(_ point: CGPoint) -> Bool {
-        notchScreenRect.insetBy(dx: -10, dy: -5).contains(point)
+        let dx: CGFloat = isPillMode ? -15 : -10
+        let dy: CGFloat = isPillMode ? -8 : -5
+        return notchScreenRect.insetBy(dx: dx, dy: dy).contains(point)
     }
 
     /// Check if a point is in the opened panel area

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -102,7 +102,8 @@ class NotchViewModel: ObservableObject {
         self.geometry = NotchGeometry(
             deviceNotchRect: deviceNotchRect,
             screenRect: screenRect,
-            windowHeight: windowHeight
+            windowHeight: windowHeight,
+            isPillMode: !hasPhysicalNotch
         )
         self.hasPhysicalNotch = hasPhysicalNotch
         setupEventHandlers()

--- a/ClaudeIsland/UI/Components/NotchShape.swift
+++ b/ClaudeIsland/UI/Components/NotchShape.swift
@@ -114,17 +114,48 @@ struct NotchShape: Shape {
     }
 }
 
+/// Pill shape for external displays without a notch.
+/// Unlike NotchShape, this has uniform rounded corners on all sides
+/// (no inward-curving top corners that mimic a physical notch).
+struct PillShape: Shape {
+    var cornerRadius: CGFloat
+
+    init(cornerRadius: CGFloat = 12) {
+        self.cornerRadius = cornerRadius
+    }
+
+    var animatableData: CGFloat {
+        get { cornerRadius }
+        set { cornerRadius = newValue }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        let r = min(cornerRadius, rect.height / 2, rect.width / 2)
+        return Path(roundedRect: rect, cornerRadius: r)
+    }
+}
+
 #Preview {
     VStack(spacing: 20) {
-        // Closed state
+        // Notch: Closed state
         NotchShape(topCornerRadius: 6, bottomCornerRadius: 14)
             .fill(.black)
             .frame(width: 200, height: 32)
 
-        // Open state
+        // Notch: Open state
         NotchShape(topCornerRadius: 19, bottomCornerRadius: 24)
             .fill(.black)
             .frame(width: 600, height: 200)
+
+        // Pill: Closed state (menu bar height)
+        PillShape(cornerRadius: 12)
+            .fill(.black)
+            .frame(width: 180, height: 24)
+
+        // Pill: Open state
+        PillShape(cornerRadius: 20)
+            .fill(.black)
+            .frame(width: 480, height: 320)
     }
     .padding(20)
     .background(Color.gray.opacity(0.3))

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -9,10 +9,16 @@ import AppKit
 import CoreGraphics
 import SwiftUI
 
-// Corner radius constants
+// Corner radius constants for notch mode
 private let cornerRadiusInsets = (
     opened: (top: CGFloat(19), bottom: CGFloat(24)),
     closed: (top: CGFloat(6), bottom: CGFloat(14))
+)
+
+// Corner radius constants for pill mode (external displays without notch)
+private let pillCornerRadius = (
+    opened: CGFloat(20),
+    closed: CGFloat(12)
 )
 
 struct NotchView: View {
@@ -108,23 +114,24 @@ struct NotchView: View {
 
     // MARK: - Corner Radii
 
+    private var isPillMode: Bool { !viewModel.hasPhysicalNotch }
+
     private var topCornerRadius: CGFloat {
-        viewModel.status == .opened
+        if isPillMode {
+            return viewModel.status == .opened ? pillCornerRadius.opened : pillCornerRadius.closed
+        }
+        return viewModel.status == .opened
             ? cornerRadiusInsets.opened.top
             : cornerRadiusInsets.closed.top
     }
 
     private var bottomCornerRadius: CGFloat {
-        viewModel.status == .opened
+        if isPillMode {
+            return viewModel.status == .opened ? pillCornerRadius.opened : pillCornerRadius.closed
+        }
+        return viewModel.status == .opened
             ? cornerRadiusInsets.opened.bottom
             : cornerRadiusInsets.closed.bottom
-    }
-
-    private var currentNotchShape: NotchShape {
-        NotchShape(
-            topCornerRadius: topCornerRadius,
-            bottomCornerRadius: bottomCornerRadius
-        )
     }
 
     // Animation springs
@@ -137,6 +144,11 @@ struct NotchView: View {
         ZStack(alignment: .top) {
             // Outer container does NOT receive hits - only the notch content does
             VStack(spacing: 0) {
+                // In pill mode, add a top gap so the pill sits within the menu bar
+                if isPillMode {
+                    Spacer().frame(height: 5)
+                }
+
                 notchLayout
                     .frame(
                         maxWidth: viewModel.status == .opened ? notchSize.width : nil,
@@ -145,21 +157,27 @@ struct NotchView: View {
                     .padding(
                         .horizontal,
                         viewModel.status == .opened
-                            ? cornerRadiusInsets.opened.top
-                            : cornerRadiusInsets.closed.bottom
+                            ? (isPillMode ? pillCornerRadius.opened : cornerRadiusInsets.opened.top)
+                            : (isPillMode ? pillCornerRadius.closed : cornerRadiusInsets.closed.bottom)
                     )
                     .padding([.horizontal, .bottom], viewModel.status == .opened ? 12 : 0)
                     .background(.black)
-                    .clipShape(currentNotchShape)
+                    .clipShape(isPillMode
+                        ? AnyShape(PillShape(cornerRadius: viewModel.status == .opened ? pillCornerRadius.opened : pillCornerRadius.closed))
+                        : AnyShape(NotchShape(topCornerRadius: topCornerRadius, bottomCornerRadius: bottomCornerRadius))
+                    )
                     .overlay(alignment: .top) {
-                        Rectangle()
-                            .fill(.black)
-                            .frame(height: 1)
-                            .padding(.horizontal, topCornerRadius)
+                        // Top-edge line only needed in notch mode to blend with the physical notch
+                        if !isPillMode {
+                            Rectangle()
+                                .fill(.black)
+                                .frame(height: 1)
+                                .padding(.horizontal, topCornerRadius)
+                        }
                     }
                     .shadow(
-                        color: (viewModel.status == .opened || isHovering) ? .black.opacity(0.7) : .clear,
-                        radius: 6
+                        color: (viewModel.status == .opened || isHovering || isPillMode) ? .black.opacity(0.7) : .clear,
+                        radius: isPillMode && viewModel.status != .opened ? 4 : 6
                     )
                     .frame(
                         maxWidth: viewModel.status == .opened ? notchSize.width : nil,
@@ -190,9 +208,9 @@ struct NotchView: View {
         .preferredColorScheme(.dark)
         .onAppear {
             sessionMonitor.startMonitoring()
-            // On non-notched devices, keep visible so users have a target to interact with
+            // Pill mode: only show when there are active sessions
             if !viewModel.hasPhysicalNotch {
-                isVisible = true
+                isVisible = !sessionMonitor.instances.isEmpty
             }
         }
         .onChange(of: viewModel.status) { oldStatus, newStatus in
@@ -204,6 +222,12 @@ struct NotchView: View {
         .onChange(of: sessionMonitor.instances) { _, instances in
             handleProcessingChange()
             handleWaitingForInputChange(instances)
+            // Pill mode: show/hide based on active sessions
+            if !viewModel.hasPhysicalNotch && viewModel.status != .opened {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isVisible = !instances.isEmpty
+                }
+            }
         }
     }
 
@@ -248,13 +272,14 @@ struct NotchView: View {
         HStack(spacing: 0) {
             // Left side - crab + optional permission indicator (visible when processing, pending, or waiting for input)
             if showClosedActivity {
+                let iconSize: CGFloat = isPillMode ? 11 : 14
                 HStack(spacing: 4) {
-                    ClaudeCrabIcon(size: 14, animateLegs: isProcessing)
+                    ClaudeCrabIcon(size: iconSize, animateLegs: isProcessing)
                         .matchedGeometryEffect(id: "crab", in: activityNamespace, isSource: showClosedActivity)
 
                     // Permission indicator only (amber) - waiting for input shows checkmark on right
                     if hasPendingPermission {
-                        PermissionIndicatorIcon(size: 14, color: Color(red: 0.85, green: 0.47, blue: 0.34))
+                        PermissionIndicatorIcon(size: iconSize, color: Color(red: 0.85, green: 0.47, blue: 0.34))
                             .matchedGeometryEffect(id: "status-indicator", in: activityNamespace, isSource: showClosedActivity)
                     }
                 }
@@ -268,14 +293,16 @@ struct NotchView: View {
                 openedHeaderContent
             } else if !showClosedActivity {
                 // Closed without activity: empty space
+                let inset: CGFloat = isPillMode ? 10 : 20
                 Rectangle()
                     .fill(.clear)
-                    .frame(width: closedNotchSize.width - 20)
+                    .frame(width: closedNotchSize.width - inset)
             } else {
                 // Closed with activity: black spacer (with optional bounce)
+                let inset: CGFloat = isPillMode ? pillCornerRadius.closed : cornerRadiusInsets.closed.top
                 Rectangle()
                     .fill(.black)
-                    .frame(width: closedNotchSize.width - cornerRadiusInsets.closed.top + (isBouncing ? 16 : 0))
+                    .frame(width: closedNotchSize.width - inset + (isBouncing ? 16 : 0))
             }
 
             // Right side - spinner when processing/pending, checkmark when waiting for input
@@ -405,8 +432,13 @@ struct NotchView: View {
                 waitingForInputTimestamps.removeAll()
             }
         case .closed:
-            // Don't hide on non-notched devices - users need a visible target
-            guard viewModel.hasPhysicalNotch else { return }
+            // Pill mode: hide if no sessions
+            if !viewModel.hasPhysicalNotch {
+                if sessionMonitor.instances.isEmpty {
+                    withAnimation(.easeInOut(duration: 0.2)) { isVisible = false }
+                }
+                return
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
                 if viewModel.status == .closed && !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !activityCoordinator.expandingActivity.show {
                     isVisible = false

--- a/ClaudeIsland/UI/Window/NotchViewController.swift
+++ b/ClaudeIsland/UI/Window/NotchViewController.swift
@@ -65,8 +65,8 @@ class NotchViewController: NSViewController {
                 // When closed, use the notch rect (or pill rect on non-notch displays)
                 let notchRect = geometry.deviceNotchRect
                 let screenWidth = geometry.screenRect.width
-                // Pill mode needs larger padding since the pill is smaller
-                let padX: CGFloat = geometry.isPillMode ? 15 : 10
+                // Pill mode needs larger padding since the pill width is content-driven
+                let padX: CGFloat = geometry.isPillMode ? 60 : 10
                 let padY: CGFloat = geometry.isPillMode ? 8 : 5
                 return CGRect(
                     x: (screenWidth - notchRect.width) / 2 - padX,

--- a/ClaudeIsland/UI/Window/NotchViewController.swift
+++ b/ClaudeIsland/UI/Window/NotchViewController.swift
@@ -62,15 +62,17 @@ class NotchViewController: NSViewController {
                     height: panelHeight
                 )
             case .closed, .popping:
-                // When closed, use the notch rect
+                // When closed, use the notch rect (or pill rect on non-notch displays)
                 let notchRect = geometry.deviceNotchRect
                 let screenWidth = geometry.screenRect.width
-                // Add some padding for easier interaction
+                // Pill mode needs larger padding since the pill is smaller
+                let padX: CGFloat = geometry.isPillMode ? 15 : 10
+                let padY: CGFloat = geometry.isPillMode ? 8 : 5
                 return CGRect(
-                    x: (screenWidth - notchRect.width) / 2 - 10,
-                    y: windowHeight - notchRect.height - 5,
-                    width: notchRect.width + 20,
-                    height: notchRect.height + 10
+                    x: (screenWidth - notchRect.width) / 2 - padX,
+                    y: windowHeight - notchRect.height - padY,
+                    width: notchRect.width + padX * 2,
+                    height: notchRect.height + padY * 2
                 )
             }
         }

--- a/ClaudeIsland/UI/Window/NotchWindowController.swift
+++ b/ClaudeIsland/UI/Window/NotchWindowController.swift
@@ -37,12 +37,14 @@ class NotchWindowController: NSWindowController {
             height: notchSize.height
         )
 
+        let hasNotch = screen.hasPhysicalNotch
+
         // Create view model
         self.viewModel = NotchViewModel(
             deviceNotchRect: deviceNotchRect,
             screenRect: screenFrame,
             windowHeight: windowHeight,
-            hasPhysicalNotch: screen.hasPhysicalNotch
+            hasPhysicalNotch: hasNotch
         )
 
         // Create the window
@@ -54,6 +56,11 @@ class NotchWindowController: NSWindowController {
         )
 
         super.init(window: notchWindow)
+
+        // Pill mode sits within the menu bar, notch mode floats above it
+        if !hasNotch {
+            notchWindow.level = .mainMenu + 1
+        }
 
         // Create the SwiftUI view with pass-through hosting
         let hostingController = NotchViewController(viewModel: viewModel)


### PR DESCRIPTION
## Motivation

Claude Island renders a Dynamic Island-style overlay anchored to the MacBook's physical notch. On external monitors — which have no notch — the existing notch shape with inward-curving top corners looks out of place and sits awkwardly at the screen edge. This PR adds a pill-shaped mode that renders a compact capsule within the menu bar area, giving external display users a native-feeling experience.

<img width="559" height="346" alt="image" src="https://github.com/user-attachments/assets/4f22e1bc-6873-47b3-98a5-acf710e39e47" />

<img width="1588" height="897" alt="image" src="https://github.com/user-attachments/assets/025ebd97-6943-49f8-aaaa-1d31c51f93ee" />



## Changes

- **PillShape**
  - New `Shape` struct with uniform rounded corners (no inward curves)
  - Animatable corner radius for smooth open/close transitions
  - Preview includes both pill and notch states for visual comparison

- **External display detection**
  - `hasPhysicalNotch` now requires `isBuiltinDisplay && safeAreaInsets.top > 0`
  - Prevents false positives where external monitors reported non-zero safe area insets
  - `notchSize` returns compact 180x22pt dimensions for pill mode

- **Pill closed state layout**
  - Content-driven width instead of fixed 180px — pill sizes to fit its contents
  - Shows crab icon (left), status text (center), and spinner (right)
  - Status text displays "X running Y idle" with white for running, light grey for idle
  - Crab icon animates legs when agents are actively processing

- **Pill visibility**
  - Auto-hides when no Claude sessions are running
  - Fades in/out with 0.2s ease animation when sessions appear/disappear
  - Always stays visible while sessions exist (unlike notch mode which hides when idle)

- **Window positioning**
  - 5px top gap so the pill floats within the menu bar rather than flush with the screen edge
  - Window level `.mainMenu + 1` for pill (vs `+3` for notch) to sit within the menu bar layer

- **Hit testing**
  - Wider hit-test padding (60px horizontal) to accommodate dynamic pill width
  - Consistent across `NotchGeometry` and `NotchViewController`