### PR TITLE
Support local build signing configuration via xcconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ Pods/
 *.iml
 .vscode/
 
+# Local build configuration (signing overrides)
+Local.xcconfig
+
 # Sparkle signing keys (NEVER commit these!)
 .sparkle-keys/
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,6 +17,14 @@ mkdir -p "$BUILD_DIR"
 
 cd "$PROJECT_DIR"
 
+# Use Local.xcconfig for signing overrides if it exists
+XCCONFIG_FLAG=""
+if [ -f "$PROJECT_DIR/Local.xcconfig" ]; then
+    XCCONFIG_FLAG="-xcconfig $PROJECT_DIR/Local.xcconfig"
+    echo "Using Local.xcconfig for signing configuration"
+    echo ""
+fi
+
 # Build and archive
 echo "Archiving..."
 xcodebuild archive \
@@ -24,15 +32,15 @@ xcodebuild archive \
     -configuration Release \
     -archivePath "$ARCHIVE_PATH" \
     -destination "generic/platform=macOS" \
+    $XCCONFIG_FLAG \
     ENABLE_HARDENED_RUNTIME=YES \
-    CODE_SIGN_STYLE=Automatic \
     | xcpretty || xcodebuild archive \
     -scheme ClaudeIsland \
     -configuration Release \
     -archivePath "$ARCHIVE_PATH" \
     -destination "generic/platform=macOS" \
-    ENABLE_HARDENED_RUNTIME=YES \
-    CODE_SIGN_STYLE=Automatic
+    $XCCONFIG_FLAG \
+    ENABLE_HARDENED_RUNTIME=YES
 
 # Create ExportOptions.plist if it doesn't exist
 EXPORT_OPTIONS="$BUILD_DIR/ExportOptions.plist"


### PR DESCRIPTION


## Summary

- Allows contributors to build the project without the original developer's signing certificate
- Contributors create a Local.xcconfig file (gitignored) that overrides code signing settings
- The build script auto-detects and applies Local.xcconfig when present

## Changes

- `.gitignore`: Add Local.xcconfig to prevent signing config from being committed
- `scripts/build.sh`: Auto-detect Local.xcconfig and pass it via -xcconfig flag to xcodebuild

## Usage

Contributors who don't have the project's signing certificate can build with ad-hoc signing by creating Local.xcconfig at the project root:

```
DEVELOPMENT_TEAM =
CODE_SIGN_IDENTITY = -
CODE_SIGN_STYLE = Manual
```

Contributors with their own Apple Developer account can substitute their team ID:
```
DEVELOPMENT_TEAM = YOUR_TEAM_ID
CODE_SIGN_IDENTITY = Apple Development
CODE_SIGN_STYLE = Automatic
```