### PR TITLE
Fix: Quit button hover not working

### DIFF
--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -468,6 +468,7 @@ struct MenuRow: View {
             )
         }
         .buttonStyle(.plain)
+        .contentShape(Rectangle())
         .onHover { isHovered = $0 }
     }
 
@@ -517,6 +518,7 @@ struct MenuToggleRow: View {
             )
         }
         .buttonStyle(.plain)
+        .contentShape(Rectangle())
         .onHover { isHovered = $0 }
     }
 


### PR DESCRIPTION
## Summary
- Add `.contentShape(Rectangle())` to `MenuRow` and `MenuToggleRow` in `NotchMenuView.swift`
- Fixes broken hit area on menu buttons (especially the Quit button) where only the icon/text was clickable instead of the entire row
- Root cause: `.buttonStyle(.plain)` shrinks the clickable area to rendered content only; `.contentShape(Rectangle())` extends it to the full bounding box

## Related Issue
Closes #60

## Test Plan
- [ ] Open the notch menu
- [ ] Hover over the Quit button — hover highlight should cover the full row width
- [ ] Click anywhere on the Quit row (not just the icon/text) — app should quit
- [ ] Verify all other menu rows (toggle rows included) have full-width click/hover areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)