### PR TITLE
Add native terminal support for input and window focusing

### DIFF
--- a/ClaudeIsland/Services/Shared/NativeTerminalInputHandler.swift
+++ b/ClaudeIsland/Services/Shared/NativeTerminalInputHandler.swift
@@ -1,0 +1,231 @@
+//
+//  NativeTerminalInputHandler.swift
+//  ClaudeIsland
+//
+//  Sends input to Claude Code sessions running in native macOS terminals
+//  (Terminal.app, iTerm2, and others) without requiring tmux.
+//  Also handles focusing terminal windows across virtual desktops.
+//
+
+import AppKit
+import Foundation
+import os.log
+
+/// Handles sending input to native terminal applications via AppleScript
+/// and focusing terminal windows across virtual desktops.
+actor NativeTerminalInputHandler {
+    static let shared = NativeTerminalInputHandler()
+
+    nonisolated static let logger = Logger(subsystem: "com.claudeisland", category: "NativeTerminal")
+
+    private init() {}
+
+    /// Send a message to a Claude Code session by writing to its terminal
+    func sendMessage(_ message: String, tty: String, pid: Int) async -> Bool {
+        let tree = ProcessTreeBuilder.shared.buildTree()
+        let terminalName = findTerminalAppName(forPid: pid, tree: tree)
+
+        Self.logger.debug("Sending to terminal: \(terminalName ?? "unknown", privacy: .public) tty: \(tty, privacy: .public)")
+
+        let fullTty = tty.hasPrefix("/dev/") ? tty : "/dev/\(tty)"
+
+        switch terminalName?.lowercased() {
+        case let name where name?.contains("iterm") == true:
+            return await sendViaITerm2(message: message, tty: fullTty)
+        case "terminal":
+            return await sendViaTerminalApp(message: message, tty: fullTty)
+        default:
+            return await sendViaSystemEvents(message: message, pid: pid, tree: tree)
+        }
+    }
+
+    // MARK: - iTerm2
+
+    private func sendViaITerm2(message: String, tty: String) async -> Bool {
+        let escapedMessage = message.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let escapedTty = tty.replacingOccurrences(of: "\"", with: "\\\"")
+
+        let script = """
+        tell application "iTerm2"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        if tty of s is "\(escapedTty)" then
+                            tell s to write text "\(escapedMessage)"
+                            return "ok"
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+        end tell
+        return "not_found"
+        """
+
+        return await runAppleScript(script, label: "iTerm2")
+    }
+
+    // MARK: - Terminal.app
+
+    private func sendViaTerminalApp(message: String, tty: String) async -> Bool {
+        let escapedMessage = message.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let escapedTty = tty.replacingOccurrences(of: "\"", with: "\\\"")
+
+        let script = """
+        tell application "Terminal"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    if tty of t is "\(escapedTty)" then
+                        set selected of t to true
+                        set index of w to 1
+                        do script "\(escapedMessage)" in t
+                        return "ok"
+                    end if
+                end repeat
+            end repeat
+        end tell
+        return "not_found"
+        """
+
+        return await runAppleScript(script, label: "Terminal.app")
+    }
+
+    // MARK: - Generic (System Events)
+
+    private func sendViaSystemEvents(message: String, pid: Int, tree: [Int: ProcessInfo]) async -> Bool {
+        guard let terminalPid = ProcessTreeBuilder.shared.findTerminalPid(forProcess: pid, tree: tree) else {
+            Self.logger.warning("Could not find terminal PID for process \(pid)")
+            return false
+        }
+
+        guard let terminalInfo = tree[terminalPid] else {
+            return false
+        }
+
+        let appName = URL(fileURLWithPath: terminalInfo.command).lastPathComponent
+
+        let escapedMessage = message.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+
+        let script = """
+        tell application "\(appName)" to activate
+        delay 0.2
+        tell application "System Events"
+            keystroke "\(escapedMessage)"
+            keystroke return
+        end tell
+        """
+
+        return await runAppleScript(script, label: "SystemEvents/\(appName)")
+    }
+
+    // MARK: - Focus Terminal
+
+    /// Focus the terminal window where a Claude Code session is running.
+    /// Works across virtual desktops using NSRunningApplication.activate().
+    /// For iTerm2 and Terminal.app, also selects the correct tab/session by TTY.
+    func focusTerminal(pid: Int, tty: String?) async -> Bool {
+        let tree = ProcessTreeBuilder.shared.buildTree()
+
+        guard let terminalPid = ProcessTreeBuilder.shared.findTerminalPid(forProcess: pid, tree: tree) else {
+            Self.logger.warning("Could not find terminal PID for process \(pid)")
+            return false
+        }
+
+        guard let app = NSRunningApplication(processIdentifier: pid_t(terminalPid)) else {
+            Self.logger.warning("Could not find NSRunningApplication for PID \(terminalPid)")
+            return false
+        }
+
+        let activated = app.activate(options: [.activateAllWindows])
+        if !activated {
+            Self.logger.warning("Failed to activate terminal app PID \(terminalPid)")
+        }
+
+        if let tty = tty {
+            let fullTty = tty.hasPrefix("/dev/") ? tty : "/dev/\(tty)"
+            let terminalName = findTerminalAppName(forPid: pid, tree: tree)
+
+            switch terminalName?.lowercased() {
+            case let name where name?.contains("iterm") == true:
+                await focusITerm2Session(tty: fullTty)
+            case "terminal":
+                await focusTerminalAppTab(tty: fullTty)
+            default:
+                break
+            }
+        }
+
+        return activated
+    }
+
+    private func focusITerm2Session(tty: String) async {
+        let escapedTty = tty.replacingOccurrences(of: "\"", with: "\\\"")
+        let script = """
+        tell application "iTerm2"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        if tty of s is "\(escapedTty)" then
+                            select s
+                            return "ok"
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+        end tell
+        """
+        _ = await runAppleScript(script, label: "iTerm2-focus")
+    }
+
+    private func focusTerminalAppTab(tty: String) async {
+        let escapedTty = tty.replacingOccurrences(of: "\"", with: "\\\"")
+        let script = """
+        tell application "Terminal"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    if tty of t is "\(escapedTty)" then
+                        set selected of t to true
+                        set index of w to 1
+                        return "ok"
+                    end if
+                end repeat
+            end repeat
+        end tell
+        """
+        _ = await runAppleScript(script, label: "Terminal.app-focus")
+    }
+
+    // MARK: - Helpers
+
+    private func findTerminalAppName(forPid pid: Int, tree: [Int: ProcessInfo]) -> String? {
+        guard let terminalPid = ProcessTreeBuilder.shared.findTerminalPid(forProcess: pid, tree: tree),
+              let info = tree[terminalPid] else {
+            return nil
+        }
+        return URL(fileURLWithPath: info.command).lastPathComponent
+    }
+
+    private func runAppleScript(_ script: String, label: String) async -> Bool {
+        do {
+            let result = await ProcessExecutor.shared.runWithResult(
+                "/usr/bin/osascript",
+                arguments: ["-e", script]
+            )
+            switch result {
+            case .success(let output):
+                let trimmed = output.output.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed == "not_found" {
+                    Self.logger.warning("[\(label, privacy: .public)] TTY not found in terminal sessions")
+                    return false
+                }
+                Self.logger.debug("[\(label, privacy: .public)] Script executed successfully")
+                return true
+            case .failure(let error):
+                Self.logger.error("[\(label, privacy: .public)] Script failed: \(error.localizedDescription, privacy: .public)")
+                return false
+            }
+        }
+    }
+}

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -160,7 +160,7 @@ struct ChatView: View {
             }
         }
         .onChange(of: canSendMessages) { _, canSend in
-            // Auto-focus input when tmux messaging becomes available
+            // Auto-focus input when messaging becomes available
             if canSend && !isInputFocused {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     isInputFocused = true
@@ -168,7 +168,7 @@ struct ChatView: View {
             }
         }
         .onAppear {
-            // Auto-focus input when chat opens and tmux messaging is available
+            // Auto-focus input when chat opens and messaging is available
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 if canSendMessages {
                     isInputFocused = true
@@ -353,14 +353,14 @@ struct ChatView: View {
 
     // MARK: - Input Bar
 
-    /// Can send messages only if session is in tmux
+    /// Can send messages if session has a TTY (works with both tmux and native terminals)
     private var canSendMessages: Bool {
-        session.isInTmux && session.tty != nil
+        session.tty != nil
     }
 
     private var inputBar: some View {
         HStack(spacing: 10) {
-            TextField(canSendMessages ? "Message Claude..." : "Open Claude Code in tmux to enable messaging", text: $inputText)
+            TextField(canSendMessages ? "Message Claude..." : "Waiting for session to connect...", text: $inputText)
                 .textFieldStyle(.plain)
                 .font(.system(size: 13))
                 .foregroundColor(canSendMessages ? .white : .white.opacity(0.4))
@@ -422,7 +422,7 @@ struct ChatView: View {
     /// Bar for interactive tools like AskUserQuestion that need terminal input
     private var interactivePromptBar: some View {
         ChatInteractivePromptBar(
-            isInTmux: session.isInTmux,
+            canSendMessages: canSendMessages,
             onGoToTerminal: { focusTerminal() }
         )
     }
@@ -479,11 +479,16 @@ struct ChatView: View {
     }
 
     private func sendToSession(_ text: String) async {
-        guard session.isInTmux else { return }
         guard let tty = session.tty else { return }
 
-        if let target = await findTmuxTarget(tty: tty) {
-            _ = await ToolApprovalHandler.shared.sendMessage(text, to: target)
+        if session.isInTmux {
+            // Use tmux send-keys for tmux sessions
+            if let target = await findTmuxTarget(tty: tty) {
+                _ = await ToolApprovalHandler.shared.sendMessage(text, to: target)
+            }
+        } else if let pid = session.pid {
+            // Use native terminal input for non-tmux sessions
+            _ = await NativeTerminalInputHandler.shared.sendMessage(text, tty: tty, pid: pid)
         }
     }
 
@@ -983,7 +988,7 @@ struct InterruptedMessageView: View {
 
 /// Bar for interactive tools like AskUserQuestion that need terminal input
 struct ChatInteractivePromptBar: View {
-    let isInTmux: Bool
+    let canSendMessages: Bool
     let onGoToTerminal: () -> Void
 
     @State private var showContent = false
@@ -1008,7 +1013,7 @@ struct ChatInteractivePromptBar: View {
 
             // Terminal button on right (similar to Allow button)
             Button {
-                if isInTmux {
+                if canSendMessages {
                     onGoToTerminal()
                 }
             } label: {
@@ -1018,10 +1023,10 @@ struct ChatInteractivePromptBar: View {
                     Text("Terminal")
                         .font(.system(size: 13, weight: .medium))
                 }
-                .foregroundColor(isInTmux ? .black : .white.opacity(0.4))
+                .foregroundColor(canSendMessages ? .black : .white.opacity(0.4))
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
-                .background(isInTmux ? Color.white.opacity(0.95) : Color.white.opacity(0.1))
+                .background(canSendMessages ? Color.white.opacity(0.95) : Color.white.opacity(0.1))
                 .clipShape(Capsule())
             }
             .buttonStyle(.plain)

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -88,12 +88,14 @@ struct ClaudeInstancesView: View {
     // MARK: - Actions
 
     private func focusSession(_ session: SessionState) {
-        guard session.isInTmux else { return }
-
         Task {
             if let pid = session.pid {
-                _ = await YabaiController.shared.focusWindow(forClaudePid: pid)
-            } else {
+                if session.isInTmux, await WindowFinder.shared.isYabaiAvailable() {
+                    _ = await YabaiController.shared.focusWindow(forClaudePid: pid)
+                } else {
+                    _ = await NativeTerminalInputHandler.shared.focusTerminal(pid: pid, tty: session.tty)
+                }
+            } else if session.isInTmux {
                 _ = await YabaiController.shared.focusWindow(forWorkingDirectory: session.cwd)
             }
         }
@@ -234,10 +236,10 @@ struct InstanceRow: View {
                         onChat()
                     }
 
-                    // Go to Terminal button (only if yabai available)
-                    if isYabaiAvailable {
+                    // Go to Terminal button
+                    if session.pid != nil {
                         TerminalButton(
-                            isEnabled: session.isInTmux,
+                            isEnabled: true,
                             onTap: { onFocus() }
                         )
                     }
@@ -257,8 +259,8 @@ struct InstanceRow: View {
                         onChat()
                     }
 
-                    // Focus icon (only for tmux instances with yabai)
-                    if session.isInTmux && isYabaiAvailable {
+                    // Focus icon - works for all sessions with a PID
+                    if session.pid != nil {
                         IconButton(icon: "eye") {
                             onFocus()
                         }
@@ -280,6 +282,9 @@ struct InstanceRow: View {
         .contentShape(Rectangle())
         .onTapGesture(count: 2) {
             onChat()
+        }
+        .onTapGesture(count: 1) {
+            onFocus()
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isWaitingForApproval)
         .background(


### PR DESCRIPTION
## Summary

- Enables sending messages to Claude Code sessions running in native macOS terminals (Terminal.app, iTerm2, Ghostty, Alacritty, etc.) without requiring tmux
- Enables focusing terminal windows across virtual desktops without requiring yabai
- Single-tap on a session row in the instances list focuses the corresponding terminal window

## Changes

- NativeTerminalInputHandler.swift (new): Actor that handles terminal input and focus via AppleScript and NSRunningApplication
- ChatView.swift: Relax canSendMessages from requiring tmux to requiring only a TTY; route non-tmux sessions through NativeTerminalInputHandler; rename ChatInteractivePromptBar.isInTmux to canSendMessages
- ClaudeInstancesView.swift: Update focusSession to fall back to NativeTerminalInputHandler when yabai is unavailable; add single-tap gesture to focus terminal; show focus button for all sessions with a PID

## Terminal support matrix

- iTerm2: Full support - finds session by TTY using AppleScript tty property, uses native write text for input, select for focus
- Terminal.app: Full support - finds tab by TTY using AppleScript tty property, uses do script for input, set selected for focus
- Other terminals (Ghostty, Alacritty, kitty, Warp, etc.): Window activation via NSRunningApplication.activate() (works across Spaces); input via System Events keystroke (requires terminal to be frontmost)
- tmux sessions: Existing behavior preserved (tmux send-keys for input, yabai for focus when available, fallback to NSRunningApplication)