### PR TITLE
Move Claude Island from notch overlay to draggable menubar pill

### DIFF
--- a/ClaudeIsland/App/AppDelegate.swift
+++ b/ClaudeIsland/App/AppDelegate.swift
@@ -8,6 +8,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var windowManager: WindowManager?
     private var screenObserver: ScreenObserver?
     private var updateCheckTimer: Timer?
+    private var statusItem: NSStatusItem?
 
     static var shared: AppDelegate?
     let updater: SPUUpdater
@@ -70,8 +71,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         HookInstaller.installIfNeeded()
         NSApplication.shared.setActivationPolicy(.accessory)
 
+        // Create status item first so it's visible even if window setup fails
+        setupStatusItem()
+
         windowManager = WindowManager()
         _ = windowManager?.setupNotchWindow()
+
+        // Sync anchor now that window/viewModel exist
+        DispatchQueue.main.async { [weak self] in
+            self?.syncStatusItemPosition()
+        }
 
         screenObserver = ScreenObserver { [weak self] in
             self?.handleScreenChange()
@@ -89,6 +98,55 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleScreenChange() {
         _ = windowManager?.setupNotchWindow()
+        // Re-sync anchor position after screen change
+        syncStatusItemPosition()
+    }
+
+    private func setupStatusItem() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        statusItem?.autosaveName = "ClaudeIslandStatus"
+        statusItem?.isVisible = true
+
+        guard let button = statusItem?.button else { return }
+
+        if let img = NSImage(systemSymbolName: "terminal.fill", accessibilityDescription: "Claude Island") {
+            img.isTemplate = true
+            img.size = NSSize(width: 18, height: 18)
+            button.image = img
+        } else {
+            button.title = "CI"
+        }
+
+        button.action = #selector(statusItemClicked(_:))
+        button.target = self
+    }
+
+    @objc private func statusItemClicked(_ sender: Any?) {
+        guard let viewModel = windowController?.viewModel else { return }
+
+        // Update anchor to current status item position (only if on-screen)
+        syncStatusItemPosition()
+
+        // Toggle panel
+        if viewModel.status == .opened {
+            viewModel.notchClose()
+        } else {
+            viewModel.notchOpen(reason: .click)
+        }
+    }
+
+    private func syncStatusItemPosition() {
+        guard let viewModel = windowController?.viewModel else { return }
+
+        // Use status item position only if it's actually on a visible screen
+        if let button = statusItem?.button,
+           let buttonWindow = button.window,
+           buttonWindow.screen != nil {
+            let frame = buttonWindow.frame
+            viewModel.statusItemRect = frame
+            viewModel.updateAnchor(screenX: frame.midX)
+        }
+        // Otherwise keep the default (window center) — don't override with off-screen position
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/ClaudeIsland/Core/NotchGeometry.swift
+++ b/ClaudeIsland/Core/NotchGeometry.swift
@@ -8,16 +8,18 @@
 import CoreGraphics
 import Foundation
 
-/// Pure geometry calculations for the notch
+/// Pure geometry calculations for the notch / menubar panel
 struct NotchGeometry: Sendable {
     let deviceNotchRect: CGRect
     let screenRect: CGRect
     let windowHeight: CGFloat
+    /// Center X position for the panel anchor (status item position in screen coords)
+    var anchorX: CGFloat
 
-    /// The notch rect in screen coordinates (for hit testing with global mouse position)
+    /// The anchor rect in screen coordinates (for hit testing with global mouse position)
     var notchScreenRect: CGRect {
         CGRect(
-            x: screenRect.midX - deviceNotchRect.width / 2,
+            x: anchorX - deviceNotchRect.width / 2,
             y: screenRect.maxY - deviceNotchRect.height,
             width: deviceNotchRect.width,
             height: deviceNotchRect.height
@@ -29,8 +31,12 @@ struct NotchGeometry: Sendable {
         // Match the actual rendered panel size (tuned to match visual output)
         let width = size.width - 6
         let height = size.height - 30
+        // Clamp so the panel stays on screen
+        let halfWidth = width / 2
+        let clampedX = max(screenRect.minX + halfWidth + 10,
+                          min(anchorX, screenRect.maxX - halfWidth - 10))
         return CGRect(
-            x: screenRect.midX - width / 2,
+            x: clampedX - width / 2,
             y: screenRect.maxY - height,
             width: width,
             height: height

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -53,9 +53,17 @@ class NotchViewModel: ObservableObject {
 
     // MARK: - Geometry
 
-    let geometry: NotchGeometry
+    var geometry: NotchGeometry
     let spacing: CGFloat = 12
     let hasPhysicalNotch: Bool
+
+    /// Screen rect of the status item button (used to avoid closing when clicking it)
+    var statusItemRect: CGRect = .zero
+
+    /// Center X anchor for the panel (status item position in screen coords)
+    @Published var anchorX: CGFloat {
+        didSet { geometry.anchorX = anchorX }
+    }
 
     var deviceNotchRect: CGRect { geometry.deviceNotchRect }
     var screenRect: CGRect { geometry.screenRect }
@@ -94,19 +102,26 @@ class NotchViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
     private let events = EventMonitors.shared
-    private var hoverTimer: DispatchWorkItem?
 
     // MARK: - Initialization
 
     init(deviceNotchRect: CGRect, screenRect: CGRect, windowHeight: CGFloat, hasPhysicalNotch: Bool) {
+        let initialAnchorX = screenRect.midX  // Center of the window
+        self._anchorX = Published(initialValue: initialAnchorX)
         self.geometry = NotchGeometry(
             deviceNotchRect: deviceNotchRect,
             screenRect: screenRect,
-            windowHeight: windowHeight
+            windowHeight: windowHeight,
+            anchorX: initialAnchorX
         )
         self.hasPhysicalNotch = hasPhysicalNotch
         setupEventHandlers()
         observeSelectors()
+    }
+
+    /// Update the anchor position (called when status item is clicked)
+    func updateAnchor(screenX: CGFloat) {
+        anchorX = screenX
     }
 
     private func observeSelectors() {
@@ -147,50 +162,26 @@ class NotchViewModel: ObservableObject {
     private var currentChatSession: SessionState?
 
     private func handleMouseMove(_ location: CGPoint) {
-        let inNotch = geometry.isPointInNotch(location)
+        let inPill = geometry.isPointInNotch(location)
         let inOpened = status == .opened && geometry.isPointInOpenedPanel(location, size: openedSize)
+        let newHovering = inPill || inOpened
 
-        let newHovering = inNotch || inOpened
-
-        // Only update if changed to prevent unnecessary re-renders
         guard newHovering != isHovering else { return }
-
         isHovering = newHovering
-
-        // Cancel any pending hover timer
-        hoverTimer?.cancel()
-        hoverTimer = nil
-
-        // Start hover timer to auto-expand after 1 second
-        if isHovering && (status == .closed || status == .popping) {
-            let workItem = DispatchWorkItem { [weak self] in
-                guard let self = self, self.isHovering else { return }
-                self.notchOpen(reason: .hover)
-            }
-            hoverTimer = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: workItem)
-        }
     }
 
     private func handleMouseDown() {
         let location = NSEvent.mouseLocation
 
-        switch status {
-        case .opened:
-            if geometry.isPointOutsidePanel(location, size: openedSize) {
-                notchClose()
-                // Re-post the click so it reaches the window/app behind us
-                repostClickAt(location)
-            } else if geometry.notchScreenRect.contains(location) {
-                // Clicking notch while opened - only close if NOT in chat mode
-                if !isInChatMode {
-                    notchClose()
-                }
-            }
-        case .closed, .popping:
-            if geometry.isPointInNotch(location) {
-                notchOpen(reason: .click)
-            }
+        // Only handle click-outside-to-close when opened
+        guard status == .opened else { return }
+
+        // Don't close if clicking the status item
+        if !statusItemRect.isEmpty && statusItemRect.contains(location) { return }
+
+        if geometry.isPointOutsidePanel(location, size: openedSize) {
+            notchClose()
+            repostClickAt(location)
         }
     }
 

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -26,6 +26,7 @@ struct NotchView: View {
     @State private var isVisible: Bool = false
     @State private var isHovering: Bool = false
     @State private var isBouncing: Bool = false
+    @State private var isDragging: Bool = false
 
     @Namespace private var activityNamespace
 
@@ -183,6 +184,26 @@ struct NotchView: View {
                             viewModel.notchOpen(reason: .click)
                         }
                     }
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                guard viewModel.status != .opened else { return }
+                                isDragging = true
+                                // Move the window horizontally
+                                if let window = NSApp.windows.first(where: { $0 is NotchPanel }) {
+                                    var frame = window.frame
+                                    frame.origin.x += value.translation.width
+                                    window.setFrame(frame, display: true)
+                                }
+                            }
+                            .onEnded { _ in
+                                isDragging = false
+                                // Save position to UserDefaults
+                                if let window = NSApp.windows.first(where: { $0 is NotchPanel }) {
+                                    UserDefaults.standard.set(Double(window.frame.origin.x), forKey: "ClaudeIsland.windowX")
+                                }
+                            }
+                    )
             }
         }
         .opacity(isVisible ? 1 : 0)
@@ -190,10 +211,8 @@ struct NotchView: View {
         .preferredColorScheme(.dark)
         .onAppear {
             sessionMonitor.startMonitoring()
-            // On non-notched devices, keep visible so users have a target to interact with
-            if !viewModel.hasPhysicalNotch {
-                isVisible = true
-            }
+            // Always visible in menubar mode — the status item is the primary indicator
+            isVisible = true
         }
         .onChange(of: viewModel.status) { oldStatus, newStatus in
             handleStatusChange(from: oldStatus, to: newStatus)
@@ -246,33 +265,24 @@ struct NotchView: View {
     @ViewBuilder
     private var headerRow: some View {
         HStack(spacing: 0) {
-            // Left side - crab + optional permission indicator (visible when processing, pending, or waiting for input)
-            if showClosedActivity {
-                HStack(spacing: 4) {
-                    ClaudeCrabIcon(size: 14, animateLegs: isProcessing)
-                        .matchedGeometryEffect(id: "crab", in: activityNamespace, isSource: showClosedActivity)
+            // Left side - always show crab icon (animated legs when processing)
+            HStack(spacing: 4) {
+                ClaudeCrabIcon(size: 14, animateLegs: isProcessing)
+                    .matchedGeometryEffect(id: "crab", in: activityNamespace, isSource: true)
 
-                    // Permission indicator only (amber) - waiting for input shows checkmark on right
-                    if hasPendingPermission {
-                        PermissionIndicatorIcon(size: 14, color: Color(red: 0.85, green: 0.47, blue: 0.34))
-                            .matchedGeometryEffect(id: "status-indicator", in: activityNamespace, isSource: showClosedActivity)
-                    }
+                if hasPendingPermission {
+                    PermissionIndicatorIcon(size: 14, color: Color(red: 0.85, green: 0.47, blue: 0.34))
+                        .matchedGeometryEffect(id: "status-indicator", in: activityNamespace, isSource: showClosedActivity)
                 }
-                .frame(width: viewModel.status == .opened ? nil : sideWidth + (hasPendingPermission ? 18 : 0))
-                .padding(.leading, viewModel.status == .opened ? 8 : 0)
             }
+            .frame(width: viewModel.status == .opened ? nil : sideWidth + (hasPendingPermission ? 18 : 0))
+            .padding(.leading, viewModel.status == .opened ? 8 : 0)
 
             // Center content
             if viewModel.status == .opened {
-                // Opened: show header content
                 openedHeaderContent
-            } else if !showClosedActivity {
-                // Closed without activity: empty space
-                Rectangle()
-                    .fill(.clear)
-                    .frame(width: closedNotchSize.width - 20)
             } else {
-                // Closed with activity: black spacer (with optional bounce)
+                // Closed: black spacer (with optional bounce)
                 Rectangle()
                     .fill(.black)
                     .frame(width: closedNotchSize.width - cornerRadiusInsets.closed.top + (isBouncing ? 16 : 0))
@@ -285,7 +295,6 @@ struct NotchView: View {
                         .matchedGeometryEffect(id: "spinner", in: activityNamespace, isSource: showClosedActivity)
                         .frame(width: viewModel.status == .opened ? 20 : sideWidth)
                 } else if hasWaitingForInput {
-                    // Checkmark for waiting-for-input on the right side
                     ReadyForInputIndicatorIcon(size: 14, color: TerminalColors.green)
                         .matchedGeometryEffect(id: "spinner", in: activityNamespace, isSource: showClosedActivity)
                         .frame(width: viewModel.status == .opened ? 20 : sideWidth)
@@ -373,27 +382,14 @@ struct NotchView: View {
 
     private func handleProcessingChange() {
         if isAnyProcessing || hasPendingPermission {
-            // Show claude activity when processing or waiting for permission
             activityCoordinator.showActivity(type: .claude)
-            isVisible = true
         } else if hasWaitingForInput {
-            // Keep visible for waiting-for-input but hide the processing spinner
             activityCoordinator.hideActivity()
-            isVisible = true
         } else {
-            // Hide activity when done
             activityCoordinator.hideActivity()
-
-            // Delay hiding the notch until animation completes
-            // Don't hide on non-notched devices - users need a visible target
-            if viewModel.status == .closed && viewModel.hasPhysicalNotch {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    if !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && viewModel.status == .closed {
-                        isVisible = false
-                    }
-                }
-            }
         }
+        // Always visible in menubar mode
+        isVisible = true
     }
 
     private func handleStatusChange(from oldStatus: NotchStatus, to newStatus: NotchStatus) {
@@ -405,13 +401,8 @@ struct NotchView: View {
                 waitingForInputTimestamps.removeAll()
             }
         case .closed:
-            // Don't hide on non-notched devices - users need a visible target
-            guard viewModel.hasPhysicalNotch else { return }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                if viewModel.status == .closed && !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !activityCoordinator.expandingActivity.show {
-                    isVisible = false
-                }
-            }
+            // In menubar mode, always stay visible (status item is the primary indicator)
+            break
         }
     }
 

--- a/ClaudeIsland/UI/Window/NotchViewController.swift
+++ b/ClaudeIsland/UI/Window/NotchViewController.swift
@@ -47,27 +47,29 @@ class NotchViewController: NSViewController {
             // Window coordinates: origin at bottom-left, Y increases upward
             // The window is positioned at top of screen, so panel is at top of window
             let windowHeight = geometry.windowHeight
+            let screenWidth = geometry.screenRect.width
+            // Anchor X relative to the window (window starts at screenFrame.origin.x)
+            let anchorInWindow = vm.anchorX - geometry.screenRect.origin.x
 
             switch vm.status {
             case .opened:
                 let panelSize = vm.openedSize
-                // Panel is centered horizontally, anchored to top
                 let panelWidth = panelSize.width + 52  // Account for corner radius padding
                 let panelHeight = panelSize.height
-                let screenWidth = geometry.screenRect.width
+                // Clamp so panel stays on screen
+                let halfPanel = panelWidth / 2
+                let clampedAnchor = max(halfPanel + 10, min(anchorInWindow, screenWidth - halfPanel - 10))
                 return CGRect(
-                    x: (screenWidth - panelWidth) / 2,
+                    x: clampedAnchor - halfPanel,
                     y: windowHeight - panelHeight,
                     width: panelWidth,
                     height: panelHeight
                 )
             case .closed, .popping:
-                // When closed, use the notch rect
+                // Small anchor rect at status item position
                 let notchRect = geometry.deviceNotchRect
-                let screenWidth = geometry.screenRect.width
-                // Add some padding for easier interaction
                 return CGRect(
-                    x: (screenWidth - notchRect.width) / 2 - 10,
+                    x: anchorInWindow - notchRect.width / 2 - 10,
                     y: windowHeight - notchRect.height - 5,
                     width: notchRect.width + 20,
                     height: notchRect.height + 10

--- a/ClaudeIsland/UI/Window/NotchWindowController.swift
+++ b/ClaudeIsland/UI/Window/NotchWindowController.swift
@@ -18,29 +18,32 @@ class NotchWindowController: NSWindowController {
         self.screen = screen
 
         let screenFrame = screen.frame
-        let notchSize = screen.notchSize
 
-        // Window covers full width at top, tall enough for largest content (chat view)
+        // Window positioned near the right side of the screen (or restored from user preference)
         let windowHeight: CGFloat = 750
+        let windowWidth: CGFloat = 620
+        let savedX = UserDefaults.standard.double(forKey: "ClaudeIsland.windowX")
+        let windowX: CGFloat = savedX > 0 ? CGFloat(savedX) : screenFrame.maxX - windowWidth
         let windowFrame = NSRect(
-            x: screenFrame.origin.x,
+            x: max(screenFrame.origin.x, min(windowX, screenFrame.maxX - windowWidth)),
             y: screenFrame.maxY - windowHeight,
-            width: screenFrame.width,
+            width: windowWidth,
             height: windowHeight
         )
 
-        // Device notch rect - positioned at center
+        // Small anchor rect centered in the window
+        let anchorSize = CGSize(width: 30, height: 24)
         let deviceNotchRect = CGRect(
-            x: (screenFrame.width - notchSize.width) / 2,
+            x: (windowWidth - anchorSize.width) / 2,
             y: 0,
-            width: notchSize.width,
-            height: notchSize.height
+            width: anchorSize.width,
+            height: anchorSize.height
         )
 
-        // Create view model
+        // Create view model — use windowFrame as the "screen" rect so SwiftUI centers within the window
         self.viewModel = NotchViewModel(
             deviceNotchRect: deviceNotchRect,
-            screenRect: screenFrame,
+            screenRect: windowFrame,
             windowHeight: windowHeight,
             hasPhysicalNotch: screen.hasPhysicalNotch
         )
@@ -61,35 +64,30 @@ class NotchWindowController: NSWindowController {
 
         notchWindow.setFrame(windowFrame, display: true)
 
-        // Dynamically toggle mouse event handling based on notch state:
-        // - Closed: ignoresMouseEvents = true (clicks pass through to menu bar/apps)
-        // - Opened: ignoresMouseEvents = false (buttons inside panel work)
-        viewModel.$status
+        // Accept mouse events when hovering over the pill OR when opened.
+        // This lets clicks/drags work on the pill while passing through everywhere else.
+        viewModel.$isHovering
+            .combineLatest(viewModel.$status)
             .receive(on: DispatchQueue.main)
-            .sink { [weak notchWindow, weak viewModel] status in
+            .sink { [weak notchWindow, weak viewModel] (hovering, status) in
                 switch status {
                 case .opened:
-                    // Accept mouse events when opened so buttons work
                     notchWindow?.ignoresMouseEvents = false
-                    // Don't steal focus when opened by notification (task finished)
                     if viewModel?.openReason != .notification {
                         NSApp.activate(ignoringOtherApps: false)
                         notchWindow?.makeKey()
                     }
                 case .closed, .popping:
-                    // Ignore mouse events when closed so clicks pass through
-                    notchWindow?.ignoresMouseEvents = true
+                    // Accept events only when hovering over the pill
+                    notchWindow?.ignoresMouseEvents = !hovering
                 }
             }
             .store(in: &cancellables)
 
-        // Start with ignoring mouse events (closed state)
+        // Start with ignoring mouse events
         notchWindow.ignoresMouseEvents = true
 
-        // Perform boot animation after a brief delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            self?.viewModel.performBootAnimation()
-        }
+        // No boot animation for menubar mode — panel opens on status item click
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Summary
- Converts the app from a full-width notch overlay to a compact, draggable pill that floats in the menubar area near system icons
- Pill is always visible with crab icon (even when Claude is idle) and can be clicked to open the panel
- Users can drag the pill horizontally to position it wherever they want — position persists across launches via UserDefaults
- Hover-based mouse event toggling ensures clicks pass through to menubar items underneath when not directly on the pill

## Motivation
On setups where the notch area is occupied by other apps (zNotch, Notchi) or on external monitors without a notch, the original overlay was unusable. This change makes Claude Island work as a standard menubar-area widget that doesn't interfere with other status items.

## Changes
- **NotchWindowController**: Window is now 620pt wide, positioned near the right side of the screen (or restored from saved position)
- **NotchViewModel**: Hover-based `ignoresMouseEvents` toggling, removed hover-to-open in favor of click-to-open, anchor-based geometry
- **NotchGeometry**: Added `anchorX` for flexible positioning with screen-edge clamping
- **NotchView**: Always-visible crab icon, drag gesture for repositioning, simplified visibility logic
- **NotchViewController**: Hit-test rects use anchor-based positioning
- **AppDelegate**: NSStatusItem added as fallback for machines with menubar space

## Test plan
- [ ] Verify pill is visible near system icons in the menubar
- [ ] Click the pill to open/close the panel
- [ ] Drag the pill left/right to reposition — quit and relaunch to confirm position persists
- [ ] Click other menubar icons near the pill — they should work normally
- [ ] Verify processing/permission indicators still animate on the pill
- [ ] Test on MacBook with notch and on external monitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)