### PR TITLE
fix: resolve Claude config directory dynamically for custom setups

### DIFF
--- a/ClaudeIsland/App/AppDelegate.swift
+++ b/ClaudeIsland/App/AppDelegate.swift
@@ -126,8 +126,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func fetchAndRegisterClaudeVersion() {
-        let claudeProjectsDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/projects")
+        let claudeProjectsDir = URL(fileURLWithPath: ClaudeConfigDir.projectsPath)
 
         guard let projectDirs = try? FileManager.default.contentsOfDirectory(
             at: claudeProjectsDir,

--- a/ClaudeIsland/Services/Session/AgentFileWatcher.swift
+++ b/ClaudeIsland/Services/Session/AgentFileWatcher.swift
@@ -42,7 +42,7 @@ class AgentFileWatcher {
 
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-")
                             .replacingOccurrences(of: ".", with: "-")
-        self.filePath = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/agent-" + agentId + ".jsonl"
+        self.filePath = ClaudeConfigDir.projectsPath + "/" + projectDir + "/agent-" + agentId + ".jsonl"
     }
 
     /// Start watching the agent file

--- a/ClaudeIsland/Services/Session/ConversationParser.swift
+++ b/ClaudeIsland/Services/Session/ConversationParser.swift
@@ -73,7 +73,7 @@ actor ConversationParser {
     /// Uses caching based on file modification time
     func parse(sessionId: String, cwd: String) -> ConversationInfo {
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ".", with: "-")
-        let sessionFile = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/" + sessionId + ".jsonl"
+        let sessionFile = ClaudeConfigDir.projectsPath + "/" + projectDir + "/" + sessionId + ".jsonl"
 
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: sessionFile),
@@ -460,7 +460,7 @@ actor ConversationParser {
     /// Build session file path
     private static func sessionFilePath(sessionId: String, cwd: String) -> String {
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ".", with: "-")
-        return NSHomeDirectory() + "/.claude/projects/" + projectDir + "/" + sessionId + ".jsonl"
+        return ClaudeConfigDir.projectsPath + "/" + projectDir + "/" + sessionId + ".jsonl"
     }
 
     private func parseMessageLine(_ json: [String: Any], seenToolIds: inout Set<String>, toolIdToName: inout [String: String]) -> ChatMessage? {
@@ -888,7 +888,7 @@ actor ConversationParser {
         guard !agentId.isEmpty else { return [] }
 
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ".", with: "-")
-        let agentFile = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/agent-" + agentId + ".jsonl"
+        let agentFile = ClaudeConfigDir.projectsPath + "/" + projectDir + "/agent-" + agentId + ".jsonl"
 
         guard FileManager.default.fileExists(atPath: agentFile),
               let content = try? String(contentsOfFile: agentFile, encoding: .utf8) else {
@@ -980,7 +980,7 @@ extension ConversationParser {
         guard !agentId.isEmpty else { return [] }
 
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ".", with: "-")
-        let agentFile = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/agent-" + agentId + ".jsonl"
+        let agentFile = ClaudeConfigDir.projectsPath + "/" + projectDir + "/agent-" + agentId + ".jsonl"
 
         guard FileManager.default.fileExists(atPath: agentFile),
               let content = try? String(contentsOfFile: agentFile, encoding: .utf8) else {

--- a/ClaudeIsland/Services/Session/JSONLInterruptWatcher.swift
+++ b/ClaudeIsland/Services/Session/JSONLInterruptWatcher.swift
@@ -41,7 +41,7 @@ class JSONLInterruptWatcher {
         self.sessionId = sessionId
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-")
                             .replacingOccurrences(of: ".", with: "-")
-        self.filePath = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/" + sessionId + ".jsonl"
+        self.filePath = ClaudeConfigDir.projectsPath + "/" + projectDir + "/" + sessionId + ".jsonl"
     }
 
     /// Start watching the JSONL file for interrupts

--- a/ClaudeIsland/Utilities/ClaudeConfigDir.swift
+++ b/ClaudeIsland/Utilities/ClaudeConfigDir.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Resolves the Claude Code configuration directory.
+///
+/// Checks in order:
+/// 1. `CLAUDE_CONFIG_DIR` environment variable (user override)
+/// 2. `~/.config/claude/` (new default since Claude Code v2.1.30+)
+/// 3. `~/.claude/` (legacy default)
+///
+/// Returns the first path that contains a `projects/` subdirectory,
+/// or falls back to `~/.claude/` if none match.
+enum ClaudeConfigDir {
+    static var projectsPath: String {
+        // 1. Check environment variable
+        if let envDir = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"] {
+            let candidate = (envDir as NSString).expandingTildeInPath
+            if FileManager.default.fileExists(atPath: candidate + "/projects") {
+                return candidate + "/projects"
+            }
+        }
+
+        let home = NSHomeDirectory()
+
+        // 2. Check new default path (~/.config/claude/)
+        let newDefault = home + "/.config/claude/projects"
+        if FileManager.default.fileExists(atPath: newDefault) {
+            return newDefault
+        }
+
+        // 3. Fall back to legacy path (~/.claude/)
+        return home + "/.claude/projects"
+    }
+}


### PR DESCRIPTION
## Problem

Chat history view shows only tool calls but no user/assistant messages when Claude Code is configured with a custom config directory (like `~/.claude-work/` instead of default `~/.claude/`).

I had same problem - my conversation view was always empty even though the session was active. Took me a while to figure out it was the hardcoded path.

## Root Cause

The app has `NSHomeDirectory() + "/.claude/projects/"` hardcoded in 4 files across 7 locations. Anyone using a non-default config directory (via `CLAUDE_CONFIG_DIR` env var) or the new default location (`~/.config/claude/` since Claude Code v2.1.30+) gets empty conversations because the JSONL files are in a different place.

Hook-based events (tool calls, permissions) still work because they come through the Unix socket, but conversation text comes from the JSONL files which the app cant find.

## Fix

Created `ClaudeConfigDir.swift` utility that resolves the projects path dynamically:

1. Check `CLAUDE_CONFIG_DIR` environment variable (user override)
2. Check `~/.config/claude/projects/` (new default since v2.1.30+)
3. Fall back to `~/.claude/projects/` (legacy)

Returns the first path that actually contains a `projects/` subdirectory.

Then replaced all 7 hardcoded path references across 4 files:

| File | Changes |
|------|---------|
| `ConversationParser.swift` | 4 paths replaced |
| `AgentFileWatcher.swift` | 1 path replaced |
| `JSONLInterruptWatcher.swift` | 1 path replaced |
| `AppDelegate.swift` | 1 path replaced |

## How it works now

```
Before: NSHomeDirectory() + "/.claude/projects/" + projectDir + "/"
After:  ClaudeConfigDir.projectsPath + "/" + projectDir + "/"
```

Users with custom config dirs no longer need the symlink workaround mentioned in the issue.

Closes #56