### PR TITLE
fix: resolve 3 P0 bugs — sleep/wake bounce, session detection, state inconsistency

### DIFF
--- a/ClaudeIsland/App/ScreenObserver.swift
+++ b/ClaudeIsland/App/ScreenObserver.swift
@@ -6,10 +6,28 @@
 //
 
 import AppKit
+import os.log
+
+private let logger = Logger(subsystem: "com.claudeisland", category: "ScreenObserver")
 
 class ScreenObserver {
-    private var observer: Any?
+    private var screenChangeObserver: Any?
+    private var sleepObserver: Any?
+    private var wakeObserver: Any?
     private let onScreenChange: () -> Void
+
+    /// Debounce work item — coalesces rapid screen-change notifications
+    /// (e.g. sleep/wake fires 3-5 events within milliseconds)
+    private var debounceWork: DispatchWorkItem?
+
+    /// Debounce interval in seconds
+    private let debounceInterval: TimeInterval = 0.5
+
+    /// Whether we're in a post-wake suppression window
+    private var isSuppressingAfterWake = false
+
+    /// Duration to suppress screen-change callbacks after wake (seconds)
+    private let wakeSuppression: TimeInterval = 2.0
 
     init(onScreenChange: @escaping () -> Void) {
         self.onScreenChange = onScreenChange
@@ -21,18 +39,76 @@ class ScreenObserver {
     }
 
     private func startObserving() {
-        observer = NotificationCenter.default.addObserver(
+        // Screen parameter changes (resolution, arrangement, connect/disconnect)
+        screenChangeObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didChangeScreenParametersNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.onScreenChange()
+            self?.handleScreenChange()
+        }
+
+        // System sleep — cancel any pending work
+        sleepObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.willSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            logger.debug("System will sleep — cancelling pending screen-change callbacks")
+            self?.debounceWork?.cancel()
+            self?.debounceWork = nil
+        }
+
+        // System wake — suppress screen-change callbacks for a short window
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            logger.debug("System did wake — suppressing screen-change callbacks for \(self.wakeSuppression)s")
+            self.isSuppressingAfterWake = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.wakeSuppression) { [weak self] in
+                guard let self = self else { return }
+                self.isSuppressingAfterWake = false
+                logger.debug("Wake suppression ended — delivering deferred screen change")
+                // Deliver one final callback so the window repositions to current screen geometry
+                self.onScreenChange()
+            }
         }
     }
 
+    private func handleScreenChange() {
+        // Drop events during post-wake suppression window
+        if isSuppressingAfterWake {
+            logger.debug("Dropping screen-change event (wake suppression active)")
+            return
+        }
+
+        // Debounce: cancel previous pending work and schedule a new one
+        debounceWork?.cancel()
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            logger.debug("Debounced screen-change callback firing")
+            self.onScreenChange()
+        }
+        debounceWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + debounceInterval, execute: work)
+    }
+
     private func stopObserving() {
-        if let observer = observer {
-            NotificationCenter.default.removeObserver(observer)
+        debounceWork?.cancel()
+        debounceWork = nil
+
+        if let obs = screenChangeObserver {
+            NotificationCenter.default.removeObserver(obs)
+        }
+        if let obs = sleepObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(obs)
+        }
+        if let obs = wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(obs)
         }
     }
 }

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -8,9 +8,16 @@ import json
 import os
 import socket
 import sys
+import time
 
 SOCKET_PATH = "/tmp/claude-island.sock"
 TIMEOUT_SECONDS = 300  # 5 minutes for permission decisions
+MAX_RETRIES = 3
+RETRY_DELAY = 0.3  # seconds between retries
+
+# Log to stderr so it doesn't interfere with hook output to stdout
+def _log(msg):
+    print(f"[claude-island-hook] {msg}", file=sys.stderr)
 
 
 def get_tty():
@@ -49,26 +56,82 @@ def get_tty():
     return None
 
 
-def send_event(state):
-    """Send event to app, return response if any"""
-    try:
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(TIMEOUT_SECONDS)
-        sock.connect(SOCKET_PATH)
-        sock.sendall(json.dumps(state).encode())
+def send_event(state, retries=MAX_RETRIES):
+    """Send event to app with retry logic. Returns response if any."""
+    is_permission = state.get("status") == "waiting_for_approval"
 
-        # For permission requests, wait for response
-        if state.get("status") == "waiting_for_approval":
-            response = sock.recv(4096)
-            sock.close()
-            if response:
-                return json.loads(response.decode())
-        else:
-            sock.close()
+    for attempt in range(1, retries + 1):
+        sock = None
+        try:
+            # Check socket file exists before attempting connection
+            if not os.path.exists(SOCKET_PATH):
+                if attempt < retries:
+                    _log(f"Socket not found at {SOCKET_PATH}, retry {attempt}/{retries}")
+                    time.sleep(RETRY_DELAY)
+                    continue
+                else:
+                    _log(f"Socket not found at {SOCKET_PATH} after {retries} attempts — is ClaudeIsland.app running?")
+                    return None
 
-        return None
-    except (socket.error, OSError, json.JSONDecodeError):
-        return None
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(TIMEOUT_SECONDS if is_permission else 5)
+            sock.connect(SOCKET_PATH)
+
+            payload = json.dumps(state).encode()
+            sock.sendall(payload)
+            # Shut down the write side so the server sees EOF
+            sock.shutdown(socket.SHUT_WR)
+
+            # For permission requests, wait for response
+            if is_permission:
+                chunks = []
+                while True:
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                sock.close()
+                sock = None
+                if chunks:
+                    return json.loads(b"".join(chunks).decode())
+                return None
+            else:
+                sock.close()
+                sock = None
+                return None
+
+        except (ConnectionRefusedError, FileNotFoundError) as e:
+            if sock:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            if attempt < retries:
+                _log(f"Connection failed ({e}), retry {attempt}/{retries}")
+                time.sleep(RETRY_DELAY)
+            else:
+                _log(f"Connection failed after {retries} attempts: {e}")
+                return None
+
+        except (socket.timeout, socket.error, OSError) as e:
+            if sock:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            _log(f"Socket error: {e}")
+            return None
+
+        except json.JSONDecodeError as e:
+            if sock:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            _log(f"Invalid JSON response: {e}")
+            return None
+
+    return None
 
 
 def main():

--- a/ClaudeIsland/Services/Hooks/HookInstaller.swift
+++ b/ClaudeIsland/Services/Hooks/HookInstaller.swift
@@ -6,8 +6,29 @@
 //
 
 import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.claudeisland", category: "HookInstaller")
 
 struct HookInstaller {
+
+    // MARK: - Required hook events
+
+    /// All hook events that must be registered for full session detection.
+    /// If any of these are missing, `isInstalled()` returns false and
+    /// `installIfNeeded()` will re-register them.
+    private static let requiredEvents: Set<String> = [
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PermissionRequest",
+        "Notification",
+        "Stop",
+        "SubagentStop",
+        "SessionStart",
+        "SessionEnd",
+        "PreCompact",
+    ]
 
     /// Install hook script and update settings.json on app launch
     static func installIfNeeded() {
@@ -17,21 +38,46 @@ struct HookInstaller {
         let pythonScript = hooksDir.appendingPathComponent("claude-island-state.py")
         let settings = claudeDir.appendingPathComponent("settings.json")
 
-        try? FileManager.default.createDirectory(
-            at: hooksDir,
-            withIntermediateDirectories: true
-        )
-
-        if let bundled = Bundle.main.url(forResource: "claude-island-state", withExtension: "py") {
-            try? FileManager.default.removeItem(at: pythonScript)
-            try? FileManager.default.copyItem(at: bundled, to: pythonScript)
-            try? FileManager.default.setAttributes(
-                [.posixPermissions: 0o755],
-                ofItemAtPath: pythonScript.path
+        // Create hooks directory
+        do {
+            try FileManager.default.createDirectory(
+                at: hooksDir,
+                withIntermediateDirectories: true
             )
+        } catch {
+            logger.error("Failed to create hooks directory: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        // Copy bundled Python hook script
+        if let bundled = Bundle.main.url(forResource: "claude-island-state", withExtension: "py") {
+            do {
+                if FileManager.default.fileExists(atPath: pythonScript.path) {
+                    try FileManager.default.removeItem(at: pythonScript)
+                }
+                try FileManager.default.copyItem(at: bundled, to: pythonScript)
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755],
+                    ofItemAtPath: pythonScript.path
+                )
+                logger.info("Hook script installed at \(pythonScript.path, privacy: .public)")
+            } catch {
+                logger.error("Failed to install hook script: \(error.localizedDescription, privacy: .public)")
+                return
+            }
+        } else {
+            logger.error("Bundled claude-island-state.py not found in app bundle")
+            return
         }
 
         updateSettings(at: settings)
+
+        // Post-install verification
+        if isInstalled() {
+            logger.info("Hook installation verified — all \(requiredEvents.count) events registered")
+        } else {
+            logger.error("Hook installation verification FAILED — some events may be missing")
+        }
     }
 
     private static func updateSettings(at settingsURL: URL) {
@@ -70,7 +116,8 @@ struct HookInstaller {
 
         for (event, config) in hookEvents {
             if var existingEvent = hooks[event] as? [[String: Any]] {
-                let hasOurHook = existingEvent.contains { entry in
+                // Remove stale entries first (e.g. pointing to wrong python path)
+                existingEvent.removeAll { entry in
                     if let entryHooks = entry["hooks"] as? [[String: Any]] {
                         return entryHooks.contains { h in
                             let cmd = h["command"] as? String ?? ""
@@ -79,10 +126,9 @@ struct HookInstaller {
                     }
                     return false
                 }
-                if !hasOurHook {
-                    existingEvent.append(contentsOf: config)
-                    hooks[event] = existingEvent
-                }
+                // Add fresh config
+                existingEvent.append(contentsOf: config)
+                hooks[event] = existingEvent
             } else {
                 hooks[event] = config
             }
@@ -90,19 +136,32 @@ struct HookInstaller {
 
         json["hooks"] = hooks
 
-        if let data = try? JSONSerialization.data(
-            withJSONObject: json,
-            options: [.prettyPrinted, .sortedKeys]
-        ) {
-            try? data.write(to: settingsURL)
+        do {
+            let data = try JSONSerialization.data(
+                withJSONObject: json,
+                options: [.prettyPrinted, .sortedKeys]
+            )
+            try data.write(to: settingsURL)
+            logger.info("Settings updated at \(settingsURL.path, privacy: .public)")
+        } catch {
+            logger.error("Failed to write settings: \(error.localizedDescription, privacy: .public)")
         }
     }
 
-    /// Check if hooks are currently installed
+    /// Check if hooks are currently installed (all required events present)
     static func isInstalled() -> Bool {
         let claudeDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude")
         let settings = claudeDir.appendingPathComponent("settings.json")
+
+        // Also check the script file itself
+        let pythonScript = claudeDir
+            .appendingPathComponent("hooks")
+            .appendingPathComponent("claude-island-state.py")
+        guard FileManager.default.fileExists(atPath: pythonScript.path) else {
+            logger.debug("isInstalled: hook script not found at \(pythonScript.path, privacy: .public)")
+            return false
+        }
 
         guard let data = try? Data(contentsOf: settings),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -110,21 +169,29 @@ struct HookInstaller {
             return false
         }
 
-        for (_, value) in hooks {
+        // Check that ALL required events have our hook registered
+        var registeredEvents = Set<String>()
+        for (event, value) in hooks {
             if let entries = value as? [[String: Any]] {
                 for entry in entries {
                     if let entryHooks = entry["hooks"] as? [[String: Any]] {
                         for hook in entryHooks {
                             if let cmd = hook["command"] as? String,
                                cmd.contains("claude-island-state.py") {
-                                return true
+                                registeredEvents.insert(event)
                             }
                         }
                     }
                 }
             }
         }
-        return false
+
+        let missing = requiredEvents.subtracting(registeredEvents)
+        if !missing.isEmpty {
+            logger.debug("isInstalled: missing hook events: \(missing.sorted().joined(separator: ", "), privacy: .public)")
+            return false
+        }
+        return true
     }
 
     /// Uninstall hooks from settings.json and remove script
@@ -175,6 +242,8 @@ struct HookInstaller {
         ) {
             try? data.write(to: settings)
         }
+
+        logger.info("Hooks uninstalled")
     }
 
     private static func detectPython() -> String {

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -374,10 +374,12 @@ class HookSocketServer {
         var allData = Data()
         var buffer = [UInt8](repeating: 0, count: 131072)
         var pollFd = pollfd(fd: clientSocket, events: Int16(POLLIN), revents: 0)
+        var gotEOF = false
 
+        // Read until EOF or timeout (2 seconds max to handle slow connections)
         let startTime = Date()
-        while Date().timeIntervalSince(startTime) < 0.5 {
-            let pollResult = poll(&pollFd, 1, 50)
+        while Date().timeIntervalSince(startTime) < 2.0 {
+            let pollResult = poll(&pollFd, 1, 100)
 
             if pollResult > 0 && (pollFd.revents & Int16(POLLIN)) != 0 {
                 let bytesRead = read(clientSocket, &buffer, buffer.count)
@@ -385,20 +387,31 @@ class HookSocketServer {
                 if bytesRead > 0 {
                     allData.append(contentsOf: buffer[0..<bytesRead])
                 } else if bytesRead == 0 {
+                    // EOF — client called shutdown(SHUT_WR) or closed
+                    gotEOF = true
                     break
                 } else if errno != EAGAIN && errno != EWOULDBLOCK {
+                    logger.warning("Read error on client socket: errno=\(errno)")
                     break
                 }
             } else if pollResult == 0 {
+                // Poll timeout — if we have data, try to parse it
                 if !allData.isEmpty {
-                    break
+                    if (try? JSONDecoder().decode(HookEvent.self, from: allData)) != nil {
+                        // Complete JSON object received, stop waiting
+                        break
+                    }
+                    // Incomplete JSON — keep waiting for more data
                 }
             } else {
+                // Poll error
+                logger.warning("Poll error on client socket: errno=\(errno)")
                 break
             }
         }
 
         guard !allData.isEmpty else {
+            logger.debug("Empty data from client socket — closing")
             close(clientSocket)
             return
         }
@@ -406,7 +419,7 @@ class HookSocketServer {
         let data = allData
 
         guard let event = try? JSONDecoder().decode(HookEvent.self, from: data) else {
-            logger.warning("Failed to parse event: \(String(data: data, encoding: .utf8) ?? "?", privacy: .public)")
+            logger.warning("Failed to parse event (\(data.count) bytes, eof=\(gotEOF)): \(String(data: data, encoding: .utf8) ?? "?", privacy: .public)")
             close(clientSocket)
             return
         }

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -141,6 +141,13 @@ actor SessionStore {
             return
         }
 
+        // Process tool tracking FIRST so chatItems are created before we set their status.
+        // This prevents the race where PermissionRequest tries to update a tool's status
+        // before the PreToolUse-created chatItem exists.
+        processToolTracking(event: event, session: &session)
+        processSubagentTracking(event: event, session: &session)
+
+        // Now apply phase transition
         let newPhase = event.determinePhase()
 
         if session.phase.canTransition(to: newPhase) {
@@ -149,20 +156,19 @@ actor SessionStore {
             Self.logger.debug("Invalid transition: \(String(describing: session.phase), privacy: .public) -> \(String(describing: newPhase), privacy: .public), ignoring")
         }
 
+        // Update tool status AFTER both chatItem creation and phase transition
         if event.event == "PermissionRequest", let toolUseId = event.toolUseId {
             Self.logger.debug("Setting tool \(toolUseId.prefix(12), privacy: .public) status to waitingForApproval")
             updateToolStatus(in: &session, toolId: toolUseId, status: .waitingForApproval)
         }
-
-        processToolTracking(event: event, session: &session)
-        processSubagentTracking(event: event, session: &session)
 
         if event.event == "Stop" {
             session.subagentState = SubagentState()
         }
 
         sessions[sessionId] = session
-        publishState()
+        // NOTE: Do NOT call publishState() here — process() calls it once at the end
+        // to avoid UI seeing intermediate states during a single event processing cycle.
 
         if event.shouldSyncFile {
             scheduleFileSync(sessionId: sessionId, cwd: event.cwd)
@@ -626,9 +632,9 @@ actor SessionStore {
 
         sessions[payload.sessionId] = session
 
-        await emitToolCompletionEvents(
+        // Apply tool completions inline (no recursive process() call)
+        applyToolCompletions(
             sessionId: payload.sessionId,
-            session: session,
             completedToolIds: payload.completedToolIds,
             toolResults: payload.toolResults,
             structuredResults: payload.structuredResults
@@ -684,18 +690,23 @@ actor SessionStore {
         }
     }
 
-    /// Emit toolCompleted events for tools that have results in JSONL but aren't marked complete yet
-    private func emitToolCompletionEvents(
+    /// Apply tool completion results inline (without re-entering process()).
+    /// This avoids the recursive process() call that caused multiple publishState()
+    /// invocations and intermediate-state visibility during a single file update cycle.
+    private func applyToolCompletions(
         sessionId: String,
-        session: SessionState,
         completedToolIds: Set<String>,
         toolResults: [String: ConversationParser.ToolResult],
         structuredResults: [String: ToolResultData]
-    ) async {
-        for item in session.chatItems {
-            guard case .toolCall(let tool) = item.type else { continue }
+    ) {
+        guard var session = sessions[sessionId] else { return }
+        var phaseNeedsUpdate = false
 
-            // Only emit for tools that are running or waiting but have results in JSONL
+        for i in 0..<session.chatItems.count {
+            let item = session.chatItems[i]
+            guard case .toolCall(var tool) = item.type else { continue }
+
+            // Only process tools that are running or waiting but have results in JSONL
             guard tool.status == .running || tool.status == .waitingForApproval else { continue }
             guard completedToolIds.contains(item.id) else { continue }
 
@@ -704,9 +715,38 @@ actor SessionStore {
                 structuredResult: structuredResults[item.id]
             )
 
-            // Process the completion event (this will update state and phase consistently)
-            await process(.toolCompleted(sessionId: sessionId, toolUseId: item.id, result: result))
+            tool.status = result.status
+            tool.result = result.result
+            tool.structuredResult = result.structuredResult
+            session.chatItems[i] = ChatHistoryItem(
+                id: item.id,
+                type: .toolCall(tool),
+                timestamp: item.timestamp
+            )
+            Self.logger.debug("Tool \(item.id.prefix(12), privacy: .public) completed inline with status: \(String(describing: result.status), privacy: .public)")
+
+            // Check if this completion affects the current phase
+            if case .waitingForApproval(let ctx) = session.phase, ctx.toolUseId == item.id {
+                phaseNeedsUpdate = true
+            }
         }
+
+        // Update phase if the completed tool was the one blocking
+        if phaseNeedsUpdate {
+            if let nextPending = findNextPendingTool(in: session, excluding: "") {
+                let newPhase = SessionPhase.waitingForApproval(PermissionContext(
+                    toolUseId: nextPending.id,
+                    toolName: nextPending.name,
+                    toolInput: nil,
+                    receivedAt: nextPending.timestamp
+                ))
+                session.phase = newPhase
+            } else if session.phase.canTransition(to: .processing) {
+                session.phase = .processing
+            }
+        }
+
+        sessions[sessionId] = session
     }
 
     /// Create chat item (checks existingIds to avoid duplicates)


### PR DESCRIPTION
## Summary

Fixes 3 P0 bugs that affect core session monitoring reliability:

- **Issue #22 — Sleep/wake window bounce**: `ScreenObserver` now debounces screen-change notifications (500ms) and suppresses events for 2s after system wake, preventing the notch window from bouncing open/closed during sleep/wake cycles.
- **Issue #11 — Session detection failure**: Python hook adds 3-retry socket connection with pre-check, `shutdown(SHUT_WR)` for clean EOF, and stderr diagnostics. Swift `HookSocketServer` reads until EOF or valid JSON (2s timeout). `HookInstaller` logs errors, verifies all 10 required hook events post-install, and replaces stale entries on re-install.
- **Issue #29 — Session state inconsistency**: `SessionStore.processHookEvent` reorders operations (tool tracking → phase transition → permission status). Removes duplicate `publishState()` call. Replaces recursive `process(.toolCompleted)` with inline `applyToolCompletions()` to prevent UI from seeing intermediate states.

## Files Changed

| File | Change |
|------|--------|
| `App/ScreenObserver.swift` | Debounce + sleep/wake observers |
| `Resources/claude-island-state.py` | Socket retry + diagnostics + SHUT_WR |
| `Services/Hooks/HookInstaller.swift` | Error logging + post-install verification |
| `Services/Hooks/HookSocketServer.swift` | Improved data read reliability |
| `Services/State/SessionStore.swift` | Operation reordering + inline tool completions |

## Test plan

- [ ] Launch app, verify hook installation logs show all 10 events registered
- [ ] Put Mac to sleep and wake — notch should NOT bounce open/closed
- [ ] Start a new Claude Code session — should appear in the island within seconds
- [ ] Run a tool that requires permission — state should show `waitingForApproval` consistently
- [ ] Approve/deny permission — state should transition cleanly to `processing`/`idle`
- [ ] Kill ClaudeIsland.app, start a Claude session, then relaunch app — session should reconnect
- [ ] Check Console.app for `[claude-island-hook]` stderr logs during normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)