### PR TITLE
Add "Always Allow" button for tool permission approval

### DIFF
--- a/ClaudeIsland/Models/SessionEvent.swift
+++ b/ClaudeIsland/Models/SessionEvent.swift
@@ -21,6 +21,9 @@ enum SessionEvent: Sendable {
     /// User approved a permission request
     case permissionApproved(sessionId: String, toolUseId: String)
 
+    /// User approved a permission request and wants to always allow this tool
+    case permissionApprovedAlways(sessionId: String, toolUseId: String, toolName: String)
+
     /// User denied a permission request
     case permissionDenied(sessionId: String, toolUseId: String, reason: String?)
 
@@ -187,6 +190,8 @@ extension SessionEvent: CustomStringConvertible {
             return "hookReceived(\(event.event), session: \(event.sessionId.prefix(8)))"
         case .permissionApproved(let sessionId, let toolUseId):
             return "permissionApproved(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)))"
+        case .permissionApprovedAlways(let sessionId, let toolUseId, let toolName):
+            return "permissionApprovedAlways(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)), name: \(toolName))"
         case .permissionDenied(let sessionId, let toolUseId, _):
             return "permissionDenied(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)))"
         case .permissionSocketFailed(let sessionId, let toolUseId):

--- a/ClaudeIsland/Models/SessionState.swift
+++ b/ClaudeIsland/Models/SessionState.swift
@@ -22,6 +22,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
     var pid: Int?
     var tty: String?
     var isInTmux: Bool
+    var autoApprovedTools: Set<String>
 
     // MARK: - State Machine
 
@@ -71,6 +72,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         pid: Int? = nil,
         tty: String? = nil,
         isInTmux: Bool = false,
+        autoApprovedTools: Set<String> = [],
         phase: SessionPhase = .idle,
         chatItems: [ChatHistoryItem] = [],
         toolTracker: ToolTracker = ToolTracker(),
@@ -89,6 +91,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         self.pid = pid
         self.tty = tty
         self.isInTmux = isInTmux
+        self.autoApprovedTools = autoApprovedTools
         self.phase = phase
         self.chatItems = chatItems
         self.toolTracker = toolTracker

--- a/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
+++ b/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
@@ -94,6 +94,28 @@ class ClaudeSessionMonitor: ObservableObject {
         }
     }
 
+    func approvePermissionAlways(sessionId: String) {
+        Task {
+            guard let session = await SessionStore.shared.session(for: sessionId),
+                  let permission = session.activePermission else {
+                return
+            }
+
+            HookSocketServer.shared.respondToPermission(
+                toolUseId: permission.toolUseId,
+                decision: "allow"
+            )
+
+            await SessionStore.shared.process(
+                .permissionApprovedAlways(
+                    sessionId: sessionId,
+                    toolUseId: permission.toolUseId,
+                    toolName: permission.toolName
+                )
+            )
+        }
+    }
+
     func denyPermission(sessionId: String, reason: String?) {
         Task {
             guard let session = await SessionStore.shared.session(for: sessionId),

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -57,6 +57,9 @@ actor SessionStore {
         case .permissionApproved(let sessionId, let toolUseId):
             await processPermissionApproved(sessionId: sessionId, toolUseId: toolUseId)
 
+        case .permissionApprovedAlways(let sessionId, let toolUseId, let toolName):
+            await processPermissionApprovedAlways(sessionId: sessionId, toolUseId: toolUseId, toolName: toolName)
+
         case .permissionDenied(let sessionId, let toolUseId, let reason):
             await processPermissionDenied(sessionId: sessionId, toolUseId: toolUseId, reason: reason)
 
@@ -159,6 +162,17 @@ actor SessionStore {
 
         if event.event == "Stop" {
             session.subagentState = SubagentState()
+        }
+
+        // Auto-approve: if waiting for approval for an auto-approved tool, approve immediately
+        if case .waitingForApproval(let ctx) = session.phase,
+           session.autoApprovedTools.contains(ctx.toolName) {
+            Self.logger.info("Auto-approving \(ctx.toolName, privacy: .public) for session \(sessionId.prefix(8), privacy: .public)")
+            HookSocketServer.shared.respondToPermission(toolUseId: ctx.toolUseId, decision: "allow")
+            updateToolStatus(in: &session, toolId: ctx.toolUseId, status: .running)
+            if session.phase.canTransition(to: .processing) {
+                session.phase = .processing
+            }
         }
 
         sessions[sessionId] = session
@@ -351,6 +365,14 @@ actor SessionStore {
         }
 
         sessions[sessionId] = session
+    }
+
+    private func processPermissionApprovedAlways(sessionId: String, toolUseId: String, toolName: String) async {
+        guard var session = sessions[sessionId] else { return }
+        session.autoApprovedTools.insert(toolName)
+        sessions[sessionId] = session
+        // Reuse existing approval logic
+        await processPermissionApproved(sessionId: sessionId, toolUseId: toolUseId)
     }
 
     // MARK: - Tool Completion Processing

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -413,6 +413,7 @@ struct ChatView: View {
             tool: tool,
             toolInput: session.pendingToolInput,
             onApprove: { approvePermission() },
+            onApproveAlways: { approvePermissionAlways() },
             onDeny: { denyPermission() }
         )
     }
@@ -456,6 +457,10 @@ struct ChatView: View {
 
     private func approvePermission() {
         sessionMonitor.approvePermission(sessionId: sessionId)
+    }
+
+    private func approvePermissionAlways() {
+        sessionMonitor.approvePermissionAlways(sessionId: sessionId)
     }
 
     private func denyPermission() {
@@ -1050,15 +1055,16 @@ struct ChatApprovalBar: View {
     let tool: String
     let toolInput: String?
     let onApprove: () -> Void
+    let onApproveAlways: () -> Void
     let onDeny: () -> Void
 
     @State private var showContent = false
+    @State private var showAlwaysButton = false
     @State private var showAllowButton = false
     @State private var showDenyButton = false
 
     var body: some View {
-        HStack(spacing: 12) {
-            // Tool info
+        HStack(spacing: 8) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(MCPToolFormatter.formatToolName(tool))
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
@@ -1075,14 +1081,11 @@ struct ChatApprovalBar: View {
 
             Spacer()
 
-            // Deny button
-            Button {
-                onDeny()
-            } label: {
+            Button { onDeny() } label: {
                 Text("Deny")
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(.white.opacity(0.7))
-                    .padding(.horizontal, 16)
+                    .padding(.horizontal, 12)
                     .padding(.vertical, 8)
                     .background(Color.white.opacity(0.1))
                     .clipShape(Capsule())
@@ -1091,14 +1094,11 @@ struct ChatApprovalBar: View {
             .opacity(showDenyButton ? 1 : 0)
             .scaleEffect(showDenyButton ? 1 : 0.8)
 
-            // Allow button
-            Button {
-                onApprove()
-            } label: {
+            Button { onApprove() } label: {
                 Text("Allow")
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(.black)
-                    .padding(.horizontal, 16)
+                    .padding(.horizontal, 12)
                     .padding(.vertical, 8)
                     .background(Color.white.opacity(0.95))
                     .clipShape(Capsule())
@@ -1106,8 +1106,21 @@ struct ChatApprovalBar: View {
             .buttonStyle(.plain)
             .opacity(showAllowButton ? 1 : 0)
             .scaleEffect(showAllowButton ? 1 : 0.8)
+
+            Button { onApproveAlways() } label: {
+                Text("Always")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color.green.opacity(0.7))
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .opacity(showAlwaysButton ? 1 : 0)
+            .scaleEffect(showAlwaysButton ? 1 : 0.8)
         }
-        .frame(minHeight: 44)  // Consistent height with other bars
+        .frame(minHeight: 44)
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(Color.black.opacity(0.2))
@@ -1120,6 +1133,9 @@ struct ChatApprovalBar: View {
             }
             withAnimation(.spring(response: 0.35, dampingFraction: 0.7).delay(0.15)) {
                 showAllowButton = true
+            }
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.7).delay(0.2)) {
+                showAlwaysButton = true
             }
         }
     }

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -75,6 +75,7 @@ struct ClaudeInstancesView: View {
                         onChat: { openChat(session) },
                         onArchive: { archiveSession(session) },
                         onApprove: { approveSession(session) },
+                        onApproveAlways: { approveAlwaysSession(session) },
                         onReject: { rejectSession(session) }
                     )
                     .id(session.stableId)
@@ -107,6 +108,10 @@ struct ClaudeInstancesView: View {
         sessionMonitor.approvePermission(sessionId: session.sessionId)
     }
 
+    private func approveAlwaysSession(_ session: SessionState) {
+        sessionMonitor.approvePermissionAlways(sessionId: session.sessionId)
+    }
+
     private func rejectSession(_ session: SessionState) {
         sessionMonitor.denyPermission(sessionId: session.sessionId, reason: nil)
     }
@@ -124,6 +129,7 @@ struct InstanceRow: View {
     let onChat: () -> Void
     let onArchive: () -> Void
     let onApprove: () -> Void
+    let onApproveAlways: () -> Void
     let onReject: () -> Void
 
     @State private var isHovered = false
@@ -247,6 +253,7 @@ struct InstanceRow: View {
                 InlineApprovalButtons(
                     onChat: onChat,
                     onApprove: onApprove,
+                    onApproveAlways: onApproveAlways,
                     onReject: onReject
                 )
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
@@ -328,11 +335,13 @@ struct InstanceRow: View {
 struct InlineApprovalButtons: View {
     let onChat: () -> Void
     let onApprove: () -> Void
+    let onApproveAlways: () -> Void
     let onReject: () -> Void
 
     @State private var showChatButton = false
     @State private var showDenyButton = false
     @State private var showAllowButton = false
+    @State private var showAlwaysButton = false
 
     var body: some View {
         HStack(spacing: 6) {
@@ -349,7 +358,7 @@ struct InlineApprovalButtons: View {
                 Text("Deny")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundColor(.white.opacity(0.6))
-                    .padding(.horizontal, 10)
+                    .padding(.horizontal, 8)
                     .padding(.vertical, 5)
                     .background(Color.white.opacity(0.1))
                     .clipShape(Capsule())
@@ -364,7 +373,7 @@ struct InlineApprovalButtons: View {
                 Text("Allow")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundColor(.black)
-                    .padding(.horizontal, 10)
+                    .padding(.horizontal, 8)
                     .padding(.vertical, 5)
                     .background(Color.white.opacity(0.9))
                     .clipShape(Capsule())
@@ -372,6 +381,21 @@ struct InlineApprovalButtons: View {
             .buttonStyle(.plain)
             .opacity(showAllowButton ? 1 : 0)
             .scaleEffect(showAllowButton ? 1 : 0.8)
+
+            Button {
+                onApproveAlways()
+            } label: {
+                Text("Always")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(Color.green.opacity(0.7))
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .opacity(showAlwaysButton ? 1 : 0)
+            .scaleEffect(showAlwaysButton ? 1 : 0.8)
         }
         .onAppear {
             withAnimation(.spring(response: 0.3, dampingFraction: 0.7).delay(0.0)) {
@@ -382,6 +406,9 @@ struct InlineApprovalButtons: View {
             }
             withAnimation(.spring(response: 0.3, dampingFraction: 0.7).delay(0.1)) {
                 showAllowButton = true
+            }
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.7).delay(0.15)) {
+                showAlwaysButton = true
             }
         }
     }

--- a/Local.xcconfig
+++ b/Local.xcconfig
@@ -1,0 +1,9 @@
+// Local build configuration - not checked into git.
+// Override signing settings for local development.
+//
+// To use your own team ID, change DEVELOPMENT_TEAM below.
+// To build without signing at all, leave as-is (ad-hoc signing).
+
+DEVELOPMENT_TEAM =
+CODE_SIGN_IDENTITY = -
+CODE_SIGN_STYLE = Manual


### PR DESCRIPTION
## Summary

- Adds a third option to the permission approval UI: "Always Allow"
- When clicked, the tool is approved immediately and the tool name is stored in a per-session auto-approve set
- All subsequent permission requests for the same tool are auto-approved without user interaction for the remainder of the session
- The "Always" button appears in both the instances list (inline approval buttons) and the chat view (approval bar)

## Changes

- SessionState.swift: Add autoApprovedTools: Set<String> property for per-session tracking
- SessionEvent.swift: Add permissionApprovedAlways event case
- ClaudeSessionMonitor.swift: Add approvePermissionAlways() method
- SessionStore.swift: Handle permissionApprovedAlways event, add auto-approve check in processHookEvent that intercepts permission requests for already-approved tools
- ChatView.swift: Add green "Always" button to ChatApprovalBar with staggered animation
- ClaudeInstancesView.swift: Add green "Always" button to InlineApprovalButtons with staggered animation

<img width="449" height="62" alt="Screenshot 2026-02-25 at 11 16 31" src="https://github.com/user-attachments/assets/a47c2ff6-3f09-4915-a746-a685830dd297" />


## How it works

- The hook protocol response remains {"decision": "allow"} (no wire protocol changes)
- Auto-approval is implemented entirely at the app level by storing approved tool names and checking them before setting the waitingForApproval phase
- Auto-approved tools are scoped to the session lifetime (cleared when session ends)