### PR TITLE
fix: Harden socket security and add hook installation consent

### DIFF
--- a/ClaudeIsland/App/AppDelegate.swift
+++ b/ClaudeIsland/App/AppDelegate.swift
@@ -67,7 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Mixpanel.mainInstance().track(event: "App Launched")
         Mixpanel.mainInstance().flush()
 
-        HookInstaller.installIfNeeded()
+        installHooksWithConsent()
         NSApplication.shared.setActivationPolicy(.accessory)
 
         windowManager = WindowManager()
@@ -89,6 +89,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleScreenChange() {
         _ = windowManager?.setupNotchWindow()
+    }
+
+    private func installHooksWithConsent() {
+        let consent = AppSettings.hooksConsentGiven
+
+        if consent == true {
+            HookInstaller.installIfNeeded()
+            return
+        }
+
+        if consent == false {
+            return
+        }
+
+        // consent == nil: first launch, never asked
+        // Existing users with hooks already installed get implied consent
+        if HookInstaller.isInstalled() {
+            AppSettings.hooksConsentGiven = true
+            HookInstaller.installIfNeeded()
+            return
+        }
+
+        // New user: show consent dialog
+        let alert = NSAlert()
+        alert.messageText = "Enable Claude Code Integration?"
+        alert.informativeText = "Claude Island can integrate with Claude Code by installing hooks into your ~/.claude/settings.json configuration. This enables real-time status monitoring and permission management from the menu bar.\n\nYou can change this later in Settings."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Enable Hooks")
+        alert.addButton(withTitle: "Not Now")
+
+        let response = alert.runModal()
+
+        if response == .alertFirstButtonReturn {
+            AppSettings.hooksConsentGiven = true
+            HookInstaller.installIfNeeded()
+        } else {
+            AppSettings.hooksConsentGiven = false
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/ClaudeIsland/Core/Settings.swift
+++ b/ClaudeIsland/Core/Settings.swift
@@ -38,6 +38,7 @@ enum AppSettings {
 
     private enum Keys {
         static let notificationSound = "notificationSound"
+        static let hooksConsentGiven = "hooksConsentGiven"
     }
 
     // MARK: - Notification Sound
@@ -53,6 +54,26 @@ enum AppSettings {
         }
         set {
             defaults.set(newValue.rawValue, forKey: Keys.notificationSound)
+        }
+    }
+
+    // MARK: - Hooks Consent
+
+    /// Whether the user has given consent for hooks installation.
+    /// Returns nil if never asked (first launch).
+    static var hooksConsentGiven: Bool? {
+        get {
+            guard defaults.object(forKey: Keys.hooksConsentGiven) != nil else {
+                return nil
+            }
+            return defaults.bool(forKey: Keys.hooksConsentGiven)
+        }
+        set {
+            if let value = newValue {
+                defaults.set(value, forKey: Keys.hooksConsentGiven)
+            } else {
+                defaults.removeObject(forKey: Keys.hooksConsentGiven)
+            }
         }
     }
 }

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -9,8 +9,18 @@ import os
 import socket
 import sys
 
-SOCKET_PATH = "/tmp/claude-island.sock"
+SOCKET_PATH = os.path.expanduser("~/.claude/claude-island.sock")
+TOKEN_PATH = os.path.expanduser("~/.claude/hooks/.claude-island-token")
 TIMEOUT_SECONDS = 300  # 5 minutes for permission decisions
+
+
+def get_token():
+    """Read the authentication token written by ClaudeIsland.app"""
+    try:
+        with open(TOKEN_PATH, "r") as f:
+            return f.read().strip()
+    except (OSError, IOError):
+        return None
 
 
 def get_tty():
@@ -94,6 +104,11 @@ def main():
         "pid": claude_pid,
         "tty": tty,
     }
+
+    # Add authentication token
+    token = get_token()
+    if token:
+        state["token"] = token
 
     # Map events to status
     if event == "UserPromptSubmit":

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -25,6 +25,7 @@ struct HookEvent: Codable, Sendable {
     let toolUseId: String?
     let notificationType: String?
     let message: String?
+    let token: String?
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
@@ -32,11 +33,11 @@ struct HookEvent: Codable, Sendable {
         case toolInput = "tool_input"
         case toolUseId = "tool_use_id"
         case notificationType = "notification_type"
-        case message
+        case message, token
     }
 
     /// Create a copy with updated toolUseId
-    init(sessionId: String, cwd: String, event: String, status: String, pid: Int?, tty: String?, tool: String?, toolInput: [String: AnyCodable]?, toolUseId: String?, notificationType: String?, message: String?) {
+    init(sessionId: String, cwd: String, event: String, status: String, pid: Int?, tty: String?, tool: String?, toolInput: [String: AnyCodable]?, toolUseId: String?, notificationType: String?, message: String?, token: String? = nil) {
         self.sessionId = sessionId
         self.cwd = cwd
         self.event = event
@@ -48,6 +49,7 @@ struct HookEvent: Codable, Sendable {
         self.toolUseId = toolUseId
         self.notificationType = notificationType
         self.message = message
+        self.token = token
     }
 
     var sessionPhase: SessionPhase {
@@ -107,9 +109,16 @@ typealias PermissionFailureHandler = @Sendable (_ sessionId: String, _ toolUseId
 /// Uses GCD DispatchSource for non-blocking I/O
 class HookSocketServer {
     static let shared = HookSocketServer()
-    static let socketPath = "/tmp/claude-island.sock"
+    static let socketPath: String = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".claude/claude-island.sock")
+        .path
+    static let tokenPath: String = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".claude/hooks/.claude-island-token")
+        .path
 
     private var serverSocket: Int32 = -1
+    /// The expected token for authenticating hook connections
+    private var expectedToken: String?
     private var acceptSource: DispatchSourceRead?
     private var eventHandler: HookEventHandler?
     private var permissionFailureHandler: PermissionFailureHandler?
@@ -141,6 +150,8 @@ class HookSocketServer {
         permissionFailureHandler = onPermissionFailure
 
         unlink(Self.socketPath)
+        // Clean up legacy socket path from previous versions
+        unlink("/tmp/claude-island.sock")
 
         serverSocket = socket(AF_UNIX, SOCK_STREAM, 0)
         guard serverSocket >= 0 else {
@@ -174,7 +185,7 @@ class HookSocketServer {
             return
         }
 
-        chmod(Self.socketPath, 0o777)
+        chmod(Self.socketPath, 0o600)
 
         guard listen(serverSocket, 10) == 0 else {
             logger.error("Failed to listen: \(errno)")
@@ -184,6 +195,8 @@ class HookSocketServer {
         }
 
         logger.info("Listening on \(Self.socketPath, privacy: .public)")
+
+        expectedToken = generateAndWriteToken()
 
         acceptSource = DispatchSource.makeReadSource(fileDescriptor: serverSocket, queue: queue)
         acceptSource?.setEventHandler { [weak self] in
@@ -203,6 +216,7 @@ class HookSocketServer {
         acceptSource?.cancel()
         acceptSource = nil
         unlink(Self.socketPath)
+        unlink(Self.tokenPath)
 
         permissionsLock.lock()
         for (_, pending) in pendingPermissions {
@@ -278,6 +292,26 @@ class HookSocketServer {
             pendingPermissions.removeValue(forKey: toolUseId)
         }
         permissionsLock.unlock()
+    }
+
+    // MARK: - Token Authentication
+
+    /// Generate a random token and write it to the token file
+    private func generateAndWriteToken() -> String {
+        let token = UUID().uuidString
+        let tokenDir = (Self.tokenPath as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(
+            atPath: tokenDir,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        FileManager.default.createFile(
+            atPath: Self.tokenPath,
+            contents: token.data(using: .utf8),
+            attributes: [.posixPermissions: 0o600]
+        )
+        logger.info("Auth token written to \(Self.tokenPath, privacy: .public)")
+        return token
     }
 
     // MARK: - Tool Use ID Cache
@@ -409,6 +443,15 @@ class HookSocketServer {
             logger.warning("Failed to parse event: \(String(data: data, encoding: .utf8) ?? "?", privacy: .public)")
             close(clientSocket)
             return
+        }
+
+        // Validate authentication token
+        if let expected = expectedToken {
+            guard event.token == expected else {
+                logger.warning("Rejected event with invalid token from \(event.sessionId.prefix(8), privacy: .public)")
+                close(clientSocket)
+                return
+            }
         }
 
         logger.debug("Received: \(event.event, privacy: .public) for \(event.sessionId.prefix(8), privacy: .public)")

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -70,9 +70,11 @@ struct NotchMenuView: View {
                 if hooksInstalled {
                     HookInstaller.uninstall()
                     hooksInstalled = false
+                    AppSettings.hooksConsentGiven = false
                 } else {
                     HookInstaller.installIfNeeded()
                     hooksInstalled = true
+                    AppSettings.hooksConsentGiven = true
                 }
             }
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                               
- Moves the Unix domain socket from world-accessible /tmp/ to the user-scoped ~/.claude/ directory                                                                                                                                                                           
- Adds token-based authentication to prevent unauthorized processes from sending events to the app                                                                                                                                                                           
- Restricts socket file permissions from 0o777 to 0o600 (owner-only)                                                                                                                                                                                                         
- Adds a first-launch consent dialog before installing hooks into the user's Claude Code configuration                                                                                                                                                                       
                                                                                                                                                                                                                                                                               
## Changes                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                               
- HookSocketServer.swift: Move socket path from /tmp/claude-island.sock to ~/.claude/claude-island.sock; generate a random auth token on server start, write it to ~/.claude/hooks/.claude-island-token with 0o600 permissions; validate the token on every incoming       
  connection and reject unauthorized events; clean up legacy /tmp/ socket on start; add token field to HookEvent
- claude-island-state.py: Update socket path to ~/.claude/claude-island.sock; read auth token from ~/.claude/hooks/.claude-island-token and include it in every event sent to the app
- Settings.swift: Add hooksConsentGiven setting (tri-state: nil = never asked, true = consented, false = declined)
- AppDelegate.swift: Replace direct HookInstaller.installIfNeeded() call with installHooksWithConsent() that checks consent state, grants implied consent to existing users who already have hooks installed, and shows a consent dialog for new users
- NotchMenuView.swift: Sync the hooks toggle in the settings menu with the consent state

## Security considerations

- The previous socket at /tmp/claude-island.sock with 0o777 permissions allowed any process on the system to send events, potentially injecting fake permission approvals
- The new location under ~/.claude/ with 0o600 permissions restricts access to the current user
- The token authentication adds defense in depth: even if another process can access the socket, it cannot send valid events without reading the token file (also 0o600)
- The consent dialog ensures hooks are not silently installed into the user's Claude Code configuration on first launch
