### PR TITLE
Add configurable Claude config directory name

### DIFF
--- a/ClaudeIsland/App/AppDelegate.swift
+++ b/ClaudeIsland/App/AppDelegate.swift
@@ -126,8 +126,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func fetchAndRegisterClaudeVersion() {
-        let claudeProjectsDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/projects")
+        let claudeProjectsDir = ClaudePaths.projectsDir
 
         guard let projectDirs = try? FileManager.default.contentsOfDirectory(
             at: claudeProjectsDir,

--- a/ClaudeIsland/Core/ClaudePaths.swift
+++ b/ClaudeIsland/Core/ClaudePaths.swift
@@ -1,0 +1,40 @@
+//
+//  ClaudePaths.swift
+//  ClaudeIsland
+//
+//  Single source of truth for all Claude config directory paths.
+//  The directory name is user-configurable via AppSettings.claudeDirectoryName
+//  (defaults to ".claude" for standard Claude Code installations).
+//
+
+import Foundation
+
+enum ClaudePaths {
+
+    /// Root Claude config directory, e.g. ~/.claude or ~/.claude-internal
+    static var claudeDir: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(AppSettings.claudeDirectoryName)
+    }
+
+    /// Hooks subdirectory, e.g. ~/.claude/hooks
+    static var hooksDir: URL {
+        claudeDir.appendingPathComponent("hooks")
+    }
+
+    /// settings.json path, e.g. ~/.claude/settings.json
+    static var settingsFile: URL {
+        claudeDir.appendingPathComponent("settings.json")
+    }
+
+    /// Projects subdirectory, e.g. ~/.claude/projects
+    static var projectsDir: URL {
+        claudeDir.appendingPathComponent("projects")
+    }
+
+    /// The shell-expanded path written into settings.json hook commands.
+    /// Uses "~/" prefix so Claude Code resolves it relative to the user's home.
+    static var hookScriptShellPath: String {
+        "~/\(AppSettings.claudeDirectoryName)/hooks/claude-island-state.py"
+    }
+}

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -74,7 +74,7 @@ class NotchViewModel: ObservableObject {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
+                height: 480 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
             )
         case .instances:
             return CGSize(

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -74,7 +74,7 @@ class NotchViewModel: ObservableObject {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 480 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
+                height: 540 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
             )
         case .instances:
             return CGSize(

--- a/ClaudeIsland/Core/Settings.swift
+++ b/ClaudeIsland/Core/Settings.swift
@@ -38,6 +38,7 @@ enum AppSettings {
 
     private enum Keys {
         static let notificationSound = "notificationSound"
+        static let claudeDirectoryName = "claudeDirectoryName"
     }
 
     // MARK: - Notification Sound
@@ -53,6 +54,21 @@ enum AppSettings {
         }
         set {
             defaults.set(newValue.rawValue, forKey: Keys.notificationSound)
+        }
+    }
+
+    // MARK: - Claude Directory
+
+    /// The name of the Claude config directory under the user's home folder.
+    /// Defaults to ".claude" (standard Claude Code installation).
+    /// Change to ".claude-internal" (or similar) for enterprise/custom distributions.
+    static var claudeDirectoryName: String {
+        get {
+            let value = defaults.string(forKey: Keys.claudeDirectoryName) ?? ""
+            return value.isEmpty ? ".claude" : value
+        }
+        set {
+            defaults.set(newValue.trimmingCharacters(in: .whitespaces), forKey: Keys.claudeDirectoryName)
         }
     }
 }

--- a/ClaudeIsland/Services/Hooks/HookInstaller.swift
+++ b/ClaudeIsland/Services/Hooks/HookInstaller.swift
@@ -11,11 +11,8 @@ struct HookInstaller {
 
     /// Install hook script and update settings.json on app launch
     static func installIfNeeded() {
-        let claudeDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude")
-        let hooksDir = claudeDir.appendingPathComponent("hooks")
+        let hooksDir = ClaudePaths.hooksDir
         let pythonScript = hooksDir.appendingPathComponent("claude-island-state.py")
-        let settings = claudeDir.appendingPathComponent("settings.json")
 
         try? FileManager.default.createDirectory(
             at: hooksDir,
@@ -31,7 +28,7 @@ struct HookInstaller {
             )
         }
 
-        updateSettings(at: settings)
+        updateSettings(at: ClaudePaths.settingsFile)
     }
 
     private static func updateSettings(at settingsURL: URL) {
@@ -42,7 +39,7 @@ struct HookInstaller {
         }
 
         let python = detectPython()
-        let command = "\(python) ~/.claude/hooks/claude-island-state.py"
+        let command = "\(python) \(ClaudePaths.hookScriptShellPath)"
         let hookEntry: [[String: Any]] = [["type": "command", "command": command]]
         let hookEntryWithTimeout: [[String: Any]] = [["type": "command", "command": command, "timeout": 86400]]
         let withMatcher: [[String: Any]] = [["matcher": "*", "hooks": hookEntry]]
@@ -100,9 +97,7 @@ struct HookInstaller {
 
     /// Check if hooks are currently installed
     static func isInstalled() -> Bool {
-        let claudeDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude")
-        let settings = claudeDir.appendingPathComponent("settings.json")
+        let settings = ClaudePaths.settingsFile
 
         guard let data = try? Data(contentsOf: settings),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -129,11 +124,9 @@ struct HookInstaller {
 
     /// Uninstall hooks from settings.json and remove script
     static func uninstall() {
-        let claudeDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude")
-        let hooksDir = claudeDir.appendingPathComponent("hooks")
+        let hooksDir = ClaudePaths.hooksDir
         let pythonScript = hooksDir.appendingPathComponent("claude-island-state.py")
-        let settings = claudeDir.appendingPathComponent("settings.json")
+        let settings = ClaudePaths.settingsFile
 
         try? FileManager.default.removeItem(at: pythonScript)
 

--- a/ClaudeIsland/Services/Session/AgentFileWatcher.swift
+++ b/ClaudeIsland/Services/Session/AgentFileWatcher.swift
@@ -42,7 +42,7 @@ class AgentFileWatcher {
 
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-")
                             .replacingOccurrences(of: ".", with: "-")
-        self.filePath = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/agent-" + agentId + ".jsonl"
+        self.filePath = ClaudePaths.projectsDir.path + "/" + projectDir + "/agent-" + agentId + ".jsonl"
     }
 
     /// Start watching the agent file

--- a/ClaudeIsland/Services/Session/ConversationParser.swift
+++ b/ClaudeIsland/Services/Session/ConversationParser.swift
@@ -73,7 +73,7 @@ actor ConversationParser {
     /// Uses caching based on file modification time
     func parse(sessionId: String, cwd: String) -> ConversationInfo {
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ".", with: "-")
-        let sessionFile = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/" + sessionId + ".jsonl"
+        let sessionFile = ClaudePaths.projectsDir.path + "/" + projectDir + "/" + sessionId + ".jsonl"
 
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: sessionFile),
@@ -460,7 +460,7 @@ actor ConversationParser {
     /// Build session file path
     private static func sessionFilePath(sessionId: String, cwd: String) -> String {
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ".", with: "-")
-        return NSHomeDirectory() + "/.claude/projects/" + projectDir + "/" + sessionId + ".jsonl"
+        return ClaudePaths.projectsDir.path + "/" + projectDir + "/" + sessionId + ".jsonl"
     }
 
     private func parseMessageLine(_ json: [String: Any], seenToolIds: inout Set<String>, toolIdToName: inout [String: String]) -> ChatMessage? {
@@ -888,7 +888,7 @@ actor ConversationParser {
         guard !agentId.isEmpty else { return [] }
 
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ".", with: "-")
-        let agentFile = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/agent-" + agentId + ".jsonl"
+        let agentFile = ClaudePaths.projectsDir.path + "/" + projectDir + "/agent-" + agentId + ".jsonl"
 
         guard FileManager.default.fileExists(atPath: agentFile),
               let content = try? String(contentsOfFile: agentFile, encoding: .utf8) else {
@@ -980,7 +980,7 @@ extension ConversationParser {
         guard !agentId.isEmpty else { return [] }
 
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-").replacingOccurrences(of: ".", with: "-")
-        let agentFile = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/agent-" + agentId + ".jsonl"
+        let agentFile = ClaudePaths.projectsDir.path + "/" + projectDir + "/agent-" + agentId + ".jsonl"
 
         guard FileManager.default.fileExists(atPath: agentFile),
               let content = try? String(contentsOfFile: agentFile, encoding: .utf8) else {

--- a/ClaudeIsland/Services/Session/JSONLInterruptWatcher.swift
+++ b/ClaudeIsland/Services/Session/JSONLInterruptWatcher.swift
@@ -41,7 +41,7 @@ class JSONLInterruptWatcher {
         self.sessionId = sessionId
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-")
                             .replacingOccurrences(of: ".", with: "-")
-        self.filePath = NSHomeDirectory() + "/.claude/projects/" + projectDir + "/" + sessionId + ".jsonl"
+        self.filePath = ClaudePaths.projectsDir.path + "/" + projectDir + "/" + sessionId + ".jsonl"
     }
 
     /// Start watching the JSONL file for interrupts

--- a/ClaudeIsland/UI/Components/ClaudeDirPickerRow.swift
+++ b/ClaudeIsland/UI/Components/ClaudeDirPickerRow.swift
@@ -1,0 +1,88 @@
+//
+//  ClaudeDirPickerRow.swift
+//  ClaudeIsland
+//
+//  Lets users configure the Claude config directory name (e.g. ".claude-internal"
+//  for enterprise/custom Claude distributions). Defaults to ".claude".
+//
+
+import SwiftUI
+
+struct ClaudeDirPickerRow: View {
+    @State private var dirName: String = AppSettings.claudeDirectoryName
+    @State private var isEditing: Bool = false
+    @State private var isHovered: Bool = false
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Button {
+            isEditing = true
+            isFocused = true
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "folder")
+                    .font(.system(size: 12))
+                    .foregroundColor(textColor)
+                    .frame(width: 16)
+
+                Text("Claude Directory")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(textColor)
+
+                Spacer()
+
+                if isEditing {
+                    TextField("", text: $dirName)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.9))
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: 140)
+                        .focused($isFocused)
+                        .onSubmit { commitEdit() }
+                        .onExitCommand { cancelEdit() }
+                } else {
+                    Text(dirName)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.4))
+                        .lineLimit(1)
+
+                    Image(systemName: "pencil")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.3))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .onAppear { dirName = AppSettings.claudeDirectoryName }
+    }
+
+    private var textColor: Color {
+        .white.opacity(isHovered ? 1.0 : 0.7)
+    }
+
+    private func commitEdit() {
+        let trimmed = dirName.trimmingCharacters(in: .whitespaces)
+        // Fall back to default if user cleared the field
+        dirName = trimmed.isEmpty ? ".claude" : trimmed
+        AppSettings.claudeDirectoryName = dirName
+        // Re-install hooks so settings.json reflects the new path
+        HookInstaller.installIfNeeded()
+        isEditing = false
+        isFocused = false
+    }
+
+    private func cancelEdit() {
+        // Restore to the last saved value
+        dirName = AppSettings.claudeDirectoryName
+        isEditing = false
+        isFocused = false
+    }
+}

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -38,6 +38,7 @@ struct NotchMenuView: View {
             // Appearance settings
             ScreenPickerRow(screenSelector: screenSelector)
             SoundPickerRow(soundSelector: soundSelector)
+            ClaudeDirPickerRow()
 
             Divider()
                 .background(Color.white.opacity(0.08))


### PR DESCRIPTION
Hard-coded ".claude" paths break for users of enterprise/custom Claude distributions that use a different directory (e.g. ".claude-internal").

- Introduce ClaudePaths.swift as a single source of truth for all ~/.claude/* paths, backed by AppSettings.claudeDirectoryName
- Add claudeDirectoryName setting to AppSettings (UserDefaults, defaults to ".claude" — zero impact for existing users)
- Replace all 12 hard-coded ".claude" path references across HookInstaller, AppDelegate, ConversationParser, JSONLInterruptWatcher and AgentFileWatcher with ClaudePaths.*
- Add ClaudeDirPickerRow UI component (inline editable text field, consistent with SoundPickerRow style) to the settings menu; saving re-installs hooks so settings.json reflects the new path