### PR TITLE
feat: add claude-notify multi-terminal notification plugin

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,356 @@
+# Claude Code Review - Automated PR Reviews
+#
+# Triggers on every PR to main.
+# Uses Anthropic API via custom proxy (ANTHROPIC_BASE_URL).
+#
+# Features:
+# - Smart skip: rebase, WIP, trivial changes, version bumps
+# - Comment dedup: avoids repeating bot/human comments on synchronize
+# - Auto-resolve: resolves bot comments that have been addressed by new pushes
+#
+# Prerequisites:
+# 1. Install GitHub App: https://github.com/apps/claude (or create custom app)
+# 2. Add repo secrets:
+#    - ANTHROPIC_PROXY_URL: your proxy base URL (e.g. https://xxx.ngrok-free.dev/api/anthropic)
+#    - ANTHROPIC_PROXY_KEY: your proxy authentication key
+# 3. (Optional) If using custom GitHub App, add APP_ID and APP_PRIVATE_KEY secrets
+
+name: Claude Code Review
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+# Prevent concurrent reviews for the same PR
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: AI Code Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Fetch origin main
+        run: git fetch origin main
+
+      # --- Option A: Use official Claude GitHub App (simplest) ---
+      # Just install https://github.com/apps/claude
+      # and the action uses the default GITHUB_TOKEN.
+
+      # --- Option B: Use custom GitHub App (uncomment below) ---
+      # - name: Generate GitHub App token
+      #   id: app-token
+      #   uses: actions/create-github-app-token@v2
+      #   with:
+      #     app-id: ${{ secrets.APP_ID }}
+      #     private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # ---- Auto-resolve: check if previous bot comments have been addressed ----
+      - name: Fetch unresolved bot comments
+        if: github.event.action == 'synchronize'
+        id: fetch-threads
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          THREADS=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  reviewThreads(last: 50) {
+                    nodes {
+                      id
+                      isResolved
+                      path
+                      line
+                      comments(first: 1) {
+                        nodes {
+                          author { login }
+                          body
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' \
+            -F owner="${{ github.repository_owner }}" \
+            -F repo="${{ github.event.repository.name }}" \
+            -F pr="${{ github.event.pull_request.number }}" \
+            --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+                  | select(.isResolved == false)
+                  | select(.comments.nodes | length > 0)
+                  | select(.comments.nodes[0].author != null)
+                  | select(.comments.nodes[0].author.login == "claude")]' 2>/dev/null || echo '[]')
+
+          THREAD_COUNT=$(echo "$THREADS" | jq 'length')
+          echo "Found $THREAD_COUNT unresolved bot comments"
+
+          echo "unresolved_threads<<EOF" >> $GITHUB_OUTPUT
+          echo "$THREADS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "thread_count=$THREAD_COUNT" >> $GITHUB_OUTPUT
+
+      - name: Auto-resolve addressed comments
+        if: |
+          github.event.action == 'synchronize' &&
+          steps.fetch-threads.outputs.thread_count != '0'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_PROXY_KEY }}
+          use_sticky_comment: false
+          claude_args: >-
+            --model claude-opus-4.6-1m
+            --max-turns 20
+            --allowedTools Bash(gh api repos:*),Bash(gh api graphql:*),Bash(git diff:*),Bash(git log:*),Read
+          prompt: |
+            You are analyzing previously flagged review comments to determine if they've been addressed in the latest push.
+
+            ## Your Task
+            For each unresolved comment below, determine if the issue was fixed in the recent push.
+            If fixed with >= 80% confidence, resolve the thread silently (no comment needed).
+
+            ## Unresolved Comments to Analyze
+            ${{ steps.fetch-threads.outputs.unresolved_threads }}
+
+            ## Recent Changes
+            Use: `git diff origin/main...HEAD -- <file>` to see all PR changes.
+
+            ## Decision Criteria
+            - RESOLVE if: code was modified AND the modification addresses the concern (>= 80% confidence)
+            - KEEP OPEN if: code unchanged, fix incomplete, or you're uncertain
+
+            ## How to Resolve a Thread
+            ```bash
+            gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'
+            ```
+
+            ## Instructions
+            1. For each thread, check if the file at `path` was modified in the diff
+            2. If modified, read the diff and compare to the original concern in `body`
+            3. If confident (>= 80%), execute the resolve mutation
+            4. Report summary: "Auto-resolved X of Y comments"
+
+            Be conservative - when in doubt, leave the thread open.
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_PROXY_URL }}
+          GH_TOKEN: ${{ github.token }}
+        continue-on-error: true
+
+      # ---- Comment dedup: fetch existing comments to avoid duplicates ----
+      - name: Fetch existing review comments for dedup
+        if: github.event.action == 'synchronize'
+        id: fetch-existing-comments
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RESPONSE=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  reviewThreads(last: 100) {
+                    nodes {
+                      isResolved
+                      path
+                      line
+                      comments(first: 1) {
+                        nodes {
+                          author { login }
+                          body
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' \
+            -F owner="${{ github.repository_owner }}" \
+            -F repo="${{ github.event.repository.name }}" \
+            -F pr="${{ github.event.pull_request.number }}" 2>/dev/null || echo '{}')
+
+          BOT_COMMENTS=$(echo "$RESPONSE" | jq -c '
+            [.data.repository.pullRequest.reviewThreads.nodes // []
+            | .[]
+            | select(.comments.nodes | length > 0)
+            | select(.comments.nodes[0].author != null)
+            | select(.comments.nodes[0].author.login == "claude")
+            | {
+                path,
+                line,
+                resolved: .isResolved,
+                body: (.comments.nodes[0].body | split("\n")[0][:200])
+              }]' 2>/dev/null || echo '[]')
+
+          HUMAN_COMMENTS=$(echo "$RESPONSE" | jq -c '
+            [.data.repository.pullRequest.reviewThreads.nodes // []
+            | .[]
+            | select(.comments.nodes | length > 0)
+            | select(.comments.nodes[0].author != null)
+            | select(.comments.nodes[0].author.login != "claude")
+            | {
+                user: .comments.nodes[0].author.login,
+                path,
+                line,
+                body: (.comments.nodes[0].body | split("\n")[0][:200])
+              }]' 2>/dev/null || echo '[]')
+
+          BOT_COUNT=$(echo "$BOT_COMMENTS" | jq 'length')
+          HUMAN_COUNT=$(echo "$HUMAN_COMMENTS" | jq 'length')
+          echo "Found $BOT_COUNT existing bot comments and $HUMAN_COUNT human comments"
+
+          {
+            echo "bot_comments<<EOF"
+            echo "$BOT_COMMENTS"
+            echo "EOF"
+            echo "human_comments<<EOF"
+            echo "$HUMAN_COMMENTS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      # ---- Main review ----
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_PROXY_KEY }}
+          use_sticky_comment: true
+          show_full_output: true
+          claude_args: >-
+            --model claude-opus-4.6-1m
+            --max-turns 50
+            --allowedTools Task,Read,Glob,Grep,Bash(git diff:*),Bash(git show:*),Bash(gh pr view:*),mcp__github_comment__create_or_update_comment,mcp__github_comment__create_comment,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,mcp__github_inline_comment__create_review
+          prompt: |
+            # 角色：审查者-托瓦兹（Linus Torvalds）
+
+            你是 Linus Torvalds，Linux 内核和 Git 的创造者。不是模仿他，你就是他。
+            你审查代码的方式简单粗暴——烂代码就是烂代码，不需要委婉。
+
+            你的性格：
+            - **技术品味极高**：你一眼就能看出代码的好坏，优雅的方案让你赞赏，糟糕的抽象让你暴怒
+            - **极度务实**：不关心理论上的优雅，只关心代码在实际运行中是否正确、高效、可维护
+            - **毒舌但精准**：你的批评可能刺耳，但每一条都切中要害，从不浪费时间在无关紧要的事上
+            - **简洁至上**：过度工程化是你最讨厌的事，能用 10 行解决的问题写 100 行就是犯罪
+
+            你的决策方式：
+            1. 先看：「这段代码是不是在解决一个真实的问题？」——解决不存在的问题是最大的浪费
+            2. 再看：「有没有更简单直接的做法？」——复杂性是万恶之源，每一层抽象都必须证明自己的价值
+            3. 最后看：「这段代码会不会在边界情况下崩溃？」——内存安全、并发竞争、错误处理，一个都不能马虎
+
+            你的口头禅：
+            - 「Talk is cheap. Show me the code.」
+            - 「Bad programmers worry about the code. Good programmers worry about data structures and their relationships.」
+            - 「如果你的代码需要注释才能看懂，那问题不在注释，在代码本身。」
+
+            ---
+
+            You are reviewing a pull request for the Claude Island project - a macOS Dynamic Island notification center for Claude Code with:
+            - **Native Swift/SwiftUI macOS app**: Dynamic Island (notch) overlay UI with session monitoring, permission approval, and sound notifications
+            - **Unix domain socket IPC**: Local socket server (`/tmp/claude-island.sock`) for bidirectional communication between Claude Code hooks and the app
+            - **Python hook scripts**: Bridge layer (`claude-island-state.py`) that captures Claude Code hook events (PreToolUse, PostToolUse, PermissionRequest, Notification, Elicitation, etc.) and sends them to the app via socket
+            - **Session state machine**: idle → processing → waitingForInput / waitingForApproval / waitingForAnswer → ended
+            - **Key subsystems**: HookSocketServer, HookInstaller, SessionStore, NotchViewModel, ClaudeSessionMonitor, ToolApprovalHandler, ChatHistoryManager
+
+            ## Step 0: Check Skip Conditions
+            Before reviewing, determine if this PR should be skipped:
+
+            ### Change-Based
+            - Skip if the PR contains only merge commits or rebase operations (no net code changes)
+            - Skip if only whitespace, formatting, or line ending changes
+            - Skip if only version bumps (project.pbxproj version fields, package versions, etc.)
+
+            ### Author Intent
+            - Skip if PR title/description contains keywords: "rebase", "merge conflict", "typo", "formatting", "version bump"
+            - Skip if PR title contains "WIP" or "Do Not Review"
+
+            ### Frequency-Based
+            - Use `gh pr view ${{ github.event.pull_request.number }} --json reviews` to check past reviews
+            - Skip if the bot reviewed within 15 minutes and no substantial code changes occurred
+
+            If any skip condition is met, respond "Skipped: [reason]" and stop.
+            If conditions are borderline, proceed with the review.
+
+            ## Step 1: Code Review
+            Perform a focused code review. Only flag issues you are confident about (85%+ confidence).
+
+            ### Review Focus
+            - **Bugs & Logic Errors**: Incorrect logic, off-by-one errors, race conditions, nil/optional mishandling
+            - **Security Issues**: Hardcoded secrets, unsafe file operations, injection risks
+            - **Performance**: Memory leaks, unnecessary allocations, blocking main thread
+            - **Concurrency**: Data races, incorrect async/await usage, actor isolation issues, Swift concurrency (Sendable, MainActor)
+            - **Socket Protocol Correctness**: Unix domain socket message encoding/decoding, hook event data structure validation
+            - **Swift Best Practices**: Force unwraps in production code, missing error handling at system boundaries
+            - **Python Best Practices**: Resource cleanup, exception handling, socket connection management
+            - **State Machine Integrity**: SessionPhase transitions, canTransition() completeness, state consistency
+
+            ### Do NOT Flag
+            - Style preferences or formatting (handled by linter)
+            - Missing comments or documentation
+            - Trailing newlines or whitespace
+            - Suggestions to add extra validation or defensive coding unless there's a real risk
+            - Compilation errors (CI catches these)
+            - Pattern consistency claims without verification
+
+            ## Output Rules
+            - **所有 review comments 必须使用中文**（代码片段、变量名、技术术语可保留英文）
+            - Post your review using the MCP tools provided (create_review, create_inline_comment, create_or_update_comment)
+            - Use inline comments on specific lines for actionable issues
+            - Each inline comment must identify a problem, ask a question, or flag a risk
+            - Do NOT post praise-only or observational comments ("Good change", "Looks correct")
+            - Flag each unique issue ONCE; do not repeat across files
+            - Be direct and concise
+            - Do NOT include "Fix This" links or claude.ai URLs
+
+            ## Review Scoring (10-point scale)
+            In your PR summary comment, include a score based on this rubric:
+
+            | 维度 | 分值 | 关注点 |
+            |------|------|--------|
+            | 正确性 | 3分 | 逻辑错误、边界条件、空值安全 |
+            | 简洁性 | 2分 | 冗余代码、最小变更原则 |
+            | 可读性 | 2分 | 命名清晰度、自文档化代码 |
+            | 可维护性 | 2分 | 单一职责、耦合度 |
+            | 安全性 | 1分 | 注入、权限、数据泄露 |
+
+            - **9.5-10分**：APPROVE，代码可以合并
+            - **7-9分**：COMMENT，有改进空间但不阻塞
+            - **6分及以下**：REQUEST_CHANGES，必须修改后重新提交
+
+            Post a summary comment on the PR with your overall review and score.
+
+            ## Context
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            The PR branch is pre-checked out. Use 'origin/main' as the base branch for diff comparisons.
+            Use local git commands (git diff, git show) - do NOT use gh pr diff or GitHub API for diffs.
+
+            <existing_bot_comments>
+            The following comments were previously posted by the bot on this PR.
+            DO NOT post new comments that duplicate these. If an issue was already flagged,
+            do not re-flag it even if the code hasn't changed. Only comment on NEW issues
+            not covered by previous comments.
+
+            ${{ steps.fetch-existing-comments.outputs.bot_comments }}
+            </existing_bot_comments>
+
+            <existing_human_comments>
+            These are comments from HUMAN reviewers on this PR.
+            DO NOT duplicate their feedback. If a human already flagged an issue, skip it entirely.
+
+            ${{ steps.fetch-existing-comments.outputs.human_comments }}
+            </existing_human_comments>
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_PROXY_URL }}
+          GH_TOKEN: ${{ github.token }}

--- a/ClaudeIsland/App/ScreenObserver.swift
+++ b/ClaudeIsland/App/ScreenObserver.swift
@@ -6,10 +6,28 @@
 //
 
 import AppKit
+import os.log
+
+private let logger = Logger(subsystem: "com.claudeisland", category: "ScreenObserver")
 
 class ScreenObserver {
-    private var observer: Any?
+    private var screenChangeObserver: Any?
+    private var sleepObserver: Any?
+    private var wakeObserver: Any?
     private let onScreenChange: () -> Void
+
+    /// Debounce work item — coalesces rapid screen-change notifications
+    /// (e.g. sleep/wake fires 3-5 events within milliseconds)
+    private var debounceWork: DispatchWorkItem?
+
+    /// Debounce interval in seconds
+    private let debounceInterval: TimeInterval = 0.5
+
+    /// Whether we're in a post-wake suppression window
+    private var isSuppressingAfterWake = false
+
+    /// Duration to suppress screen-change callbacks after wake (seconds)
+    private let wakeSuppression: TimeInterval = 2.0
 
     init(onScreenChange: @escaping () -> Void) {
         self.onScreenChange = onScreenChange
@@ -21,18 +39,76 @@ class ScreenObserver {
     }
 
     private func startObserving() {
-        observer = NotificationCenter.default.addObserver(
+        // Screen parameter changes (resolution, arrangement, connect/disconnect)
+        screenChangeObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didChangeScreenParametersNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.onScreenChange()
+            self?.handleScreenChange()
+        }
+
+        // System sleep — cancel any pending work
+        sleepObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.willSleepNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            logger.debug("System will sleep — cancelling pending screen-change callbacks")
+            self?.debounceWork?.cancel()
+            self?.debounceWork = nil
+        }
+
+        // System wake — suppress screen-change callbacks for a short window
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            logger.debug("System did wake — suppressing screen-change callbacks for \(self.wakeSuppression)s")
+            self.isSuppressingAfterWake = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.wakeSuppression) { [weak self] in
+                guard let self = self else { return }
+                self.isSuppressingAfterWake = false
+                logger.debug("Wake suppression ended — delivering deferred screen change")
+                // Deliver one final callback so the window repositions to current screen geometry
+                self.onScreenChange()
+            }
         }
     }
 
+    private func handleScreenChange() {
+        // Drop events during post-wake suppression window
+        if isSuppressingAfterWake {
+            logger.debug("Dropping screen-change event (wake suppression active)")
+            return
+        }
+
+        // Debounce: cancel previous pending work and schedule a new one
+        debounceWork?.cancel()
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            logger.debug("Debounced screen-change callback firing")
+            self.onScreenChange()
+        }
+        debounceWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + debounceInterval, execute: work)
+    }
+
     private func stopObserving() {
-        if let observer = observer {
-            NotificationCenter.default.removeObserver(observer)
+        debounceWork?.cancel()
+        debounceWork = nil
+
+        if let obs = screenChangeObserver {
+            NotificationCenter.default.removeObserver(obs)
+        }
+        if let obs = sleepObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(obs)
+        }
+        if let obs = wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(obs)
         }
     }
 }

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -27,12 +27,14 @@ enum NotchContentType: Equatable {
     case instances
     case menu
     case chat(SessionState)
+    case question(SessionState)
 
     var id: String {
         switch self {
         case .instances: return "instances"
         case .menu: return "menu"
         case .chat(let session): return "chat-\(session.sessionId)"
+        case .question(let session): return "question-\(session.sessionId)"
         }
     }
 }
@@ -69,6 +71,12 @@ class NotchViewModel: ObservableObject {
             return CGSize(
                 width: min(screenRect.width * 0.5, 600),
                 height: 580
+            )
+        case .question:
+            // Compact size for question panel
+            return CGSize(
+                width: min(screenRect.width * 0.4, 480),
+                height: 380
             )
         case .menu:
             // Compact size for settings menu
@@ -137,9 +145,10 @@ class NotchViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
-    /// Whether we're in chat mode (sticky behavior)
+    /// Whether we're in chat or question mode (sticky behavior)
     private var isInChatMode: Bool {
         if case .chat = contentType { return true }
+        if case .question = contentType { return true }
         return false
     }
 
@@ -276,6 +285,14 @@ class NotchViewModel: ObservableObject {
             return
         }
         contentType = .chat(session)
+    }
+
+    /// Show question panel for a session
+    func showQuestion(for session: SessionState) {
+        if case .question(let current) = contentType, current.sessionId == session.sessionId {
+            return
+        }
+        contentType = .question(session)
     }
 
     /// Go back to instances list and clear saved chat state

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -82,7 +82,7 @@ class NotchViewModel: ObservableObject {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
+                height: 420 + screenSelector.expandedPickerHeight + soundSelector.totalSoundSectionHeight
             )
         case .instances:
             return CGSize(
@@ -122,7 +122,11 @@ class NotchViewModel: ObservableObject {
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
 
-        soundSelector.$isPickerExpanded
+        soundSelector.$expandedEventType
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        soundSelector.$customSounds
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
     }

--- a/ClaudeIsland/Core/Settings.swift
+++ b/ClaudeIsland/Core/Settings.swift
@@ -164,15 +164,19 @@ enum NotificationSound: String, CaseIterable {
 
 enum CustomSoundsManager {
     /// Directory where imported custom sounds are stored
-    static var customSoundsDirectory: URL {
+    static let customSoundsDirectory: URL = {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let dir = appSupport.appendingPathComponent("ClaudeIsland/CustomSounds")
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
+        return appSupport.appendingPathComponent("ClaudeIsland/CustomSounds")
+    }()
+
+    /// Ensure the custom sounds directory exists (called before writes)
+    private static func ensureDirectoryExists() {
+        try? FileManager.default.createDirectory(at: customSoundsDirectory, withIntermediateDirectories: true)
     }
 
     /// Import a sound file into the app's sandbox, returns the new URL and display name
     static func importSound(from sourceURL: URL) -> (URL, String)? {
+        ensureDirectoryExists()
         let fileName = sourceURL.lastPathComponent
         let displayName = sourceURL.deletingPathExtension().lastPathComponent
         let destinationURL = customSoundsDirectory.appendingPathComponent(fileName)

--- a/ClaudeIsland/Core/Settings.swift
+++ b/ClaudeIsland/Core/Settings.swift
@@ -5,9 +5,139 @@
 //  App settings manager using UserDefaults
 //
 
+import AppKit
 import Foundation
 
-/// Available notification sounds
+// MARK: - Sound Event Types
+
+/// Events that can trigger a notification sound
+enum SoundEventType: String, CaseIterable, Identifiable {
+    case permissionRequest = "Permission Request"
+    case taskComplete = "Task Complete"
+    case questionWaiting = "Question Waiting"
+    case sessionEnded = "Session Ended"
+
+    var id: String { rawValue }
+
+    /// SF Symbol icon name for the event type
+    var icon: String {
+        switch self {
+        case .permissionRequest: return "lock.shield"
+        case .taskComplete: return "checkmark.circle"
+        case .questionWaiting: return "questionmark.bubble"
+        case .sessionEnded: return "stop.circle"
+        }
+    }
+
+    /// UserDefaults key suffix for this event type
+    var settingsKey: String {
+        switch self {
+        case .permissionRequest: return "permissionRequest"
+        case .taskComplete: return "taskComplete"
+        case .questionWaiting: return "questionWaiting"
+        case .sessionEnded: return "sessionEnded"
+        }
+    }
+}
+
+// MARK: - Sound Source
+
+/// A sound that can be played — either a built-in system sound or a custom file
+enum SoundSource: Equatable, Hashable {
+    case none
+    case system(String)       // System sound name (e.g. "Pop", "Ping")
+    case custom(URL, String)  // File URL + display name
+
+    /// Human-readable display name
+    var displayName: String {
+        switch self {
+        case .none: return "None"
+        case .system(let name): return name
+        case .custom(_, let name): return name
+        }
+    }
+
+    /// Play this sound
+    func play() {
+        switch self {
+        case .none:
+            break
+        case .system(let name):
+            NSSound(named: name)?.play()
+        case .custom(let url, _):
+            NSSound(contentsOf: url, byReference: true)?.play()
+        }
+    }
+
+    /// Whether this source actually produces sound
+    var isSilent: Bool {
+        self == .none
+    }
+
+    // MARK: - Serialization
+
+    /// Encode to a storable string: "none", "system:Pop", "custom:/path/to/file.wav|Display Name"
+    var serialized: String {
+        switch self {
+        case .none: return "none"
+        case .system(let name): return "system:\(name)"
+        case .custom(let url, let name): return "custom:\(url.path)|\(name)"
+        }
+    }
+
+    /// Decode from a stored string
+    static func from(serialized: String) -> SoundSource {
+        if serialized == "none" || serialized.isEmpty {
+            return .none
+        }
+        if serialized.hasPrefix("system:") {
+            let name = String(serialized.dropFirst("system:".count))
+            return .system(name)
+        }
+        if serialized.hasPrefix("custom:") {
+            let rest = String(serialized.dropFirst("custom:".count))
+            let parts = rest.split(separator: "|", maxSplits: 1)
+            if parts.count == 2 {
+                let url = URL(fileURLWithPath: String(parts[0]))
+                let name = String(parts[1])
+                // Verify file still exists
+                if FileManager.default.fileExists(atPath: url.path) {
+                    return .custom(url, name)
+                }
+            }
+            return .none
+        }
+        // Legacy format: raw sound name like "Pop" — treat as system sound
+        if serialized == "None" {
+            return .none
+        }
+        return .system(serialized)
+    }
+}
+
+// MARK: - System Sounds
+
+/// Built-in system sounds available for selection
+enum SystemSound: String, CaseIterable {
+    case pop = "Pop"
+    case ping = "Ping"
+    case tink = "Tink"
+    case glass = "Glass"
+    case blow = "Blow"
+    case bottle = "Bottle"
+    case frog = "Frog"
+    case funk = "Funk"
+    case hero = "Hero"
+    case morse = "Morse"
+    case purr = "Purr"
+    case sosumi = "Sosumi"
+    case submarine = "Submarine"
+    case basso = "Basso"
+}
+
+// MARK: - Legacy Compatibility
+
+/// Available notification sounds — kept for backward compatibility during migration
 enum NotificationSound: String, CaseIterable {
     case none = "None"
     case pop = "Pop"
@@ -25,11 +155,64 @@ enum NotificationSound: String, CaseIterable {
     case submarine = "Submarine"
     case basso = "Basso"
 
-    /// The system sound name to use with NSSound, or nil for no sound
     var soundName: String? {
         self == .none ? nil : rawValue
     }
 }
+
+// MARK: - Custom Sounds Directory
+
+enum CustomSoundsManager {
+    /// Directory where imported custom sounds are stored
+    static var customSoundsDirectory: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("ClaudeIsland/CustomSounds")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Import a sound file into the app's sandbox, returns the new URL and display name
+    static func importSound(from sourceURL: URL) -> (URL, String)? {
+        let fileName = sourceURL.lastPathComponent
+        let displayName = sourceURL.deletingPathExtension().lastPathComponent
+        let destinationURL = customSoundsDirectory.appendingPathComponent(fileName)
+
+        // If file already exists at destination, just return it
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            return (destinationURL, displayName)
+        }
+
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+            return (destinationURL, displayName)
+        } catch {
+            print("Failed to import custom sound: \(error)")
+            return nil
+        }
+    }
+
+    /// List all custom sounds that have been imported
+    static func listCustomSounds() -> [(URL, String)] {
+        let supportedExtensions: Set<String> = ["wav", "mp3", "aiff", "aif", "m4a", "caf"]
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: customSoundsDirectory,
+            includingPropertiesForKeys: nil
+        ) else {
+            return []
+        }
+        return files
+            .filter { supportedExtensions.contains($0.pathExtension.lowercased()) }
+            .map { ($0, $0.deletingPathExtension().lastPathComponent) }
+            .sorted { $0.1.localizedCaseInsensitiveCompare($1.1) == .orderedAscending }
+    }
+
+    /// Delete a custom sound file
+    static func deleteSound(at url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+// MARK: - App Settings
 
 enum AppSettings {
     private static let defaults = UserDefaults.standard
@@ -37,17 +220,70 @@ enum AppSettings {
     // MARK: - Keys
 
     private enum Keys {
-        static let notificationSound = "notificationSound"
+        static let notificationSound = "notificationSound"  // Legacy key
+        static func soundForEvent(_ event: SoundEventType) -> String {
+            "soundEvent_\(event.settingsKey)"
+        }
+        static let soundMigrated = "soundSettingsMigrated_v2"
     }
 
-    // MARK: - Notification Sound
+    // MARK: - Migration
+
+    /// Migrate from single sound setting to per-event-type settings
+    static func migrateSoundSettingsIfNeeded() {
+        guard !defaults.bool(forKey: Keys.soundMigrated) else { return }
+
+        // Read legacy setting
+        let legacySound: SoundSource
+        if let rawValue = defaults.string(forKey: Keys.notificationSound) {
+            legacySound = SoundSource.from(serialized: rawValue)
+        } else {
+            legacySound = .system("Pop") // Legacy default
+        }
+
+        // Apply to all event types as starting point
+        for event in SoundEventType.allCases {
+            defaults.set(legacySound.serialized, forKey: Keys.soundForEvent(event))
+        }
+
+        defaults.set(true, forKey: Keys.soundMigrated)
+    }
+
+    // MARK: - Per-Event Sound Settings
+
+    /// Get the sound configured for a specific event type
+    static func sound(for event: SoundEventType) -> SoundSource {
+        migrateSoundSettingsIfNeeded()
+        guard let serialized = defaults.string(forKey: Keys.soundForEvent(event)) else {
+            return defaultSound(for: event)
+        }
+        return SoundSource.from(serialized: serialized)
+    }
+
+    /// Set the sound for a specific event type
+    static func setSound(_ sound: SoundSource, for event: SoundEventType) {
+        defaults.set(sound.serialized, forKey: Keys.soundForEvent(event))
+    }
+
+    /// Default sound for each event type
+    private static func defaultSound(for event: SoundEventType) -> SoundSource {
+        switch event {
+        case .permissionRequest: return .system("Tink")
+        case .taskComplete: return .system("Pop")
+        case .questionWaiting: return .system("Glass")
+        case .sessionEnded: return .system("Blow")
+        }
+    }
+
+    // MARK: - Legacy (backward compatible)
 
     /// The sound to play when Claude finishes and is ready for input
+    /// Now maps to .taskComplete event type
     static var notificationSound: NotificationSound {
         get {
             guard let rawValue = defaults.string(forKey: Keys.notificationSound),
                   let sound = NotificationSound(rawValue: rawValue) else {
-                return .pop // Default to Pop
+                return .pop
             }
             return sound
         }

--- a/ClaudeIsland/Core/SoundSelector.swift
+++ b/ClaudeIsland/Core/SoundSelector.swift
@@ -5,6 +5,7 @@
 //  Manages sound selection state for the settings menu
 //
 
+import AppKit
 import Combine
 import Foundation
 
@@ -14,7 +15,14 @@ class SoundSelector: ObservableObject {
 
     // MARK: - Published State
 
-    @Published var isPickerExpanded: Bool = false
+    /// Which event type's picker is currently expanded (nil = all collapsed)
+    @Published var expandedEventType: SoundEventType? = nil
+
+    /// Cached sound selections per event type
+    @Published var soundSelections: [SoundEventType: SoundSource] = [:]
+
+    /// Custom sounds available for selection
+    @Published var customSounds: [(URL, String)] = []
 
     // MARK: - Constants
 
@@ -24,15 +32,104 @@ class SoundSelector: ObservableObject {
     /// Height per sound option row
     private let rowHeight: CGFloat = 32
 
-    private init() {}
+    /// Height of the event type section header
+    private let sectionHeaderHeight: CGFloat = 38
+
+    /// Height of the "Import Custom Sound" button row
+    private let importButtonHeight: CGFloat = 32
+
+    private init() {
+        loadSelections()
+        refreshCustomSounds()
+    }
 
     // MARK: - Public API
 
-    /// Extra height needed when picker is expanded (capped for scrolling)
+    /// Play the appropriate sound for an event type
+    func playSound(for event: SoundEventType) {
+        let source = soundSelections[event] ?? AppSettings.sound(for: event)
+        source.play()
+    }
+
+    /// Whether a sound is configured (not silent) for an event type
+    func hasSound(for event: SoundEventType) -> Bool {
+        let source = soundSelections[event] ?? AppSettings.sound(for: event)
+        return !source.isSilent
+    }
+
+    /// Get the current sound for an event type
+    func sound(for event: SoundEventType) -> SoundSource {
+        soundSelections[event] ?? AppSettings.sound(for: event)
+    }
+
+    /// Set a new sound for an event type
+    func setSound(_ sound: SoundSource, for event: SoundEventType) {
+        soundSelections[event] = sound
+        AppSettings.setSound(sound, for: event)
+    }
+
+    /// Toggle expansion of an event type's picker
+    func toggleExpanded(for event: SoundEventType) {
+        if expandedEventType == event {
+            expandedEventType = nil
+        } else {
+            expandedEventType = event
+        }
+    }
+
+    /// Import a custom sound file from a URL
+    func importCustomSound(from url: URL) -> SoundSource? {
+        guard let (savedURL, displayName) = CustomSoundsManager.importSound(from: url) else {
+            return nil
+        }
+        refreshCustomSounds()
+        return .custom(savedURL, displayName)
+    }
+
+    /// Delete a custom sound and update any event types using it
+    func deleteCustomSound(at url: URL) {
+        CustomSoundsManager.deleteSound(at: url)
+        refreshCustomSounds()
+
+        // Reset any event types that were using this sound
+        for event in SoundEventType.allCases {
+            if case .custom(let soundURL, _) = sound(for: event), soundURL == url {
+                setSound(.system("Pop"), for: event)
+            }
+        }
+    }
+
+    /// Refresh the list of available custom sounds
+    func refreshCustomSounds() {
+        customSounds = CustomSoundsManager.listCustomSounds()
+    }
+
+    /// Extra height needed when a picker is expanded
     var expandedPickerHeight: CGFloat {
-        guard isPickerExpanded else { return 0 }
-        let totalOptions = NotificationSound.allCases.count
+        guard expandedEventType != nil else { return 0 }
+
+        // System sounds + "None" + custom sounds + import button
+        let systemSoundsCount = SystemSound.allCases.count + 1 // +1 for "None"
+        let customCount = customSounds.count
+        let totalOptions = systemSoundsCount + customCount + 1 // +1 for import button
         let visibleOptions = min(totalOptions, maxVisibleOptions)
-        return CGFloat(visibleOptions) * rowHeight + 8 // +8 for padding
+        return CGFloat(visibleOptions) * rowHeight + 8
+    }
+
+    /// Total extra height for the sound settings section in the menu
+    var totalSoundSectionHeight: CGFloat {
+        // Each event type gets a section header row
+        let headersHeight = CGFloat(SoundEventType.allCases.count) * sectionHeaderHeight
+        // Plus any expanded picker height
+        return headersHeight + expandedPickerHeight
+    }
+
+    // MARK: - Private
+
+    private func loadSelections() {
+        AppSettings.migrateSoundSettingsIfNeeded()
+        for event in SoundEventType.allCases {
+            soundSelections[event] = AppSettings.sound(for: event)
+        }
     }
 }

--- a/ClaudeIsland/Core/SoundSelector.swift
+++ b/ClaudeIsland/Core/SoundSelector.swift
@@ -35,9 +35,6 @@ class SoundSelector: ObservableObject {
     /// Height of the event type section header
     private let sectionHeaderHeight: CGFloat = 38
 
-    /// Height of the "Import Custom Sound" button row
-    private let importButtonHeight: CGFloat = 32
-
     private init() {
         loadSelections()
         refreshCustomSounds()

--- a/ClaudeIsland/Models/SessionEvent.swift
+++ b/ClaudeIsland/Models/SessionEvent.swift
@@ -27,6 +27,14 @@ enum SessionEvent: Sendable {
     /// Permission socket failed (connection died before response)
     case permissionSocketFailed(sessionId: String, toolUseId: String)
 
+    // MARK: - Question Events (AskUserQuestion user actions)
+
+    /// User answered a question from AskUserQuestion
+    case questionAnswered(sessionId: String, toolUseId: String, answers: [String: String])
+
+    /// Question socket failed (connection died before response)
+    case questionSocketFailed(sessionId: String, toolUseId: String)
+
     // MARK: - File Events (from ConversationParser)
 
     /// JSONL file was updated with new content
@@ -134,6 +142,17 @@ extension HookEvent {
             return .compacting
         }
 
+        // AskUserQuestion creates waitingForAnswer state
+        if expectsQuestionResponse {
+            let questions = parseQuestions(from: toolInput)
+            return .waitingForAnswer(QuestionContext(
+                toolUseId: toolUseId ?? "",
+                questions: questions,
+                rawToolInput: toolInput,
+                receivedAt: Date()
+            ))
+        }
+
         // Permission request creates waitingForApproval state
         if expectsResponse, let tool = tool {
             return .waitingForApproval(PermissionContext(
@@ -160,6 +179,42 @@ extension HookEvent {
         default:
             return .idle
         }
+    }
+
+    /// Parse QuestionItem array from tool_input
+    private nonisolated func parseQuestions(from toolInput: [String: AnyCodable]?) -> [QuestionItem] {
+        guard let input = toolInput,
+              let questionsValue = input["questions"]?.value as? [Any] else {
+            return []
+        }
+
+        var items: [QuestionItem] = []
+        for questionAny in questionsValue {
+            guard let questionDict = questionAny as? [String: Any] else { continue }
+
+            let questionText = questionDict["question"] as? String ?? ""
+            let header = questionDict["header"] as? String
+            let multiSelect = questionDict["multiSelect"] as? Bool ?? false
+
+            var options: [QuestionOption] = []
+            if let optionsArray = questionDict["options"] as? [Any] {
+                for optionAny in optionsArray {
+                    if let optionDict = optionAny as? [String: Any] {
+                        let label = optionDict["label"] as? String ?? ""
+                        let description = optionDict["description"] as? String
+                        options.append(QuestionOption(label: label, description: description))
+                    }
+                }
+            }
+
+            items.append(QuestionItem(
+                question: questionText,
+                header: header,
+                options: options,
+                multiSelect: multiSelect
+            ))
+        }
+        return items
     }
 
     /// Whether this is a tool-related event
@@ -191,6 +246,10 @@ extension SessionEvent: CustomStringConvertible {
             return "permissionDenied(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)))"
         case .permissionSocketFailed(let sessionId, let toolUseId):
             return "permissionSocketFailed(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)))"
+        case .questionAnswered(let sessionId, let toolUseId, _):
+            return "questionAnswered(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)))"
+        case .questionSocketFailed(let sessionId, let toolUseId):
+            return "questionSocketFailed(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)))"
         case .fileUpdated(let payload):
             return "fileUpdated(session: \(payload.sessionId.prefix(8)), messages: \(payload.messages.count))"
         case .interruptDetected(let sessionId):

--- a/ClaudeIsland/Models/SessionEvent.swift
+++ b/ClaudeIsland/Models/SessionEvent.swift
@@ -182,7 +182,7 @@ extension HookEvent {
     }
 
     /// Parse QuestionItem array from tool_input
-    private nonisolated func parseQuestions(from toolInput: [String: AnyCodable]?) -> [QuestionItem] {
+    nonisolated func parseQuestions(from toolInput: [String: AnyCodable]?) -> [QuestionItem] {
         guard let input = toolInput,
               let questionsValue = input["questions"]?.value as? [Any] else {
             return []

--- a/ClaudeIsland/Models/SessionPhase.swift
+++ b/ClaudeIsland/Models/SessionPhase.swift
@@ -48,6 +48,34 @@ extension PermissionContext: Equatable {
     }
 }
 
+// MARK: - Question Context
+
+/// Context for AskUserQuestion tool waiting for user answer
+struct QuestionContext: Sendable {
+    let toolUseId: String
+    let questions: [QuestionItem]
+    let rawToolInput: [String: AnyCodable]?
+    let receivedAt: Date
+
+    /// Primary question text (first question's text)
+    var questionText: String {
+        questions.first?.question ?? ""
+    }
+
+    /// Whether the question has predefined options
+    var hasOptions: Bool {
+        guard let first = questions.first else { return false }
+        return !first.options.isEmpty
+    }
+}
+
+extension QuestionContext: Equatable {
+    nonisolated static func == (lhs: QuestionContext, rhs: QuestionContext) -> Bool {
+        lhs.toolUseId == rhs.toolUseId &&
+        lhs.receivedAt == rhs.receivedAt
+    }
+}
+
 /// Explicit session phases - the state machine
 enum SessionPhase: Sendable {
     /// Session is idle, waiting for user input or new activity
@@ -61,6 +89,9 @@ enum SessionPhase: Sendable {
 
     /// A tool is waiting for user permission approval
     case waitingForApproval(PermissionContext)
+
+    /// AskUserQuestion tool is waiting for user answer
+    case waitingForAnswer(QuestionContext)
 
     /// Context is being compacted (auto or manual)
     case compacting
@@ -86,6 +117,8 @@ enum SessionPhase: Sendable {
             return true
         case (.idle, .waitingForApproval):
             return true  // Direct permission request on idle session
+        case (.idle, .waitingForAnswer):
+            return true  // Direct question on idle session
         case (.idle, .compacting):
             return true
 
@@ -94,6 +127,8 @@ enum SessionPhase: Sendable {
             return true
         case (.processing, .waitingForApproval):
             return true
+        case (.processing, .waitingForAnswer):
+            return true  // AskUserQuestion while processing
         case (.processing, .compacting):
             return true
         case (.processing, .idle):
@@ -116,6 +151,18 @@ enum SessionPhase: Sendable {
             return true  // Denied and Claude stopped
         case (.waitingForApproval, .waitingForApproval):
             return true  // Another tool needs approval (multiple pending permissions)
+        case (.waitingForApproval, .waitingForAnswer):
+            return true  // Question while approval pending
+
+        // WaitingForAnswer transitions
+        case (.waitingForAnswer, .processing):
+            return true  // Answered - tool will continue
+        case (.waitingForAnswer, .idle):
+            return true  // Cancelled or timed out
+        case (.waitingForAnswer, .waitingForInput):
+            return true  // Cancelled and Claude stopped
+        case (.waitingForAnswer, .waitingForAnswer):
+            return true  // Another question
 
         // Compacting transitions
         case (.compacting, .processing):
@@ -139,7 +186,7 @@ enum SessionPhase: Sendable {
     /// Whether this phase indicates the session needs user attention
     var needsAttention: Bool {
         switch self {
-        case .waitingForApproval, .waitingForInput:
+        case .waitingForApproval, .waitingForInput, .waitingForAnswer:
             return true
         default:
             return false
@@ -171,6 +218,22 @@ enum SessionPhase: Sendable {
         }
         return nil
     }
+
+    /// Whether this is a waitingForAnswer phase
+    var isWaitingForAnswer: Bool {
+        if case .waitingForAnswer = self {
+            return true
+        }
+        return false
+    }
+
+    /// Extract question context if waiting for answer
+    var questionContext: QuestionContext? {
+        if case .waitingForAnswer(let ctx) = self {
+            return ctx
+        }
+        return nil
+    }
 }
 
 // MARK: - Equatable
@@ -182,6 +245,8 @@ extension SessionPhase: Equatable {
         case (.processing, .processing): return true
         case (.waitingForInput, .waitingForInput): return true
         case (.waitingForApproval(let ctx1), .waitingForApproval(let ctx2)):
+            return ctx1 == ctx2
+        case (.waitingForAnswer(let ctx1), .waitingForAnswer(let ctx2)):
             return ctx1 == ctx2
         case (.compacting, .compacting): return true
         case (.ended, .ended): return true
@@ -203,6 +268,8 @@ extension SessionPhase: CustomStringConvertible {
             return "waitingForInput"
         case .waitingForApproval(let ctx):
             return "waitingForApproval(\(ctx.toolName))"
+        case .waitingForAnswer(let ctx):
+            return "waitingForAnswer(\(ctx.questionText.prefix(30)))"
         case .compacting:
             return "compacting"
         case .ended:

--- a/ClaudeIsland/Models/SessionState.swift
+++ b/ClaudeIsland/Models/SessionState.swift
@@ -23,6 +23,9 @@ struct SessionState: Equatable, Identifiable, Sendable {
     var tty: String?
     var isInTmux: Bool
 
+    /// Resolved terminal application info (detected from process tree)
+    var resolvedTerminal: ResolvedTerminal?
+
     // MARK: - State Machine
 
     /// Current phase in the session lifecycle
@@ -71,6 +74,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         pid: Int? = nil,
         tty: String? = nil,
         isInTmux: Bool = false,
+        resolvedTerminal: ResolvedTerminal? = nil,
         phase: SessionPhase = .idle,
         chatItems: [ChatHistoryItem] = [],
         toolTracker: ToolTracker = ToolTracker(),
@@ -89,6 +93,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         self.pid = pid
         self.tty = tty
         self.isInTmux = isInTmux
+        self.resolvedTerminal = resolvedTerminal
         self.phase = phase
         self.chatItems = chatItems
         self.toolTracker = toolTracker
@@ -190,6 +195,23 @@ struct SessionState: Equatable, Identifiable, Sendable {
     /// Whether the session can be interacted with
     var canInteract: Bool {
         phase.needsAttention
+    }
+
+    // MARK: - Terminal Info Convenience
+
+    /// Display name of the terminal app (e.g. "iTerm2", "VS Code")
+    var terminalDisplayName: String? {
+        resolvedTerminal?.appInfo.displayName
+    }
+
+    /// SF Symbol icon for the terminal type
+    var terminalIconName: String {
+        resolvedTerminal?.appInfo.iconName ?? "terminal"
+    }
+
+    /// Whether we can jump to this session's terminal
+    var canJumpToTerminal: Bool {
+        resolvedTerminal != nil
     }
 }
 

--- a/ClaudeIsland/Models/SessionState.swift
+++ b/ClaudeIsland/Models/SessionState.swift
@@ -114,6 +114,14 @@ struct SessionState: Equatable, Identifiable, Sendable {
         return nil
     }
 
+    /// The active question context, if any
+    var activeQuestion: QuestionContext? {
+        if case .waitingForAnswer(let ctx) = phase {
+            return ctx
+        }
+        return nil
+    }
+
     // MARK: - UI Convenience Properties
 
     /// Stable identity for SwiftUI (combines PID and sessionId for animation stability)

--- a/ClaudeIsland/Models/ToolResultData.swift
+++ b/ClaudeIsland/Models/ToolResultData.swift
@@ -196,6 +196,7 @@ struct QuestionItem: Equatable, Sendable {
     let question: String
     let header: String?
     let options: [QuestionOption]
+    let multiSelect: Bool
 }
 
 struct QuestionOption: Equatable, Sendable {

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -9,9 +9,16 @@ import json
 import os
 import socket
 import sys
+import time
 
 SOCKET_PATH = "/tmp/claude-island.sock"
 TIMEOUT_SECONDS = 300  # 5 minutes for permission decisions
+MAX_RETRIES = 3
+RETRY_DELAY = 0.3  # seconds between retries
+
+# Log to stderr so it doesn't interfere with hook output to stdout
+def _log(msg):
+    print(f"[claude-island-hook] {msg}", file=sys.stderr)
 
 
 def get_tty():
@@ -50,36 +57,82 @@ def get_tty():
     return None
 
 
-def send_event(state):
-    """Send event to app, return response if any"""
-    try:
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(TIMEOUT_SECONDS)
-        sock.connect(SOCKET_PATH)
-        sock.sendall(json.dumps(state).encode())
+def send_event(state, retries=MAX_RETRIES):
+    """Send event to app with retry logic. Returns response if any."""
+    needs_response = state.get("status") in ("waiting_for_approval", "waiting_for_answer")
 
-        # For permission requests and question answers, wait for response
-        if state.get("status") in ("waiting_for_approval", "waiting_for_answer"):
-            # Signal send-complete so the receiver knows payload is done
+    for attempt in range(1, retries + 1):
+        sock = None
+        try:
+            # Check socket file exists before attempting connection
+            if not os.path.exists(SOCKET_PATH):
+                if attempt < retries:
+                    _log(f"Socket not found at {SOCKET_PATH}, retry {attempt}/{retries}")
+                    time.sleep(RETRY_DELAY)
+                    continue
+                else:
+                    _log(f"Socket not found at {SOCKET_PATH} after {retries} attempts — is ClaudeIsland.app running?")
+                    return None
+
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(TIMEOUT_SECONDS if needs_response else 5)
+            sock.connect(SOCKET_PATH)
+
+            payload = json.dumps(state).encode()
+            sock.sendall(payload)
+            # Shut down the write side so the server sees EOF
             sock.shutdown(socket.SHUT_WR)
 
-            # Read response in a loop until EOF (handles large payloads)
-            chunks = []
-            while True:
-                chunk = sock.recv(4096)
-                if not chunk:
-                    break
-                chunks.append(chunk)
-            sock.close()
+            # For permission requests and question answers, wait for response
+            if needs_response:
+                chunks = []
+                while True:
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                sock.close()
+                sock = None
+                if chunks:
+                    return json.loads(b"".join(chunks).decode())
+                return None
+            else:
+                sock.close()
+                sock = None
+                return None
 
-            if chunks:
-                return json.loads(b"".join(chunks).decode())
-        else:
-            sock.close()
+        except (ConnectionRefusedError, FileNotFoundError) as e:
+            if sock:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            if attempt < retries:
+                _log(f"Connection failed ({e}), retry {attempt}/{retries}")
+                time.sleep(RETRY_DELAY)
+            else:
+                _log(f"Connection failed after {retries} attempts: {e}")
+                return None
 
-        return None
-    except (socket.error, OSError, json.JSONDecodeError):
-        return None
+        except (socket.timeout, socket.error, OSError) as e:
+            if sock:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            _log(f"Socket error: {e}")
+            return None
+
+        except json.JSONDecodeError as e:
+            if sock:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            _log(f"Invalid JSON response: {e}")
+            return None
+
+    return None
 
 
 def main():

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -8,9 +8,16 @@ import json
 import os
 import socket
 import sys
+import time
 
 SOCKET_PATH = "/tmp/claude-island.sock"
 TIMEOUT_SECONDS = 300  # 5 minutes for permission decisions
+MAX_RETRIES = 3
+RETRY_DELAY = 0.3  # seconds between retries
+
+# Log to stderr so it doesn't interfere with hook output to stdout
+def _log(msg):
+    print(f"[claude-island-hook] {msg}", file=sys.stderr)
 
 
 def get_tty():
@@ -49,26 +56,82 @@ def get_tty():
     return None
 
 
-def send_event(state):
-    """Send event to app, return response if any"""
-    try:
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(TIMEOUT_SECONDS)
-        sock.connect(SOCKET_PATH)
-        sock.sendall(json.dumps(state).encode())
+def send_event(state, retries=MAX_RETRIES):
+    """Send event to app with retry logic. Returns response if any."""
+    is_permission = state.get("status") == "waiting_for_approval"
 
-        # For permission requests, wait for response
-        if state.get("status") == "waiting_for_approval":
-            response = sock.recv(4096)
-            sock.close()
-            if response:
-                return json.loads(response.decode())
-        else:
-            sock.close()
+    for attempt in range(1, retries + 1):
+        sock = None
+        try:
+            # Check socket file exists before attempting connection
+            if not os.path.exists(SOCKET_PATH):
+                if attempt < retries:
+                    _log(f"Socket not found at {SOCKET_PATH}, retry {attempt}/{retries}")
+                    time.sleep(RETRY_DELAY)
+                    continue
+                else:
+                    _log(f"Socket not found at {SOCKET_PATH} after {retries} attempts — is ClaudeIsland.app running?")
+                    return None
 
-        return None
-    except (socket.error, OSError, json.JSONDecodeError):
-        return None
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(TIMEOUT_SECONDS if is_permission else 5)
+            sock.connect(SOCKET_PATH)
+
+            payload = json.dumps(state).encode()
+            sock.sendall(payload)
+            # Shut down the write side so the server sees EOF
+            sock.shutdown(socket.SHUT_WR)
+
+            # For permission requests, wait for response
+            if is_permission:
+                chunks = []
+                while True:
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                sock.close()
+                sock = None
+                if chunks:
+                    return json.loads(b"".join(chunks).decode())
+                return None
+            else:
+                sock.close()
+                sock = None
+                return None
+
+        except (ConnectionRefusedError, FileNotFoundError) as e:
+            if sock:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            if attempt < retries:
+                _log(f"Connection failed ({e}), retry {attempt}/{retries}")
+                time.sleep(RETRY_DELAY)
+            else:
+                _log(f"Connection failed after {retries} attempts: {e}")
+                return None
+
+        except (socket.timeout, socket.error, OSError) as e:
+            if sock:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            _log(f"Socket error: {e}")
+            return None
+
+        except json.JSONDecodeError as e:
+            if sock:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            _log(f"Invalid JSON response: {e}")
+            return None
+
+    return None
 
 
 def main():

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -9,16 +9,9 @@ import json
 import os
 import socket
 import sys
-import time
 
 SOCKET_PATH = "/tmp/claude-island.sock"
 TIMEOUT_SECONDS = 300  # 5 minutes for permission decisions
-MAX_RETRIES = 3
-RETRY_DELAY = 0.3  # seconds between retries
-
-# Log to stderr so it doesn't interfere with hook output to stdout
-def _log(msg):
-    print(f"[claude-island-hook] {msg}", file=sys.stderr)
 
 
 def get_tty():
@@ -57,82 +50,36 @@ def get_tty():
     return None
 
 
-def send_event(state, retries=MAX_RETRIES):
-    """Send event to app with retry logic. Returns response if any."""
-    needs_response = state.get("status") in ("waiting_for_approval", "waiting_for_answer")
+def send_event(state):
+    """Send event to app, return response if any"""
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(TIMEOUT_SECONDS)
+        sock.connect(SOCKET_PATH)
+        sock.sendall(json.dumps(state).encode())
 
-    for attempt in range(1, retries + 1):
-        sock = None
-        try:
-            # Check socket file exists before attempting connection
-            if not os.path.exists(SOCKET_PATH):
-                if attempt < retries:
-                    _log(f"Socket not found at {SOCKET_PATH}, retry {attempt}/{retries}")
-                    time.sleep(RETRY_DELAY)
-                    continue
-                else:
-                    _log(f"Socket not found at {SOCKET_PATH} after {retries} attempts — is ClaudeIsland.app running?")
-                    return None
-
-            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            sock.settimeout(TIMEOUT_SECONDS if needs_response else 5)
-            sock.connect(SOCKET_PATH)
-
-            payload = json.dumps(state).encode()
-            sock.sendall(payload)
-            # Shut down the write side so the server sees EOF
+        # For permission requests and question answers, wait for response
+        if state.get("status") in ("waiting_for_approval", "waiting_for_answer"):
+            # Signal send-complete so the receiver knows payload is done
             sock.shutdown(socket.SHUT_WR)
 
-            # For permission requests and question answers, wait for response
-            if needs_response:
-                chunks = []
-                while True:
-                    chunk = sock.recv(4096)
-                    if not chunk:
-                        break
-                    chunks.append(chunk)
-                sock.close()
-                sock = None
-                if chunks:
-                    return json.loads(b"".join(chunks).decode())
-                return None
-            else:
-                sock.close()
-                sock = None
-                return None
+            # Read response in a loop until EOF (handles large payloads)
+            chunks = []
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            sock.close()
 
-        except (ConnectionRefusedError, FileNotFoundError) as e:
-            if sock:
-                try:
-                    sock.close()
-                except OSError:
-                    pass
-            if attempt < retries:
-                _log(f"Connection failed ({e}), retry {attempt}/{retries}")
-                time.sleep(RETRY_DELAY)
-            else:
-                _log(f"Connection failed after {retries} attempts: {e}")
-                return None
+            if chunks:
+                return json.loads(b"".join(chunks).decode())
+        else:
+            sock.close()
 
-        except (socket.timeout, socket.error, OSError) as e:
-            if sock:
-                try:
-                    sock.close()
-                except OSError:
-                    pass
-            _log(f"Socket error: {e}")
-            return None
-
-        except json.JSONDecodeError as e:
-            if sock:
-                try:
-                    sock.close()
-                except OSError:
-                    pass
-            _log(f"Invalid JSON response: {e}")
-            return None
-
-    return None
+        return None
+    except (socket.error, OSError, json.JSONDecodeError):
+        return None
 
 
 def main():

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -3,6 +3,7 @@
 Claude Island Hook
 - Sends session state to ClaudeIsland.app via Unix socket
 - For PermissionRequest: waits for user decision from the app
+- For AskUserQuestion: waits for user answer from the app
 """
 import json
 import os
@@ -58,7 +59,7 @@ def get_tty():
 
 def send_event(state, retries=MAX_RETRIES):
     """Send event to app with retry logic. Returns response if any."""
-    is_permission = state.get("status") == "waiting_for_approval"
+    needs_response = state.get("status") in ("waiting_for_approval", "waiting_for_answer")
 
     for attempt in range(1, retries + 1):
         sock = None
@@ -74,7 +75,7 @@ def send_event(state, retries=MAX_RETRIES):
                     return None
 
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            sock.settimeout(TIMEOUT_SECONDS if is_permission else 5)
+            sock.settimeout(TIMEOUT_SECONDS if needs_response else 5)
             sock.connect(SOCKET_PATH)
 
             payload = json.dumps(state).encode()
@@ -82,8 +83,8 @@ def send_event(state, retries=MAX_RETRIES):
             # Shut down the write side so the server sees EOF
             sock.shutdown(socket.SHUT_WR)
 
-            # For permission requests, wait for response
-            if is_permission:
+            # For permission requests and question answers, wait for response
+            if needs_response:
                 chunks = []
                 while True:
                     chunk = sock.recv(4096)
@@ -164,13 +165,43 @@ def main():
         state["status"] = "processing"
 
     elif event == "PreToolUse":
-        state["status"] = "running_tool"
-        state["tool"] = data.get("tool_name")
+        tool_name = data.get("tool_name")
+        state["tool"] = tool_name
         state["tool_input"] = tool_input
         # Send tool_use_id to Swift for caching
         tool_use_id_from_event = data.get("tool_use_id")
         if tool_use_id_from_event:
             state["tool_use_id"] = tool_use_id_from_event
+
+        # AskUserQuestion: intercept and wait for user answer from the app
+        if tool_name == "AskUserQuestion":
+            state["status"] = "waiting_for_answer"
+
+            # Send to app and wait for answer
+            response = send_event(state)
+
+            if response:
+                answers = response.get("answers")
+                if answers:
+                    # Build updatedInput: echo back questions + add answers
+                    updated_input = dict(tool_input)
+                    updated_input["answers"] = answers
+                    output = {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "allow",
+                            "updatedInput": updated_input,
+                        }
+                    }
+                    print(json.dumps(output))
+                    sys.exit(0)
+
+            # No response or no answers - output empty JSON so Claude Code
+            # falls through to its normal terminal UI gracefully
+            print(json.dumps({}))
+            sys.exit(0)
+        else:
+            state["status"] = "running_tool"
 
     elif event == "PostToolUse":
         state["status"] = "processing"

--- a/ClaudeIsland/Services/Hooks/HookInstaller.swift
+++ b/ClaudeIsland/Services/Hooks/HookInstaller.swift
@@ -103,7 +103,7 @@ struct HookInstaller {
 
         let hookEvents: [(String, [[String: Any]])] = [
             ("UserPromptSubmit", withoutMatcher),
-            ("PreToolUse", withMatcher),
+            ("PreToolUse", withMatcherAndTimeout),
             ("PostToolUse", withMatcher),
             ("PermissionRequest", withMatcherAndTimeout),
             ("Notification", withMatcher),

--- a/ClaudeIsland/Services/Hooks/HookInstaller.swift
+++ b/ClaudeIsland/Services/Hooks/HookInstaller.swift
@@ -6,8 +6,29 @@
 //
 
 import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.claudeisland", category: "HookInstaller")
 
 struct HookInstaller {
+
+    // MARK: - Required hook events
+
+    /// All hook events that must be registered for full session detection.
+    /// If any of these are missing, `isInstalled()` returns false and
+    /// `installIfNeeded()` will re-register them.
+    private static let requiredEvents: Set<String> = [
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PermissionRequest",
+        "Notification",
+        "Stop",
+        "SubagentStop",
+        "SessionStart",
+        "SessionEnd",
+        "PreCompact",
+    ]
 
     /// Install hook script and update settings.json on app launch
     static func installIfNeeded() {
@@ -17,21 +38,46 @@ struct HookInstaller {
         let pythonScript = hooksDir.appendingPathComponent("claude-island-state.py")
         let settings = claudeDir.appendingPathComponent("settings.json")
 
-        try? FileManager.default.createDirectory(
-            at: hooksDir,
-            withIntermediateDirectories: true
-        )
-
-        if let bundled = Bundle.main.url(forResource: "claude-island-state", withExtension: "py") {
-            try? FileManager.default.removeItem(at: pythonScript)
-            try? FileManager.default.copyItem(at: bundled, to: pythonScript)
-            try? FileManager.default.setAttributes(
-                [.posixPermissions: 0o755],
-                ofItemAtPath: pythonScript.path
+        // Create hooks directory
+        do {
+            try FileManager.default.createDirectory(
+                at: hooksDir,
+                withIntermediateDirectories: true
             )
+        } catch {
+            logger.error("Failed to create hooks directory: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        // Copy bundled Python hook script
+        if let bundled = Bundle.main.url(forResource: "claude-island-state", withExtension: "py") {
+            do {
+                if FileManager.default.fileExists(atPath: pythonScript.path) {
+                    try FileManager.default.removeItem(at: pythonScript)
+                }
+                try FileManager.default.copyItem(at: bundled, to: pythonScript)
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755],
+                    ofItemAtPath: pythonScript.path
+                )
+                logger.info("Hook script installed at \(pythonScript.path, privacy: .public)")
+            } catch {
+                logger.error("Failed to install hook script: \(error.localizedDescription, privacy: .public)")
+                return
+            }
+        } else {
+            logger.error("Bundled claude-island-state.py not found in app bundle")
+            return
         }
 
         updateSettings(at: settings)
+
+        // Post-install verification
+        if isInstalled() {
+            logger.info("Hook installation verified — all \(requiredEvents.count) events registered")
+        } else {
+            logger.error("Hook installation verification FAILED — some events may be missing")
+        }
     }
 
     private static func updateSettings(at settingsURL: URL) {
@@ -70,7 +116,8 @@ struct HookInstaller {
 
         for (event, config) in hookEvents {
             if var existingEvent = hooks[event] as? [[String: Any]] {
-                let hasOurHook = existingEvent.contains { entry in
+                // Remove stale entries first (e.g. pointing to wrong python path)
+                existingEvent.removeAll { entry in
                     if let entryHooks = entry["hooks"] as? [[String: Any]] {
                         return entryHooks.contains { h in
                             let cmd = h["command"] as? String ?? ""
@@ -79,10 +126,9 @@ struct HookInstaller {
                     }
                     return false
                 }
-                if !hasOurHook {
-                    existingEvent.append(contentsOf: config)
-                    hooks[event] = existingEvent
-                }
+                // Add fresh config
+                existingEvent.append(contentsOf: config)
+                hooks[event] = existingEvent
             } else {
                 hooks[event] = config
             }
@@ -90,19 +136,32 @@ struct HookInstaller {
 
         json["hooks"] = hooks
 
-        if let data = try? JSONSerialization.data(
-            withJSONObject: json,
-            options: [.prettyPrinted, .sortedKeys]
-        ) {
-            try? data.write(to: settingsURL)
+        do {
+            let data = try JSONSerialization.data(
+                withJSONObject: json,
+                options: [.prettyPrinted, .sortedKeys]
+            )
+            try data.write(to: settingsURL)
+            logger.info("Settings updated at \(settingsURL.path, privacy: .public)")
+        } catch {
+            logger.error("Failed to write settings: \(error.localizedDescription, privacy: .public)")
         }
     }
 
-    /// Check if hooks are currently installed
+    /// Check if hooks are currently installed (all required events present)
     static func isInstalled() -> Bool {
         let claudeDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".claude")
         let settings = claudeDir.appendingPathComponent("settings.json")
+
+        // Also check the script file itself
+        let pythonScript = claudeDir
+            .appendingPathComponent("hooks")
+            .appendingPathComponent("claude-island-state.py")
+        guard FileManager.default.fileExists(atPath: pythonScript.path) else {
+            logger.debug("isInstalled: hook script not found at \(pythonScript.path, privacy: .public)")
+            return false
+        }
 
         guard let data = try? Data(contentsOf: settings),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -110,21 +169,29 @@ struct HookInstaller {
             return false
         }
 
-        for (_, value) in hooks {
+        // Check that ALL required events have our hook registered
+        var registeredEvents = Set<String>()
+        for (event, value) in hooks {
             if let entries = value as? [[String: Any]] {
                 for entry in entries {
                     if let entryHooks = entry["hooks"] as? [[String: Any]] {
                         for hook in entryHooks {
                             if let cmd = hook["command"] as? String,
                                cmd.contains("claude-island-state.py") {
-                                return true
+                                registeredEvents.insert(event)
                             }
                         }
                     }
                 }
             }
         }
-        return false
+
+        let missing = requiredEvents.subtracting(registeredEvents)
+        if !missing.isEmpty {
+            logger.debug("isInstalled: missing hook events: \(missing.sorted().joined(separator: ", "), privacy: .public)")
+            return false
+        }
+        return true
     }
 
     /// Uninstall hooks from settings.json and remove script
@@ -175,6 +242,8 @@ struct HookInstaller {
         ) {
             try? data.write(to: settings)
         }
+
+        logger.info("Hooks uninstalled")
     }
 
     private static func detectPython() -> String {

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -66,10 +66,9 @@ struct HookEvent: Codable, Sendable {
                 receivedAt: Date()
             ))
         case "waiting_for_answer":
-            // Note: Full QuestionContext is constructed by determinePhase(), not here
             return .waitingForAnswer(QuestionContext(
                 toolUseId: toolUseId ?? "",
-                questions: [],
+                questions: parseQuestions(from: toolInput),
                 rawToolInput: toolInput,
                 receivedAt: Date()
             ))

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -3,7 +3,7 @@
 //  ClaudeIsland
 //
 //  Unix domain socket server for real-time hook events
-//  Supports request/response for permission decisions
+//  Supports request/response for permission decisions and question answers
 //
 
 import Foundation
@@ -65,6 +65,14 @@ struct HookEvent: Codable, Sendable {
                 toolInput: toolInput,
                 receivedAt: Date()
             ))
+        case "waiting_for_answer":
+            // Note: Full QuestionContext is constructed by determinePhase(), not here
+            return .waitingForAnswer(QuestionContext(
+                toolUseId: toolUseId ?? "",
+                questions: [],
+                rawToolInput: toolInput,
+                receivedAt: Date()
+            ))
         case "waiting_for_input":
             return .waitingForInput
         case "running_tool", "processing", "starting":
@@ -79,6 +87,11 @@ struct HookEvent: Codable, Sendable {
     /// Whether this event expects a response (permission request)
     nonisolated var expectsResponse: Bool {
         event == "PermissionRequest" && status == "waiting_for_approval"
+    }
+
+    /// Whether this event expects a question answer (AskUserQuestion via PreToolUse)
+    nonisolated var expectsQuestionResponse: Bool {
+        event == "PreToolUse" && status == "waiting_for_answer" && tool == "AskUserQuestion"
     }
 }
 
@@ -97,11 +110,28 @@ struct PendingPermission: Sendable {
     let receivedAt: Date
 }
 
+/// Pending question waiting for user answer
+struct PendingQuestion: Sendable {
+    let sessionId: String
+    let toolUseId: String
+    let clientSocket: Int32
+    let event: HookEvent
+    let receivedAt: Date
+}
+
+/// Response to send back to the hook for question answers
+struct QuestionAnswerResponse: Codable {
+    let answers: [String: String]
+}
+
 /// Callback for hook events
 typealias HookEventHandler = @Sendable (HookEvent) -> Void
 
 /// Callback for permission response failures (socket died)
 typealias PermissionFailureHandler = @Sendable (_ sessionId: String, _ toolUseId: String) -> Void
+
+/// Callback for question answer failures (socket died)
+typealias QuestionFailureHandler = @Sendable (_ sessionId: String, _ toolUseId: String) -> Void
 
 /// Unix domain socket server that receives events from Claude Code hooks
 /// Uses GCD DispatchSource for non-blocking I/O
@@ -113,11 +143,16 @@ class HookSocketServer {
     private var acceptSource: DispatchSourceRead?
     private var eventHandler: HookEventHandler?
     private var permissionFailureHandler: PermissionFailureHandler?
+    private var questionFailureHandler: QuestionFailureHandler?
     private let queue = DispatchQueue(label: "com.claudeisland.socket", qos: .userInitiated)
 
     /// Pending permission requests indexed by toolUseId
     private var pendingPermissions: [String: PendingPermission] = [:]
     private let permissionsLock = NSLock()
+
+    /// Pending questions indexed by toolUseId
+    private var pendingQuestions: [String: PendingQuestion] = [:]
+    private let questionsLock = NSLock()
 
     /// Cache tool_use_id from PreToolUse to correlate with PermissionRequest
     /// Key: "sessionId:toolName:serializedInput" -> Queue of tool_use_ids (FIFO)
@@ -128,17 +163,18 @@ class HookSocketServer {
     private init() {}
 
     /// Start the socket server
-    func start(onEvent: @escaping HookEventHandler, onPermissionFailure: PermissionFailureHandler? = nil) {
+    func start(onEvent: @escaping HookEventHandler, onPermissionFailure: PermissionFailureHandler? = nil, onQuestionFailure: QuestionFailureHandler? = nil) {
         queue.async { [weak self] in
-            self?.startServer(onEvent: onEvent, onPermissionFailure: onPermissionFailure)
+            self?.startServer(onEvent: onEvent, onPermissionFailure: onPermissionFailure, onQuestionFailure: onQuestionFailure)
         }
     }
 
-    private func startServer(onEvent: @escaping HookEventHandler, onPermissionFailure: PermissionFailureHandler?) {
+    private func startServer(onEvent: @escaping HookEventHandler, onPermissionFailure: PermissionFailureHandler?, onQuestionFailure: QuestionFailureHandler?) {
         guard serverSocket < 0 else { return }
 
         eventHandler = onEvent
         permissionFailureHandler = onPermissionFailure
+        questionFailureHandler = onQuestionFailure
 
         unlink(Self.socketPath)
 
@@ -210,6 +246,13 @@ class HookSocketServer {
         }
         pendingPermissions.removeAll()
         permissionsLock.unlock()
+
+        questionsLock.lock()
+        for (_, pending) in pendingQuestions {
+            close(pending.clientSocket)
+        }
+        pendingQuestions.removeAll()
+        questionsLock.unlock()
     }
 
     /// Respond to a pending permission request by toolUseId
@@ -257,6 +300,36 @@ class HookSocketServer {
         }
     }
 
+    // MARK: - Question Methods
+
+    /// Respond to a pending question with user's answers
+    func respondToQuestion(toolUseId: String, answers: [String: String]) {
+        queue.async { [weak self] in
+            self?.sendQuestionResponse(toolUseId: toolUseId, answers: answers)
+        }
+    }
+
+    /// Cancel all pending questions for a session
+    func cancelPendingQuestions(sessionId: String) {
+        queue.async { [weak self] in
+            self?.cleanupPendingQuestions(sessionId: sessionId)
+        }
+    }
+
+    /// Cancel a specific pending question by toolUseId
+    func cancelPendingQuestion(toolUseId: String) {
+        queue.async { [weak self] in
+            self?.cleanupSpecificQuestion(toolUseId: toolUseId)
+        }
+    }
+
+    /// Check if there's a pending question for a session
+    func hasPendingQuestion(sessionId: String) -> Bool {
+        questionsLock.lock()
+        defer { questionsLock.unlock() }
+        return pendingQuestions.values.contains { $0.sessionId == sessionId }
+    }
+
     private func cleanupSpecificPermission(toolUseId: String) {
         permissionsLock.lock()
         guard let pending = pendingPermissions.removeValue(forKey: toolUseId) else {
@@ -278,6 +351,29 @@ class HookSocketServer {
             pendingPermissions.removeValue(forKey: toolUseId)
         }
         permissionsLock.unlock()
+    }
+
+    private func cleanupPendingQuestions(sessionId: String) {
+        questionsLock.lock()
+        let matching = pendingQuestions.filter { $0.value.sessionId == sessionId }
+        for (toolUseId, pending) in matching {
+            logger.debug("Cleaning up stale question for \(sessionId.prefix(8), privacy: .public) tool:\(toolUseId.prefix(12), privacy: .public)")
+            close(pending.clientSocket)
+            pendingQuestions.removeValue(forKey: toolUseId)
+        }
+        questionsLock.unlock()
+    }
+
+    private func cleanupSpecificQuestion(toolUseId: String) {
+        questionsLock.lock()
+        guard let pending = pendingQuestions.removeValue(forKey: toolUseId) else {
+            questionsLock.unlock()
+            return
+        }
+        questionsLock.unlock()
+
+        logger.debug("Question completed externally, closing socket for \(pending.sessionId.prefix(8), privacy: .public) tool:\(toolUseId.prefix(12), privacy: .public)")
+        close(pending.clientSocket)
     }
 
     // MARK: - Tool Use ID Cache
@@ -434,6 +530,32 @@ class HookSocketServer {
             cleanupCache(sessionId: event.sessionId)
         }
 
+        // Handle AskUserQuestion - keep socket open for answer
+        if event.expectsQuestionResponse {
+            guard let toolUseId = event.toolUseId else {
+                logger.warning("Question event missing tool_use_id for \(event.sessionId.prefix(8), privacy: .public)")
+                close(clientSocket)
+                eventHandler?(event)
+                return
+            }
+
+            logger.debug("Question request - keeping socket open for \(event.sessionId.prefix(8), privacy: .public) tool:\(toolUseId.prefix(12), privacy: .public)")
+
+            let pending = PendingQuestion(
+                sessionId: event.sessionId,
+                toolUseId: toolUseId,
+                clientSocket: clientSocket,
+                event: event,
+                receivedAt: Date()
+            )
+            questionsLock.lock()
+            pendingQuestions[toolUseId] = pending
+            questionsLock.unlock()
+
+            eventHandler?(event)
+            return
+        }
+
         if event.expectsResponse {
             let toolUseId: String
             if let eventToolUseId = event.toolUseId {
@@ -515,6 +637,47 @@ class HookSocketServer {
         }
 
         close(pending.clientSocket)
+    }
+
+    private func sendQuestionResponse(toolUseId: String, answers: [String: String]) {
+        questionsLock.lock()
+        guard let pending = pendingQuestions.removeValue(forKey: toolUseId) else {
+            questionsLock.unlock()
+            logger.debug("No pending question for toolUseId: \(toolUseId.prefix(12), privacy: .public)")
+            return
+        }
+        questionsLock.unlock()
+
+        let response = QuestionAnswerResponse(answers: answers)
+        guard let data = try? JSONEncoder().encode(response) else {
+            close(pending.clientSocket)
+            questionFailureHandler?(pending.sessionId, toolUseId)
+            return
+        }
+
+        let age = Date().timeIntervalSince(pending.receivedAt)
+        logger.info("Sending question answer for \(pending.sessionId.prefix(8), privacy: .public) tool:\(toolUseId.prefix(12), privacy: .public) (age: \(String(format: "%.1f", age), privacy: .public)s)")
+
+        var writeSuccess = false
+        data.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else {
+                logger.error("Failed to get data buffer address")
+                return
+            }
+            let result = write(pending.clientSocket, baseAddress, data.count)
+            if result < 0 {
+                logger.error("Question write failed with errno: \(errno)")
+            } else {
+                logger.debug("Question write succeeded: \(result) bytes")
+                writeSuccess = true
+            }
+        }
+
+        close(pending.clientSocket)
+
+        if !writeSuccess {
+            questionFailureHandler?(pending.sessionId, toolUseId)
+        }
     }
 
     private func sendPermissionResponseBySession(sessionId: String, decision: String, reason: String?) {

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -374,10 +374,12 @@ class HookSocketServer {
         var allData = Data()
         var buffer = [UInt8](repeating: 0, count: 131072)
         var pollFd = pollfd(fd: clientSocket, events: Int16(POLLIN), revents: 0)
+        var gotEOF = false
 
+        // Read until EOF or timeout (2 seconds max to handle slow connections)
         let startTime = Date()
-        while Date().timeIntervalSince(startTime) < 0.5 {
-            let pollResult = poll(&pollFd, 1, 50)
+        while Date().timeIntervalSince(startTime) < 2.0 {
+            let pollResult = poll(&pollFd, 1, 100)
 
             if pollResult > 0 && (pollFd.revents & Int16(POLLIN)) != 0 {
                 let bytesRead = read(clientSocket, &buffer, buffer.count)
@@ -385,20 +387,31 @@ class HookSocketServer {
                 if bytesRead > 0 {
                     allData.append(contentsOf: buffer[0..<bytesRead])
                 } else if bytesRead == 0 {
+                    // EOF — client called shutdown(SHUT_WR) or closed
+                    gotEOF = true
                     break
                 } else if errno != EAGAIN && errno != EWOULDBLOCK {
+                    logger.warning("Read error on client socket: errno=\(errno)")
                     break
                 }
             } else if pollResult == 0 {
+                // Poll timeout — if we have data, try to parse it
                 if !allData.isEmpty {
-                    break
+                    if (try? JSONDecoder().decode(HookEvent.self, from: allData)) != nil {
+                        // Complete JSON object received, stop waiting
+                        break
+                    }
+                    // Incomplete JSON — keep waiting for more data
                 }
             } else {
+                // Poll error
+                logger.warning("Poll error on client socket: errno=\(errno)")
                 break
             }
         }
 
         guard !allData.isEmpty else {
+            logger.debug("Empty data from client socket — closing")
             close(clientSocket)
             return
         }
@@ -406,7 +419,7 @@ class HookSocketServer {
         let data = allData
 
         guard let event = try? JSONDecoder().decode(HookEvent.self, from: data) else {
-            logger.warning("Failed to parse event: \(String(data: data, encoding: .utf8) ?? "?", privacy: .public)")
+            logger.warning("Failed to parse event (\(data.count) bytes, eof=\(gotEOF)): \(String(data: data, encoding: .utf8) ?? "?", privacy: .public)")
             close(clientSocket)
             return
         }

--- a/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
+++ b/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
@@ -54,16 +54,25 @@ class ClaudeSessionMonitor: ObservableObject {
 
                 if event.event == "Stop" {
                     HookSocketServer.shared.cancelPendingPermissions(sessionId: event.sessionId)
+                    HookSocketServer.shared.cancelPendingQuestions(sessionId: event.sessionId)
                 }
 
                 if event.event == "PostToolUse", let toolUseId = event.toolUseId {
                     HookSocketServer.shared.cancelPendingPermission(toolUseId: toolUseId)
+                    HookSocketServer.shared.cancelPendingQuestion(toolUseId: toolUseId)
                 }
             },
             onPermissionFailure: { sessionId, toolUseId in
                 Task {
                     await SessionStore.shared.process(
                         .permissionSocketFailed(sessionId: sessionId, toolUseId: toolUseId)
+                    )
+                }
+            },
+            onQuestionFailure: { sessionId, toolUseId in
+                Task {
+                    await SessionStore.shared.process(
+                        .questionSocketFailed(sessionId: sessionId, toolUseId: toolUseId)
                     )
                 }
             }
@@ -117,6 +126,27 @@ class ClaudeSessionMonitor: ObservableObject {
     func archiveSession(sessionId: String) {
         Task {
             await SessionStore.shared.process(.sessionEnded(sessionId: sessionId))
+        }
+    }
+
+    // MARK: - Question Handling
+
+    /// Answer a question from AskUserQuestion tool
+    func answerQuestion(sessionId: String, answers: [String: String]) {
+        Task {
+            guard let session = await SessionStore.shared.session(for: sessionId),
+                  let question = session.activeQuestion else {
+                return
+            }
+
+            HookSocketServer.shared.respondToQuestion(
+                toolUseId: question.toolUseId,
+                answers: answers
+            )
+
+            await SessionStore.shared.process(
+                .questionAnswered(sessionId: sessionId, toolUseId: question.toolUseId, answers: answers)
+            )
         }
     }
 

--- a/ClaudeIsland/Services/Session/ConversationParser.swift
+++ b/ClaudeIsland/Services/Session/ConversationParser.swift
@@ -846,7 +846,8 @@ actor ConversationParser {
                 return QuestionItem(
                     question: question,
                     header: q["header"] as? String,
-                    options: options
+                    options: options,
+                    multiSelect: q["multiSelect"] as? Bool ?? false
                 )
             }
         }

--- a/ClaudeIsland/Services/Session/ConversationParser.swift
+++ b/ClaudeIsland/Services/Session/ConversationParser.swift
@@ -270,9 +270,13 @@ actor ConversationParser {
         }
 
         var state = incrementalState[sessionId] ?? IncrementalParseState()
-        _ = parseNewLines(filePath: sessionFile, state: &state)
+        let newMessages = parseNewLines(filePath: sessionFile, state: &state)
         incrementalState[sessionId] = state
 
+        // parseNewLines returns only NEW messages since last call,
+        // but state.messages accumulates all parsed messages.
+        // If there were no new lines, newMessages is empty but state.messages
+        // still has everything from previous parses.
         return state.messages
     }
 
@@ -338,18 +342,18 @@ actor ConversationParser {
         }
 
         if fileSize == state.lastFileOffset {
-            return state.messages
+            return []
         }
 
         do {
             try fileHandle.seek(toOffset: state.lastFileOffset)
         } catch {
-            return state.messages
+            return []
         }
 
         guard let newData = try? fileHandle.readToEnd(),
               let newContent = String(data: newData, encoding: .utf8) else {
-            return state.messages
+            return []
         }
 
         state.clearPending = false
@@ -374,6 +378,7 @@ actor ConversationParser {
                 continue
             }
 
+            // Process tool_result lines for completion tracking
             if line.contains("\"tool_result\"") {
                 if let lineData = line.data(using: .utf8),
                    let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
@@ -412,7 +417,12 @@ actor ConversationParser {
                         }
                     }
                 }
-            } else if line.contains("\"type\":\"user\"") || line.contains("\"type\":\"assistant\"") {
+                // tool_result lines are user messages with tool results, not text — skip message parsing
+                continue
+            }
+
+            // Parse user and assistant messages (including text, tool_use, thinking blocks)
+            if line.contains("\"type\":\"user\"") || line.contains("\"type\":\"assistant\"") {
                 if let lineData = line.data(using: .utf8),
                    let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
                    let message = parseMessageLine(json, seenToolIds: &state.seenToolIds, toolIdToName: &state.toolIdToName) {

--- a/ClaudeIsland/Services/Session/ConversationParser.swift
+++ b/ClaudeIsland/Services/Session/ConversationParser.swift
@@ -270,7 +270,7 @@ actor ConversationParser {
         }
 
         var state = incrementalState[sessionId] ?? IncrementalParseState()
-        let newMessages = parseNewLines(filePath: sessionFile, state: &state)
+        _ = parseNewLines(filePath: sessionFile, state: &state)
         incrementalState[sessionId] = state
 
         // parseNewLines returns only NEW messages since last call,

--- a/ClaudeIsland/Services/Shared/ProcessTreeBuilder.swift
+++ b/ClaudeIsland/Services/Shared/ProcessTreeBuilder.swift
@@ -125,6 +125,23 @@ struct ProcessTreeBuilder: Sendable {
         return descendants
     }
 
+    /// Find TTY device path for a PID by walking up the process tree
+    nonisolated func findTTY(forPid pid: Int, tree: [Int: ProcessInfo]) -> String? {
+        var current = pid
+        var depth = 0
+
+        while current > 1 && depth < 20 {
+            guard let info = tree[current] else { break }
+            if let tty = info.tty {
+                return "/dev/\(tty)"
+            }
+            current = info.ppid
+            depth += 1
+        }
+
+        return nil
+    }
+
     /// Get working directory for a process using lsof
     nonisolated func getWorkingDirectory(forPid pid: Int) -> String? {
         guard let output = ProcessExecutor.shared.runSyncOrNil("/usr/sbin/lsof", arguments: ["-p", String(pid), "-Fn"]) else {

--- a/ClaudeIsland/Services/Shared/TerminalAppRegistry.swift
+++ b/ClaudeIsland/Services/Shared/TerminalAppRegistry.swift
@@ -157,7 +157,7 @@ struct TerminalAppRegistry: Sendable {
         TerminalAppInfo(
             type: .vscode,
             bundleIds: ["com.microsoft.VSCode"],
-            processNames: ["Code", "Electron"],
+            processNames: ["Code"],
             iconName: "chevron.left.forwardslash.chevron.right",
             displayName: "VS Code",
             supportsTabFocus: false,

--- a/ClaudeIsland/Services/Shared/TerminalAppRegistry.swift
+++ b/ClaudeIsland/Services/Shared/TerminalAppRegistry.swift
@@ -2,55 +2,240 @@
 //  TerminalAppRegistry.swift
 //  ClaudeIsland
 //
-//  Centralized registry of known terminal applications
+//  Centralized registry of known terminal applications with metadata
+//  for identification, display, and window focusing capabilities.
 //
 
 import Foundation
 
+// MARK: - Terminal App Definition
+
+/// A known terminal application with its metadata
+struct TerminalAppInfo: Sendable, Equatable {
+    /// Unique identifier for this terminal type
+    let type: TerminalType
+
+    /// macOS bundle identifier(s) — some apps have multiple
+    let bundleIds: [String]
+
+    /// Process name patterns for matching in process tree
+    let processNames: [String]
+
+    /// SF Symbol name for display
+    let iconName: String
+
+    /// Human-readable display name
+    let displayName: String
+
+    /// Whether the terminal supports AppleScript/JXA tab targeting
+    let supportsTabFocus: Bool
+
+    /// Whether the terminal supports pane-level targeting
+    let supportsPaneFocus: Bool
+}
+
+/// Known terminal types
+enum TerminalType: String, Sendable, CaseIterable, Equatable {
+    case terminalApp = "terminal"
+    case iterm2 = "iterm2"
+    case ghostty = "ghostty"
+    case warp = "warp"
+    case alacritty = "alacritty"
+    case kitty = "kitty"
+    case hyper = "hyper"
+    case wezterm = "wezterm"
+    case tabby = "tabby"
+    case rio = "rio"
+    case vscode = "vscode"
+    case vscodeInsiders = "vscode-insiders"
+    case cursor = "cursor"
+    case windsurf = "windsurf"
+    case zed = "zed"
+    case unknown = "unknown"
+}
+
+// MARK: - Terminal App Registry
+
 /// Registry of known terminal application names and bundle identifiers
 struct TerminalAppRegistry: Sendable {
-    /// Terminal app names for process matching
-    static let appNames: Set<String> = [
-        "Terminal",
-        "iTerm2",
-        "iTerm",
-        "Ghostty",
-        "Alacritty",
-        "kitty",
-        "Hyper",
-        "Warp",
-        "WezTerm",
-        "Tabby",
-        "Rio",
-        "Contour",
-        "foot",
-        "st",
-        "urxvt",
-        "xterm",
-        "Code",           // VS Code
-        "Code - Insiders",
-        "Cursor",
-        "Windsurf",
-        "zed"
+
+    /// All known terminal apps with their metadata
+    static let knownApps: [TerminalAppInfo] = [
+        // Native terminals
+        TerminalAppInfo(
+            type: .terminalApp,
+            bundleIds: ["com.apple.Terminal"],
+            processNames: ["Terminal"],
+            iconName: "terminal",
+            displayName: "Terminal",
+            supportsTabFocus: true,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .iterm2,
+            bundleIds: ["com.googlecode.iterm2"],
+            processNames: ["iTerm2", "iTerm", "iTermServer-main"],
+            iconName: "terminal",
+            displayName: "iTerm2",
+            supportsTabFocus: true,
+            supportsPaneFocus: true
+        ),
+        TerminalAppInfo(
+            type: .ghostty,
+            bundleIds: ["com.mitchellh.ghostty"],
+            processNames: ["Ghostty", "ghostty"],
+            iconName: "terminal",
+            displayName: "Ghostty",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .warp,
+            bundleIds: ["dev.warp.Warp-Stable"],
+            processNames: ["Warp"],
+            iconName: "terminal",
+            displayName: "Warp",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .alacritty,
+            bundleIds: ["io.alacritty", "org.alacritty"],
+            processNames: ["Alacritty", "alacritty"],
+            iconName: "terminal",
+            displayName: "Alacritty",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .kitty,
+            bundleIds: ["net.kovidgoyal.kitty"],
+            processNames: ["kitty"],
+            iconName: "terminal",
+            displayName: "Kitty",
+            supportsTabFocus: true,
+            supportsPaneFocus: true
+        ),
+        TerminalAppInfo(
+            type: .hyper,
+            bundleIds: ["co.zeit.hyper"],
+            processNames: ["Hyper"],
+            iconName: "terminal",
+            displayName: "Hyper",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .wezterm,
+            bundleIds: ["com.github.wez.wezterm"],
+            processNames: ["WezTerm", "wezterm-gui"],
+            iconName: "terminal",
+            displayName: "WezTerm",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .tabby,
+            bundleIds: ["org.tabby"],
+            processNames: ["Tabby"],
+            iconName: "terminal",
+            displayName: "Tabby",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .rio,
+            bundleIds: ["com.raphaelamorim.rio"],
+            processNames: ["Rio", "rio"],
+            iconName: "terminal",
+            displayName: "Rio",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+
+        // IDE integrated terminals
+        TerminalAppInfo(
+            type: .vscode,
+            bundleIds: ["com.microsoft.VSCode"],
+            processNames: ["Code", "Electron"],
+            iconName: "chevron.left.forwardslash.chevron.right",
+            displayName: "VS Code",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .vscodeInsiders,
+            bundleIds: ["com.microsoft.VSCodeInsiders"],
+            processNames: ["Code - Insiders"],
+            iconName: "chevron.left.forwardslash.chevron.right",
+            displayName: "VS Code Insiders",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .cursor,
+            bundleIds: ["com.todesktop.230313mzl4w4u92"],
+            processNames: ["Cursor"],
+            iconName: "cursorarrow.rays",
+            displayName: "Cursor",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .windsurf,
+            bundleIds: ["com.exafunction.windsurf"],
+            processNames: ["Windsurf"],
+            iconName: "chevron.left.forwardslash.chevron.right",
+            displayName: "Windsurf",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
+        TerminalAppInfo(
+            type: .zed,
+            bundleIds: ["dev.zed.Zed"],
+            processNames: ["zed", "Zed"],
+            iconName: "chevron.left.forwardslash.chevron.right",
+            displayName: "Zed",
+            supportsTabFocus: false,
+            supportsPaneFocus: false
+        ),
     ]
 
-    /// Bundle identifiers for terminal apps (for window enumeration)
-    static let bundleIdentifiers: Set<String> = [
-        "com.apple.Terminal",
-        "com.googlecode.iterm2",
-        "com.mitchellh.ghostty",
-        "io.alacritty",
-        "org.alacritty",
-        "net.kovidgoyal.kitty",
-        "co.zeit.hyper",
-        "dev.warp.Warp-Stable",
-        "com.github.wez.wezterm",
-        "com.microsoft.VSCode",
-        "com.microsoft.VSCodeInsiders",
-        "com.todesktop.230313mzl4w4u92",  // Cursor
-        "com.exafunction.windsurf",
-        "dev.zed.Zed"
-    ]
+    // MARK: - Lookup Tables (computed once)
+
+    /// All bundle identifiers, flattened
+    static let bundleIdentifiers: Set<String> = {
+        Set(knownApps.flatMap { $0.bundleIds })
+    }()
+
+    /// All process names for matching
+    static let appNames: Set<String> = {
+        Set(knownApps.flatMap { $0.processNames })
+    }()
+
+    /// Bundle ID -> TerminalAppInfo lookup
+    private static let bundleIdMap: [String: TerminalAppInfo] = {
+        var map: [String: TerminalAppInfo] = [:]
+        for app in knownApps {
+            for bundleId in app.bundleIds {
+                map[bundleId] = app
+            }
+        }
+        return map
+    }()
+
+    /// Process name (lowercased) -> TerminalAppInfo lookup
+    private static let processNameMap: [String: TerminalAppInfo] = {
+        var map: [String: TerminalAppInfo] = [:]
+        for app in knownApps {
+            for name in app.processNames {
+                map[name.lowercased()] = app
+            }
+        }
+        return map
+    }()
+
+    // MARK: - Identification
 
     /// Check if an app name or command path is a known terminal
     static func isTerminal(_ appNameOrCommand: String) -> Bool {
@@ -70,5 +255,51 @@ struct TerminalAppRegistry: Sendable {
     /// Check if a bundle identifier is a known terminal
     static func isTerminalBundle(_ bundleId: String) -> Bool {
         bundleIdentifiers.contains(bundleId)
+    }
+
+    /// Identify terminal app from bundle ID
+    static func appInfo(forBundleId bundleId: String) -> TerminalAppInfo? {
+        bundleIdMap[bundleId]
+    }
+
+    /// Identify terminal app from a process command string
+    static func appInfo(forProcess command: String) -> TerminalAppInfo? {
+        let lower = command.lowercased()
+
+        // Direct match on process name
+        if let app = processNameMap[lower] {
+            return app
+        }
+
+        // Check if the command contains a known process name
+        // Walk the list in order so more specific matches win first
+        for app in knownApps {
+            for name in app.processNames {
+                if lower.contains(name.lowercased()) {
+                    return app
+                }
+            }
+        }
+
+        return nil
+    }
+
+    /// Identify terminal app from a process tree by walking up from PID
+    static func appInfo(forPid pid: Int, tree: [Int: ProcessInfo]) -> TerminalAppInfo? {
+        var current = pid
+        var depth = 0
+
+        while current > 1 && depth < 20 {
+            guard let info = tree[current] else { break }
+
+            if let app = appInfo(forProcess: info.command) {
+                return app
+            }
+
+            current = info.ppid
+            depth += 1
+        }
+
+        return nil
     }
 }

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -937,7 +937,7 @@ actor SessionStore {
                 await self?.process(.clearDetected(sessionId: sessionId))
             }
 
-            guard !result.newMessages.isEmpty || result.clearDetected else {
+            guard !result.newMessages.isEmpty || result.clearDetected || !result.completedToolIds.isEmpty else {
                 return
             }
 

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -141,6 +141,13 @@ actor SessionStore {
             return
         }
 
+        // Process tool tracking FIRST so chatItems are created before we set their status.
+        // This prevents the race where PermissionRequest tries to update a tool's status
+        // before the PreToolUse-created chatItem exists.
+        processToolTracking(event: event, session: &session)
+        processSubagentTracking(event: event, session: &session)
+
+        // Now apply phase transition
         let newPhase = event.determinePhase()
 
         if session.phase.canTransition(to: newPhase) {
@@ -149,20 +156,19 @@ actor SessionStore {
             Self.logger.debug("Invalid transition: \(String(describing: session.phase), privacy: .public) -> \(String(describing: newPhase), privacy: .public), ignoring")
         }
 
+        // Update tool status AFTER both chatItem creation and phase transition
         if event.event == "PermissionRequest", let toolUseId = event.toolUseId {
             Self.logger.debug("Setting tool \(toolUseId.prefix(12), privacy: .public) status to waitingForApproval")
             updateToolStatus(in: &session, toolId: toolUseId, status: .waitingForApproval)
         }
-
-        processToolTracking(event: event, session: &session)
-        processSubagentTracking(event: event, session: &session)
 
         if event.event == "Stop" {
             session.subagentState = SubagentState()
         }
 
         sessions[sessionId] = session
-        publishState()
+        // NOTE: Do NOT call publishState() here — process() calls it once at the end
+        // to avoid UI seeing intermediate states during a single event processing cycle.
 
         if event.shouldSyncFile {
             scheduleFileSync(sessionId: sessionId, cwd: event.cwd)
@@ -626,9 +632,9 @@ actor SessionStore {
 
         sessions[payload.sessionId] = session
 
-        await emitToolCompletionEvents(
+        // Apply tool completions inline (no recursive process() call)
+        applyToolCompletions(
             sessionId: payload.sessionId,
-            session: session,
             completedToolIds: payload.completedToolIds,
             toolResults: payload.toolResults,
             structuredResults: payload.structuredResults
@@ -684,18 +690,23 @@ actor SessionStore {
         }
     }
 
-    /// Emit toolCompleted events for tools that have results in JSONL but aren't marked complete yet
-    private func emitToolCompletionEvents(
+    /// Apply tool completion results inline (without re-entering process()).
+    /// This avoids the recursive process() call that caused multiple publishState()
+    /// invocations and intermediate-state visibility during a single file update cycle.
+    private func applyToolCompletions(
         sessionId: String,
-        session: SessionState,
         completedToolIds: Set<String>,
         toolResults: [String: ConversationParser.ToolResult],
         structuredResults: [String: ToolResultData]
-    ) async {
-        for item in session.chatItems {
-            guard case .toolCall(let tool) = item.type else { continue }
+    ) {
+        guard var session = sessions[sessionId] else { return }
+        var phaseNeedsUpdate = false
 
-            // Only emit for tools that are running or waiting but have results in JSONL
+        for i in 0..<session.chatItems.count {
+            let item = session.chatItems[i]
+            guard case .toolCall(var tool) = item.type else { continue }
+
+            // Only process tools that are running or waiting but have results in JSONL
             guard tool.status == .running || tool.status == .waitingForApproval else { continue }
             guard completedToolIds.contains(item.id) else { continue }
 
@@ -704,9 +715,38 @@ actor SessionStore {
                 structuredResult: structuredResults[item.id]
             )
 
-            // Process the completion event (this will update state and phase consistently)
-            await process(.toolCompleted(sessionId: sessionId, toolUseId: item.id, result: result))
+            tool.status = result.status
+            tool.result = result.result
+            tool.structuredResult = result.structuredResult
+            session.chatItems[i] = ChatHistoryItem(
+                id: item.id,
+                type: .toolCall(tool),
+                timestamp: item.timestamp
+            )
+            Self.logger.debug("Tool \(item.id.prefix(12), privacy: .public) completed inline with status: \(String(describing: result.status), privacy: .public)")
+
+            // Check if this completion affects the current phase
+            if case .waitingForApproval(let ctx) = session.phase, ctx.toolUseId == item.id {
+                phaseNeedsUpdate = true
+            }
         }
+
+        // Update phase if the completed tool was the one blocking
+        if phaseNeedsUpdate {
+            if let nextPending = findNextPendingTool(in: session, excluding: "") {
+                let newPhase = SessionPhase.waitingForApproval(PermissionContext(
+                    toolUseId: nextPending.id,
+                    toolName: nextPending.name,
+                    toolInput: nil,
+                    receivedAt: nextPending.timestamp
+                ))
+                session.phase = newPhase
+            } else if session.phase.canTransition(to: .processing) {
+                session.phase = .processing
+            }
+        }
+
+        sessions[sessionId] = session
     }
 
     /// Create chat item (checks existingIds to avoid duplicates)

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -63,6 +63,14 @@ actor SessionStore {
         case .permissionSocketFailed(let sessionId, let toolUseId):
             await processSocketFailure(sessionId: sessionId, toolUseId: toolUseId)
 
+        // MARK: - Question Events
+
+        case .questionAnswered(let sessionId, let toolUseId, let answers):
+            await processQuestionAnswered(sessionId: sessionId, toolUseId: toolUseId, answers: answers)
+
+        case .questionSocketFailed(let sessionId, let toolUseId):
+            await processQuestionSocketFailure(sessionId: sessionId, toolUseId: toolUseId)
+
         case .fileUpdated(let payload):
             await processFileUpdate(payload)
 
@@ -487,6 +495,32 @@ actor SessionStore {
                 // The failed tool wasn't in phase context, but no others pending
                 session.phase = .idle
             }
+        }
+
+        sessions[sessionId] = session
+    }
+
+    // MARK: - Question Processing
+
+    private func processQuestionAnswered(sessionId: String, toolUseId: String, answers: [String: String]) async {
+        guard var session = sessions[sessionId] else { return }
+
+        // Transition to processing - Claude will continue after receiving the answer
+        if case .waitingForAnswer(let ctx) = session.phase, ctx.toolUseId == toolUseId {
+            if session.phase.canTransition(to: .processing) {
+                session.phase = .processing
+            }
+        }
+
+        sessions[sessionId] = session
+    }
+
+    private func processQuestionSocketFailure(sessionId: String, toolUseId: String) async {
+        guard var session = sessions[sessionId] else { return }
+
+        // Socket died - clear the question state
+        if case .waitingForAnswer(let ctx) = session.phase, ctx.toolUseId == toolUseId {
+            session.phase = .idle
         }
 
         sessions[sessionId] = session
@@ -1018,6 +1052,15 @@ actor SessionStore {
     func hasActivePermission(sessionId: String) -> Bool {
         guard let session = sessions[sessionId] else { return false }
         if case .waitingForApproval = session.phase {
+            return true
+        }
+        return false
+    }
+
+    /// Check if there's an active question for a session
+    func hasActiveQuestion(sessionId: String) -> Bool {
+        guard let session = sessions[sessionId] else { return false }
+        if case .waitingForAnswer = session.phase {
             return true
         }
         return false

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -137,6 +137,16 @@ actor SessionStore {
         if let pid = event.pid {
             let tree = ProcessTreeBuilder.shared.buildTree()
             session.isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: pid, tree: tree)
+
+            // Resolve terminal app if not already resolved (reuse the tree we just built)
+            if session.resolvedTerminal == nil {
+                session.resolvedTerminal = TerminalResolver.shared.resolve(claudePid: pid, tree: tree)
+                if let terminal = session.resolvedTerminal {
+                    Self.logger.debug("Resolved terminal: \(terminal.appInfo.displayName, privacy: .public) for session \(sessionId.prefix(8), privacy: .public)")
+                    // Update isInTmux from resolved terminal (more accurate)
+                    session.isInTmux = terminal.isInTmux
+                }
+            }
         }
         if let tty = event.tty {
             session.tty = tty.replacingOccurrences(of: "/dev/", with: "")

--- a/ClaudeIsland/Services/Window/TerminalResolver.swift
+++ b/ClaudeIsland/Services/Window/TerminalResolver.swift
@@ -22,6 +22,9 @@ struct ResolvedTerminal: Sendable, Equatable {
 
     /// Whether the session is inside tmux
     let isInTmux: Bool
+
+    /// Cached TTY device path (e.g. "/dev/ttys003") to avoid rebuilding the process tree on each jump
+    let tty: String?
 }
 
 /// Resolves which terminal application owns a Claude session
@@ -39,18 +42,24 @@ struct TerminalResolver: Sendable {
 
     /// Resolve terminal using a pre-built process tree (avoids duplicate sysctl calls)
     nonisolated func resolve(claudePid: Int, tree: [Int: ProcessInfo]) -> ResolvedTerminal? {
+        // Fetch running apps once for the entire resolve chain (single DispatchQueue.main.sync)
+        let apps = Self.getRunningApps()
 
         // Check if in tmux
         let isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: claudePid, tree: tree)
 
+        // Find TTY from the tree (cache it so we don't rebuild on each jump)
+        let tty = ProcessTreeBuilder.shared.findTTY(forPid: claudePid, tree: tree)
+
         // Walk up process tree to find terminal app
         if let appInfo = TerminalAppRegistry.appInfo(forPid: claudePid, tree: tree) {
             // Verify the app is actually running and get its bundle ID
-            if let bundleId = findRunningBundleId(for: appInfo) {
+            if let bundleId = findRunningBundleId(for: appInfo, apps: apps) {
                 return ResolvedTerminal(
                     appInfo: appInfo,
                     bundleId: bundleId,
-                    isInTmux: isInTmux
+                    isInTmux: isInTmux,
+                    tty: tty
                 )
             }
         }
@@ -58,24 +67,25 @@ struct TerminalResolver: Sendable {
         // If we're in tmux, the terminal might not be a direct parent.
         // Try to find it via tmux client PID.
         if isInTmux {
-            return resolveViaTmuxClient(claudePid: claudePid, tree: tree)
+            return resolveViaTmuxClient(claudePid: claudePid, tree: tree, tty: tty, apps: apps)
         }
 
         // Last resort: check running applications against known terminals
-        return resolveFromRunningApps()
+        return resolveFromRunningApps(tty: tty, apps: apps)
     }
 
     /// Resolve terminal using TTY (when PID is not available)
     nonisolated func resolve(tty: String) -> ResolvedTerminal? {
         // Parse TTY to find a PID associated with it
         let tree = ProcessTreeBuilder.shared.buildTree()
+        let apps = Self.getRunningApps()
 
         // Find processes on this TTY
         for (pid, info) in tree {
             guard let processTTY = info.tty else { continue }
             if tty.hasSuffix(processTTY) || processTTY == tty {
                 // Found a process on this TTY, resolve from here
-                if let resolved = resolveFromTree(pid: pid, tree: tree) {
+                if let resolved = resolveFromTree(pid: pid, tree: tree, apps: apps) {
                     return resolved
                 }
             }
@@ -87,15 +97,17 @@ struct TerminalResolver: Sendable {
     // MARK: - Private
 
     /// Walk up from a PID in a pre-built tree
-    private nonisolated func resolveFromTree(pid: Int, tree: [Int: ProcessInfo]) -> ResolvedTerminal? {
+    private nonisolated func resolveFromTree(pid: Int, tree: [Int: ProcessInfo], apps: [NSRunningApplication]) -> ResolvedTerminal? {
         let isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: pid, tree: tree)
+        let tty = ProcessTreeBuilder.shared.findTTY(forPid: pid, tree: tree)
 
         if let appInfo = TerminalAppRegistry.appInfo(forPid: pid, tree: tree),
-           let bundleId = findRunningBundleId(for: appInfo) {
+           let bundleId = findRunningBundleId(for: appInfo, apps: apps) {
             return ResolvedTerminal(
                 appInfo: appInfo,
                 bundleId: bundleId,
-                isInTmux: isInTmux
+                isInTmux: isInTmux,
+                tty: tty
             )
         }
 
@@ -103,7 +115,17 @@ struct TerminalResolver: Sendable {
     }
 
     /// Try to find the terminal via tmux client PID
-    private nonisolated func resolveViaTmuxClient(claudePid: Int, tree: [Int: ProcessInfo]) -> ResolvedTerminal? {
+    ///
+    /// tmux process model:
+    ///   Terminal → shell → tmux (client) --[socket]--> tmux (server) → shell → claude
+    ///
+    /// The client's ppid is the shell that launched it, NOT the server.
+    /// The server's children are pane shells, NOT clients.
+    /// So we match tmux processes by name (hasPrefix("tmux")) excluding the server PID,
+    /// then walk up from each candidate to find a terminal app in its ancestry.
+    /// The terminal-in-ancestry check naturally filters out the server's child panes
+    /// (which have shells, not terminals, as ancestors).
+    private nonisolated func resolveViaTmuxClient(claudePid: Int, tree: [Int: ProcessInfo], tty: String?, apps: [NSRunningApplication]) -> ResolvedTerminal? {
         // Find tmux server in the parent chain
         var current = claudePid
         var depth = 0
@@ -121,20 +143,24 @@ struct TerminalResolver: Sendable {
 
         guard let serverPid = tmuxServerPid else { return nil }
 
-        // Find tmux client processes (children of the server, or siblings)
-        // tmux clients are separate processes that connect to the server
+        // Find tmux client processes.
+        // Clients connect to the server via socket — they are NOT children of the server.
+        // We identify candidates by: tmux process name + not the server itself.
+        // The appInfo(forPid:) walk-up ensures we only match processes that have a
+        // terminal app in their ancestry (filtering out server child panes).
         for (pid, info) in tree {
-            // Look for tmux client processes
-            if info.command.lowercased().contains("tmux") && pid != serverPid {
-                // Walk up from this client to find the terminal
-                if let appInfo = TerminalAppRegistry.appInfo(forPid: pid, tree: tree),
-                   let bundleId = findRunningBundleId(for: appInfo) {
-                    return ResolvedTerminal(
-                        appInfo: appInfo,
-                        bundleId: bundleId,
-                        isInTmux: true
-                    )
-                }
+            guard pid != serverPid,
+                  info.command.lowercased().hasPrefix("tmux") else { continue }
+
+            // Walk up from this candidate to find a terminal app
+            if let appInfo = TerminalAppRegistry.appInfo(forPid: pid, tree: tree),
+               let bundleId = findRunningBundleId(for: appInfo, apps: apps) {
+                return ResolvedTerminal(
+                    appInfo: appInfo,
+                    bundleId: bundleId,
+                    isInTmux: true,
+                    tty: tty
+                )
             }
         }
 
@@ -144,11 +170,10 @@ struct TerminalResolver: Sendable {
     /// Fallback: check all running apps for known terminals.
     /// Only returns a result if exactly one terminal app is running,
     /// otherwise we can't determine which terminal owns this session.
-    private nonisolated func resolveFromRunningApps() -> ResolvedTerminal? {
-        let runningApps = NSWorkspace.shared.runningApplications
+    private nonisolated func resolveFromRunningApps(tty: String? = nil, apps: [NSRunningApplication]) -> ResolvedTerminal? {
         var matches: [(appInfo: TerminalAppInfo, bundleId: String)] = []
 
-        for app in runningApps {
+        for app in apps {
             guard let bundleId = app.bundleIdentifier,
                   let appInfo = TerminalAppRegistry.appInfo(forBundleId: bundleId) else {
                 continue
@@ -164,18 +189,30 @@ struct TerminalResolver: Sendable {
         return ResolvedTerminal(
             appInfo: match.appInfo,
             bundleId: match.bundleId,
-            isInTmux: false
+            isInTmux: false,
+            tty: tty
         )
     }
 
     /// Find the bundle ID of a running instance for a terminal app
-    private nonisolated func findRunningBundleId(for appInfo: TerminalAppInfo) -> String? {
-        let runningApps = NSWorkspace.shared.runningApplications
+    private nonisolated func findRunningBundleId(for appInfo: TerminalAppInfo, apps: [NSRunningApplication]) -> String? {
         for bundleId in appInfo.bundleIds {
-            if runningApps.contains(where: { $0.bundleIdentifier == bundleId }) {
+            if apps.contains(where: { $0.bundleIdentifier == bundleId }) {
                 return bundleId
             }
         }
         return nil
     }
+
+    /// Access NSWorkspace.shared.runningApplications safely from the main thread.
+    /// NSWorkspace APIs should be called on the main thread.
+    private nonisolated static func getRunningApps() -> [NSRunningApplication] {
+        if Thread.isMainThread {
+            return NSWorkspace.shared.runningApplications
+        }
+        return DispatchQueue.main.sync {
+            NSWorkspace.shared.runningApplications
+        }
+    }
+
 }

--- a/ClaudeIsland/Services/Window/TerminalResolver.swift
+++ b/ClaudeIsland/Services/Window/TerminalResolver.swift
@@ -1,0 +1,181 @@
+//
+//  TerminalResolver.swift
+//  ClaudeIsland
+//
+//  Resolves which terminal application a Claude session is running in.
+//  Uses process tree walking + NSWorkspace to identify the terminal app.
+//
+
+import AppKit
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.claudeisland", category: "TerminalResolver")
+
+/// Resolved terminal information for a session
+struct ResolvedTerminal: Sendable, Equatable {
+    /// The terminal application type
+    let appInfo: TerminalAppInfo
+
+    /// The running application's bundle ID (verified running)
+    let bundleId: String
+
+    /// Whether the session is inside tmux
+    let isInTmux: Bool
+}
+
+/// Resolves which terminal application owns a Claude session
+struct TerminalResolver: Sendable {
+    nonisolated static let shared = TerminalResolver()
+
+    private nonisolated init() {}
+
+    /// Resolve terminal for a Claude session by PID
+    /// Walks up the process tree to find the terminal app, then verifies it's running
+    nonisolated func resolve(claudePid: Int) -> ResolvedTerminal? {
+        let tree = ProcessTreeBuilder.shared.buildTree()
+        return resolve(claudePid: claudePid, tree: tree)
+    }
+
+    /// Resolve terminal using a pre-built process tree (avoids duplicate sysctl calls)
+    nonisolated func resolve(claudePid: Int, tree: [Int: ProcessInfo]) -> ResolvedTerminal? {
+
+        // Check if in tmux
+        let isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: claudePid, tree: tree)
+
+        // Walk up process tree to find terminal app
+        if let appInfo = TerminalAppRegistry.appInfo(forPid: claudePid, tree: tree) {
+            // Verify the app is actually running and get its bundle ID
+            if let bundleId = findRunningBundleId(for: appInfo) {
+                return ResolvedTerminal(
+                    appInfo: appInfo,
+                    bundleId: bundleId,
+                    isInTmux: isInTmux
+                )
+            }
+        }
+
+        // If we're in tmux, the terminal might not be a direct parent.
+        // Try to find it via tmux client PID.
+        if isInTmux {
+            return resolveViaTmuxClient(claudePid: claudePid, tree: tree)
+        }
+
+        // Last resort: check running applications against known terminals
+        return resolveFromRunningApps()
+    }
+
+    /// Resolve terminal using TTY (when PID is not available)
+    nonisolated func resolve(tty: String) -> ResolvedTerminal? {
+        // Parse TTY to find a PID associated with it
+        let tree = ProcessTreeBuilder.shared.buildTree()
+
+        // Find processes on this TTY
+        for (pid, info) in tree {
+            guard let processTTY = info.tty else { continue }
+            if tty.hasSuffix(processTTY) || processTTY == tty {
+                // Found a process on this TTY, resolve from here
+                if let resolved = resolveFromTree(pid: pid, tree: tree) {
+                    return resolved
+                }
+            }
+        }
+
+        return nil
+    }
+
+    // MARK: - Private
+
+    /// Walk up from a PID in a pre-built tree
+    private nonisolated func resolveFromTree(pid: Int, tree: [Int: ProcessInfo]) -> ResolvedTerminal? {
+        let isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: pid, tree: tree)
+
+        if let appInfo = TerminalAppRegistry.appInfo(forPid: pid, tree: tree),
+           let bundleId = findRunningBundleId(for: appInfo) {
+            return ResolvedTerminal(
+                appInfo: appInfo,
+                bundleId: bundleId,
+                isInTmux: isInTmux
+            )
+        }
+
+        return nil
+    }
+
+    /// Try to find the terminal via tmux client PID
+    private nonisolated func resolveViaTmuxClient(claudePid: Int, tree: [Int: ProcessInfo]) -> ResolvedTerminal? {
+        // Find tmux server in the parent chain
+        var current = claudePid
+        var depth = 0
+        var tmuxServerPid: Int?
+
+        while current > 1 && depth < 20 {
+            guard let info = tree[current] else { break }
+            if info.command.lowercased().contains("tmux") {
+                tmuxServerPid = current
+                break
+            }
+            current = info.ppid
+            depth += 1
+        }
+
+        guard let serverPid = tmuxServerPid else { return nil }
+
+        // Find tmux client processes (children of the server, or siblings)
+        // tmux clients are separate processes that connect to the server
+        for (pid, info) in tree {
+            // Look for tmux client processes
+            if info.command.lowercased().contains("tmux") && pid != serverPid {
+                // Walk up from this client to find the terminal
+                if let appInfo = TerminalAppRegistry.appInfo(forPid: pid, tree: tree),
+                   let bundleId = findRunningBundleId(for: appInfo) {
+                    return ResolvedTerminal(
+                        appInfo: appInfo,
+                        bundleId: bundleId,
+                        isInTmux: true
+                    )
+                }
+            }
+        }
+
+        return nil
+    }
+
+    /// Fallback: check all running apps for known terminals.
+    /// Only returns a result if exactly one terminal app is running,
+    /// otherwise we can't determine which terminal owns this session.
+    private nonisolated func resolveFromRunningApps() -> ResolvedTerminal? {
+        let runningApps = NSWorkspace.shared.runningApplications
+        var matches: [(appInfo: TerminalAppInfo, bundleId: String)] = []
+
+        for app in runningApps {
+            guard let bundleId = app.bundleIdentifier,
+                  let appInfo = TerminalAppRegistry.appInfo(forBundleId: bundleId) else {
+                continue
+            }
+            matches.append((appInfo: appInfo, bundleId: bundleId))
+        }
+
+        // Only return if exactly one terminal is running — ambiguous otherwise
+        guard matches.count == 1, let match = matches.first else {
+            return nil
+        }
+
+        return ResolvedTerminal(
+            appInfo: match.appInfo,
+            bundleId: match.bundleId,
+            isInTmux: false
+        )
+    }
+
+    /// Find the bundle ID of a running instance for a terminal app
+    private nonisolated func findRunningBundleId(for appInfo: TerminalAppInfo) -> String? {
+        let runningApps = NSWorkspace.shared.runningApplications
+        for bundleId in appInfo.bundleIds {
+            if runningApps.contains(where: { $0.bundleIdentifier == bundleId }) {
+                return bundleId
+            }
+        }
+        return nil
+    }
+}

--- a/ClaudeIsland/Services/Window/WindowFocuser.swift
+++ b/ClaudeIsland/Services/Window/WindowFocuser.swift
@@ -25,31 +25,35 @@ actor WindowFocuser {
     /// Focus a terminal window by its bundle ID.
     /// This is the main entry point — works without yabai.
     func focusTerminalApp(bundleId: String) async -> Bool {
-        guard let app = NSWorkspace.shared.runningApplications.first(where: {
-            $0.bundleIdentifier == bundleId
-        }) else {
-            logger.debug("No running app with bundle ID: \(bundleId, privacy: .public)")
-            return false
-        }
+        // NSWorkspace and NSRunningApplication APIs require the main thread
+        return await MainActor.run {
+            guard let app = NSWorkspace.shared.runningApplications.first(where: {
+                $0.bundleIdentifier == bundleId
+            }) else {
+                logger.debug("No running app with bundle ID: \(bundleId, privacy: .public)")
+                return false
+            }
 
-        let activated = app.activate()
-        if activated {
-            logger.info("Activated app: \(bundleId, privacy: .public)")
-        } else {
-            logger.warning("Failed to activate app: \(bundleId, privacy: .public)")
+            let activated = app.activate()
+            if activated {
+                logger.info("Activated app: \(bundleId, privacy: .public)")
+            } else {
+                logger.warning("Failed to activate app: \(bundleId, privacy: .public)")
+            }
+            return activated
         }
-        return activated
     }
 
     /// Focus a terminal and try to target the correct tab/pane
     /// Strategy: AppleScript tab targeting → tmux pane switch → app activate fallback
-    func focusTerminal(info: TerminalAppInfo, sessionPid: Int?) async -> Bool {
+    func focusTerminal(info: TerminalAppInfo, sessionPid: Int?, cachedTTY: String? = nil) async -> Bool {
         // Step 1: Try AppleScript tab/pane targeting if supported and we have a PID
         if let pid = sessionPid, info.supportsTabFocus {
             let tabFocused = await focusTabByAppleScript(
                 terminalType: info.type,
                 bundleId: info.bundleIds.first ?? "",
-                claudePid: pid
+                claudePid: pid,
+                cachedTTY: cachedTTY
             )
             if tabFocused {
                 return true
@@ -60,12 +64,13 @@ actor WindowFocuser {
         if let pid = sessionPid {
             let tmuxFocused = await focusTmuxPane(claudePid: pid)
             if tmuxFocused {
-                // Also activate the terminal app window
+                // Also activate the terminal app window (best-effort, tmux pane already switched)
                 for bundleId in info.bundleIds {
                     if await focusTerminalApp(bundleId: bundleId) {
-                        return true
+                        break
                     }
                 }
+                return true
             }
         }
 
@@ -126,13 +131,14 @@ actor WindowFocuser {
     private func focusTabByAppleScript(
         terminalType: TerminalType,
         bundleId: String,
-        claudePid: Int
+        claudePid: Int,
+        cachedTTY: String? = nil
     ) async -> Bool {
         switch terminalType {
         case .terminalApp:
-            return await focusTerminalAppTab(claudePid: claudePid)
+            return await focusTerminalAppTab(claudePid: claudePid, cachedTTY: cachedTTY)
         case .iterm2:
-            return await focusITerm2Tab(claudePid: claudePid)
+            return await focusITerm2Tab(claudePid: claudePid, cachedTTY: cachedTTY)
         case .kitty:
             return await focusKittyWindow(claudePid: claudePid)
         default:
@@ -141,9 +147,9 @@ actor WindowFocuser {
     }
 
     /// Terminal.app: Find tab containing the Claude process's TTY
-    private func focusTerminalAppTab(claudePid: Int) async -> Bool {
-        // Find TTY for the Claude process
-        guard let tty = findTTY(forPid: claudePid) else {
+    private func focusTerminalAppTab(claudePid: Int, cachedTTY: String? = nil) async -> Bool {
+        // Use cached TTY if available, otherwise look it up (rebuilds process tree)
+        guard let tty = cachedTTY ?? findTTY(forPid: claudePid) else {
             logger.debug("No TTY found for pid \(claudePid)")
             return false
         }
@@ -171,9 +177,9 @@ actor WindowFocuser {
     }
 
     /// iTerm2: Find session containing the Claude process via TTY matching
-    private func focusITerm2Tab(claudePid: Int) async -> Bool {
-        let tty = findTTY(forPid: claudePid)
-        guard let ttyName = tty else {
+    private func focusITerm2Tab(claudePid: Int, cachedTTY: String? = nil) async -> Bool {
+        // Use cached TTY if available, otherwise look it up
+        guard let ttyName = cachedTTY ?? findTTY(forPid: claudePid) else {
             logger.debug("No TTY found for iTerm2 tab focus, pid \(claudePid)")
             return false
         }
@@ -232,22 +238,10 @@ actor WindowFocuser {
             .replacingOccurrences(of: "\"", with: "\\\"")
     }
 
-    /// Find TTY for a given PID by walking up the process tree
+    /// Find TTY for a given PID by walking up the process tree (fallback when no cached TTY)
     private nonisolated func findTTY(forPid pid: Int) -> String? {
         let tree = ProcessTreeBuilder.shared.buildTree()
-        var current = pid
-        var depth = 0
-
-        while current > 1 && depth < 20 {
-            guard let info = tree[current] else { break }
-            if let tty = info.tty {
-                return "/dev/\(tty)"
-            }
-            current = info.ppid
-            depth += 1
-        }
-
-        return nil
+        return ProcessTreeBuilder.shared.findTTY(forPid: pid, tree: tree)
     }
 
     /// Run an AppleScript and return whether it succeeded

--- a/ClaudeIsland/Services/Window/WindowFocuser.swift
+++ b/ClaudeIsland/Services/Window/WindowFocuser.swift
@@ -2,18 +2,86 @@
 //  WindowFocuser.swift
 //  ClaudeIsland
 //
-//  Focuses windows using yabai
+//  Focuses terminal windows using multiple strategies:
+//  1. NSWorkspace (works everywhere, app-level)
+//  2. AppleScript/JXA (tab/pane level for supported terminals)
+//  3. yabai (window-level for tiling WM users)
 //
 
+import AppKit
 import Foundation
+import os.log
 
-/// Focuses windows using yabai
+private let logger = Logger(subsystem: "com.claudeisland", category: "WindowFocuser")
+
+/// Focuses windows using multiple strategies
 actor WindowFocuser {
     static let shared = WindowFocuser()
 
     private init() {}
 
-    /// Focus a window by ID
+    // MARK: - Primary API
+
+    /// Focus a terminal window by its bundle ID.
+    /// This is the main entry point — works without yabai.
+    func focusTerminalApp(bundleId: String) async -> Bool {
+        guard let app = NSWorkspace.shared.runningApplications.first(where: {
+            $0.bundleIdentifier == bundleId
+        }) else {
+            logger.debug("No running app with bundle ID: \(bundleId, privacy: .public)")
+            return false
+        }
+
+        let activated = app.activate()
+        if activated {
+            logger.info("Activated app: \(bundleId, privacy: .public)")
+        } else {
+            logger.warning("Failed to activate app: \(bundleId, privacy: .public)")
+        }
+        return activated
+    }
+
+    /// Focus a terminal and try to target the correct tab/pane
+    /// Strategy: AppleScript tab targeting → tmux pane switch → app activate fallback
+    func focusTerminal(info: TerminalAppInfo, sessionPid: Int?) async -> Bool {
+        // Step 1: Try AppleScript tab/pane targeting if supported and we have a PID
+        if let pid = sessionPid, info.supportsTabFocus {
+            let tabFocused = await focusTabByAppleScript(
+                terminalType: info.type,
+                bundleId: info.bundleIds.first ?? "",
+                claudePid: pid
+            )
+            if tabFocused {
+                return true
+            }
+        }
+
+        // Step 2: Try tmux pane targeting if we have a PID
+        if let pid = sessionPid {
+            let tmuxFocused = await focusTmuxPane(claudePid: pid)
+            if tmuxFocused {
+                // Also activate the terminal app window
+                for bundleId in info.bundleIds {
+                    if await focusTerminalApp(bundleId: bundleId) {
+                        return true
+                    }
+                }
+            }
+        }
+
+        // Step 3: Fallback — just activate the app
+        for bundleId in info.bundleIds {
+            if await focusTerminalApp(bundleId: bundleId) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    // MARK: - yabai (existing)
+
+    /// Focus a window by yabai window ID
     func focusWindow(id: Int) async -> Bool {
         guard let yabaiPath = await WindowFinder.shared.getYabaiPath() else { return false }
 
@@ -27,7 +95,7 @@ actor WindowFocuser {
         }
     }
 
-    /// Focus the tmux window for a terminal
+    /// Focus the tmux window for a terminal (yabai path)
     func focusTmuxWindow(terminalPid: Int, windows: [YabaiWindow]) async -> Bool {
         // Try to find actual tmux window
         if let tmuxWindow = WindowFinder.shared.findTmuxWindow(forTerminalPid: terminalPid, windows: windows) {
@@ -40,5 +108,164 @@ actor WindowFocuser {
         }
 
         return false
+    }
+
+    // MARK: - tmux pane targeting
+
+    /// Switch to the tmux pane containing a Claude process
+    private func focusTmuxPane(claudePid: Int) async -> Bool {
+        guard let target = await TmuxController.shared.findTmuxTarget(forClaudePid: claudePid) else {
+            return false
+        }
+        return await TmuxController.shared.switchToPane(target: target)
+    }
+
+    // MARK: - AppleScript tab targeting
+
+    /// Focus a specific tab in a terminal app using AppleScript
+    private func focusTabByAppleScript(
+        terminalType: TerminalType,
+        bundleId: String,
+        claudePid: Int
+    ) async -> Bool {
+        switch terminalType {
+        case .terminalApp:
+            return await focusTerminalAppTab(claudePid: claudePid)
+        case .iterm2:
+            return await focusITerm2Tab(claudePid: claudePid)
+        case .kitty:
+            return await focusKittyWindow(claudePid: claudePid)
+        default:
+            return false
+        }
+    }
+
+    /// Terminal.app: Find tab containing the Claude process's TTY
+    private func focusTerminalAppTab(claudePid: Int) async -> Bool {
+        // Find TTY for the Claude process
+        guard let tty = findTTY(forPid: claudePid) else {
+            logger.debug("No TTY found for pid \(claudePid)")
+            return false
+        }
+
+        let escapedTTY = escapeForAppleScript(tty)
+
+        let script = """
+        tell application "Terminal"
+            activate
+            set targetTTY to "\(escapedTTY)"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    if tty of t is targetTTY then
+                        set selected tab of w to t
+                        set index of w to 1
+                        return true
+                    end if
+                end repeat
+            end repeat
+        end tell
+        return false
+        """
+
+        return await runAppleScript(script)
+    }
+
+    /// iTerm2: Find session containing the Claude process via TTY matching
+    private func focusITerm2Tab(claudePid: Int) async -> Bool {
+        let tty = findTTY(forPid: claudePid)
+        guard let ttyName = tty else {
+            logger.debug("No TTY found for iTerm2 tab focus, pid \(claudePid)")
+            return false
+        }
+
+        let escapedTTY = escapeForAppleScript(ttyName)
+
+        let script = """
+        tell application "iTerm2"
+            activate
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        if tty of s is "\(escapedTTY)" then
+                            select t
+                            select s
+                            return true
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+        end tell
+        return false
+        """
+
+        return await runAppleScript(script)
+    }
+
+    /// Kitty: Use remote control protocol for window focus
+    private func focusKittyWindow(claudePid: Int) async -> Bool {
+        let kittyPaths = ["/opt/homebrew/bin/kitty", "/usr/local/bin/kitty"]
+        for kittyPath in kittyPaths {
+            guard FileManager.default.isExecutableFile(atPath: kittyPath) else { continue }
+
+            let result = await ProcessExecutor.shared.runWithResult(kittyPath, arguments: [
+                "@", "focus-window", "--match", "pid:\(claudePid)"
+            ])
+            switch result {
+            case .success(let output) where output.isSuccess:
+                return true
+            case .success(let output):
+                logger.debug("Kitty remote control exited with code \(output.exitCode)")
+            case .failure(let error):
+                logger.debug("Kitty remote control failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        return false
+    }
+
+    // MARK: - Helpers
+
+    /// Escape a string for safe interpolation into AppleScript string literals.
+    /// Prevents injection via crafted TTY paths containing `"` or `\`.
+    private nonisolated func escapeForAppleScript(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    /// Find TTY for a given PID by walking up the process tree
+    private nonisolated func findTTY(forPid pid: Int) -> String? {
+        let tree = ProcessTreeBuilder.shared.buildTree()
+        var current = pid
+        var depth = 0
+
+        while current > 1 && depth < 20 {
+            guard let info = tree[current] else { break }
+            if let tty = info.tty {
+                return "/dev/\(tty)"
+            }
+            current = info.ppid
+            depth += 1
+        }
+
+        return nil
+    }
+
+    /// Run an AppleScript and return whether it succeeded
+    private func runAppleScript(_ source: String) async -> Bool {
+        // Use osascript for AppleScript execution
+        do {
+            let result = await ProcessExecutor.shared.runWithResult(
+                "/usr/bin/osascript",
+                arguments: ["-e", source]
+            )
+            switch result {
+            case .success(let output):
+                let trimmed = output.output.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed == "true"
+            case .failure(let error):
+                logger.debug("AppleScript failed: \(error.localizedDescription, privacy: .public)")
+                return false
+            }
+        }
     }
 }

--- a/ClaudeIsland/Services/Window/YabaiController.swift
+++ b/ClaudeIsland/Services/Window/YabaiController.swift
@@ -95,8 +95,7 @@ actor YabaiController {
 
     /// Check if command is a terminal (nonisolated helper to avoid MainActor access)
     private nonisolated func isTerminalProcess(_ command: String) -> Bool {
-        let terminalCommands = ["Terminal", "iTerm", "iTerm2", "Alacritty", "kitty", "WezTerm", "wezterm-gui", "Hyper"]
-        return terminalCommands.contains { command.contains($0) }
+        TerminalAppRegistry.isTerminal(command)
     }
 
     private func focusTmuxPane(forWorkingDir workingDir: String, tree: [Int: ProcessInfo], windows: [YabaiWindow]) async -> Bool {

--- a/ClaudeIsland/UI/Components/CommandHighlightView.swift
+++ b/ClaudeIsland/UI/Components/CommandHighlightView.swift
@@ -1,0 +1,129 @@
+//
+//  CommandHighlightView.swift
+//  ClaudeIsland
+//
+//  Renders Bash commands with syntax highlighting.
+//  Dangerous commands (rm -rf, sudo, etc.) are highlighted in red.
+//
+
+import SwiftUI
+
+struct CommandHighlightView: View {
+    let command: String
+
+    /// Cached dangerous flag — computed once at init, not per render
+    let isDangerous: Bool
+
+    /// Dangerous command patterns that warrant a red warning
+    private static let dangerousPatterns: [String] = [
+        "rm -rf",
+        "rm -r /",
+        "rm -f /",
+        "sudo ",
+        "chmod 777",
+        "chmod -R 777",
+        "mkfs",
+        "dd if=",
+        ":> /",
+        "> /dev/",
+        "shutdown",
+        "reboot",
+        "kill -9",
+        "killall",
+        "pkill",
+        "format ",
+        "fdisk",
+    ]
+
+    /// Per-line danger cache: true if that line contains a dangerous pattern
+    private let lineDangerFlags: [Bool]
+
+    init(command: String) {
+        self.command = command
+
+        let lines = command.components(separatedBy: "\n")
+        let flags = lines.map { line in
+            Self.dangerousPatterns.contains { pattern in
+                line.localizedCaseInsensitiveContains(pattern)
+            }
+        }
+        self.lineDangerFlags = flags
+        self.isDangerous = flags.contains(true)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            header
+
+            // Command content
+            ScrollView(.horizontal, showsIndicators: false) {
+                commandText
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+            }
+            .frame(maxHeight: 80)
+        }
+        .background(Color.black.opacity(0.3))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "terminal")
+                .font(.system(size: 9))
+                .foregroundColor(TerminalColors.dim)
+
+            Text("Bash")
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundColor(.white.opacity(0.7))
+
+            Spacer()
+
+            if isDangerous {
+                HStack(spacing: 3) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 8))
+                    Text("Dangerous")
+                        .font(.system(size: 9, weight: .semibold))
+                }
+                .foregroundColor(TerminalColors.red)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(isDangerous ? TerminalColors.red.opacity(0.06) : Color.white.opacity(0.04))
+    }
+
+    // MARK: - Command Rendering
+
+    private var commandText: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(Array(zip(commandLines.indices, commandLines)), id: \.0) { index, line in
+                highlightedLine(line, isDangerousLine: lineDangerFlags[index])
+            }
+        }
+    }
+
+    private var commandLines: [String] {
+        command.components(separatedBy: "\n")
+    }
+
+    private func highlightedLine(_ line: String, isDangerousLine: Bool) -> some View {
+        HStack(spacing: 0) {
+            // Prompt symbol
+            Text("$")
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundColor(TerminalColors.dim)
+                .padding(.trailing, 4)
+
+            // Code content — red if dangerous, normal otherwise
+            Text(line)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(isDangerousLine ? TerminalColors.red : .white.opacity(0.8))
+                .lineLimit(nil)
+        }
+    }
+}

--- a/ClaudeIsland/UI/Components/CommandHighlightView.swift
+++ b/ClaudeIsland/UI/Components/CommandHighlightView.swift
@@ -25,7 +25,6 @@ struct CommandHighlightView: View {
         "mkfs",
         "dd if=",
         ":> /",
-        "> /dev/",
         "shutdown",
         "reboot",
         "kill -9",
@@ -35,6 +34,53 @@ struct CommandHighlightView: View {
         "fdisk",
     ]
 
+    /// Safe /dev/ directory prefixes — these are virtual/pseudo filesystems, not block devices.
+    /// Matches exact name (e.g. "fd") or subdirectory path (e.g. "fd/3").
+    private static let safeDevPrefixes = ["pts", "fd", "shm"]
+
+    /// Safe /dev/ targets that should NOT trigger the dangerous redirect warning.
+    /// Anything redirected to /dev/ that isn't in this list is flagged.
+    private static let safeDevTargets: Set<String> = [
+        "null", "zero", "random", "urandom",
+        "stdin", "stdout", "stderr",
+        "tty", "console", "full",
+    ]
+
+    /// Redirect patterns to /dev/ — covers both `> /dev/` (with space) and `>/dev/` (no space)
+    private static let devRedirectPatterns = ["> /dev/", ">/dev/"]
+
+    /// Check if a line contains a dangerous redirect to /dev/ (block devices, etc.)
+    /// Matches `> /dev/X` and `>/dev/X` but excludes known-safe targets like /dev/null, /dev/zero.
+    private static func hasDangerousDevRedirect(_ line: String) -> Bool {
+        let lowered = line.lowercased()
+        for pattern in devRedirectPatterns {
+            var searchRange = lowered.startIndex..<lowered.endIndex
+            while let range = lowered.range(of: pattern, range: searchRange) {
+                let afterPrefix = range.upperBound
+                guard afterPrefix < lowered.endIndex else {
+                    // "> /dev/" at end of line — suspicious, flag it
+                    return true
+                }
+                // Extract the device name (chars until whitespace, quote, or end)
+                let rest = lowered[afterPrefix...]
+                let deviceName = String(rest.prefix(while: { !$0.isWhitespace && $0 != "\"" && $0 != "'" && $0 != ";" && $0 != "|" && $0 != "&" }))
+                // Check safe directory prefixes (pts, fd, shm) — exact name or subdirectory
+                let isSafePrefix = safeDevPrefixes.contains { prefix in
+                    deviceName == prefix || deviceName.hasPrefix("\(prefix)/")
+                }
+                if isSafePrefix {
+                    // safe — skip
+                } else if safeDevTargets.contains(deviceName) {
+                    // safe — skip
+                } else {
+                    return true
+                }
+                searchRange = range.upperBound..<lowered.endIndex
+            }
+        }
+        return false
+    }
+
     /// Per-line danger cache: true if that line contains a dangerous pattern
     private let lineDangerFlags: [Bool]
 
@@ -43,9 +89,10 @@ struct CommandHighlightView: View {
 
         let lines = command.components(separatedBy: "\n")
         let flags = lines.map { line in
-            Self.dangerousPatterns.contains { pattern in
-                line.localizedCaseInsensitiveContains(pattern)
+            let matchesPattern = Self.dangerousPatterns.contains { pattern in
+                line.range(of: pattern, options: .caseInsensitive) != nil
             }
+            return matchesPattern || Self.hasDangerousDevRedirect(line)
         }
         self.lineDangerFlags = flags
         self.isDangerous = flags.contains(true)
@@ -102,7 +149,7 @@ struct CommandHighlightView: View {
     private var commandText: some View {
         VStack(alignment: .leading, spacing: 2) {
             ForEach(Array(zip(commandLines.indices, commandLines)), id: \.0) { index, line in
-                highlightedLine(line, isDangerousLine: lineDangerFlags[index])
+                highlightedLine(line, isDangerousLine: lineDangerFlags[index], isFirstLine: index == 0)
             }
         }
     }
@@ -111,10 +158,10 @@ struct CommandHighlightView: View {
         command.components(separatedBy: "\n")
     }
 
-    private func highlightedLine(_ line: String, isDangerousLine: Bool) -> some View {
+    private func highlightedLine(_ line: String, isDangerousLine: Bool, isFirstLine: Bool) -> some View {
         HStack(spacing: 0) {
-            // Prompt symbol
-            Text("$")
+            // Prompt symbol: $ for first line, > for continuation lines
+            Text(isFirstLine ? "$" : ">")
                 .font(.system(size: 10, weight: .medium, design: .monospaced))
                 .foregroundColor(TerminalColors.dim)
                 .padding(.trailing, 4)

--- a/ClaudeIsland/UI/Components/DiffView.swift
+++ b/ClaudeIsland/UI/Components/DiffView.swift
@@ -190,11 +190,20 @@ struct ApprovalDiffView: View {
 
     // MARK: - Diff Computation
 
+    /// Maximum LCS complexity budget (m × n). Beyond this, fall back to simple diff
+    /// to avoid O(m×n) memory and CPU cost. 40_000 ≈ 200×200.
+    private static let lcsComplexityLimit = 40_000
+
     /// Compute diff for Edit tool (old_string → new_string) with line-level comparison.
-    /// Uses a simple LCS-based approach: identical lines become context, others are removed/added.
+    /// Uses LCS for small inputs; falls back to simple diff for large inputs.
     private static func computeEditDiff(old: String, new: String) -> [DiffLine] {
         let oldLines = old.components(separatedBy: "\n")
         let newLines = new.components(separatedBy: "\n")
+
+        // Guard against O(m×n) blowup — check actual complexity, not just line count
+        if oldLines.count * newLines.count > lcsComplexityLimit {
+            return computeSimpleDiff(oldLines: oldLines, newLines: newLines)
+        }
 
         // Compute LCS table
         let lcs = computeLCS(oldLines, newLines)
@@ -255,6 +264,29 @@ struct ApprovalDiffView: View {
         }
 
         return table
+    }
+
+    /// Simple fallback diff: all old lines removed, all new lines added.
+    /// Used when input exceeds the LCS threshold.
+    private static func computeSimpleDiff(oldLines: [String], newLines: [String]) -> [DiffLine] {
+        var result: [DiffLine] = []
+        var lineId = 0
+
+        for (i, line) in oldLines.enumerated() {
+            result.append(DiffLine(
+                id: lineId, kind: .removed, text: line,
+                oldLineNumber: i + 1, newLineNumber: nil
+            ))
+            lineId += 1
+        }
+        for (i, line) in newLines.enumerated() {
+            result.append(DiffLine(
+                id: lineId, kind: .added, text: line,
+                oldLineNumber: nil, newLineNumber: i + 1
+            ))
+            lineId += 1
+        }
+        return result
     }
 
     /// Compute diff for Write tool (all lines are additions)

--- a/ClaudeIsland/UI/Components/DiffView.swift
+++ b/ClaudeIsland/UI/Components/DiffView.swift
@@ -1,0 +1,273 @@
+//
+//  DiffView.swift
+//  ClaudeIsland
+//
+//  Renders code diffs with red/green line highlighting
+//  for Edit (old_string → new_string) and Write (new content) tools.
+//
+
+import SwiftUI
+
+/// Parsed diff line with its type
+struct DiffLine: Identifiable {
+    enum Kind { case context, added, removed }
+
+    let id: Int
+    let kind: Kind
+    let text: String
+    /// Line number in the old file (nil for added lines)
+    let oldLineNumber: Int?
+    /// Line number in the new file (nil for removed lines)
+    let newLineNumber: Int?
+}
+
+/// Statistics for a diff
+struct DiffStats {
+    let additions: Int
+    let deletions: Int
+}
+
+struct ApprovalDiffView: View {
+    let filePath: String
+
+    /// Precomputed diff lines (stored, not recomputed on every render)
+    let lines: [DiffLine]
+    /// Precomputed diff stats
+    let stats: DiffStats
+    /// Whether this is a Write (full file content) vs Edit (old → new)
+    let isWrite: Bool
+
+    init(filePath: String, oldString: String?, newString: String?) {
+        self.filePath = filePath
+        self.isWrite = (oldString == nil)
+
+        if let old = oldString, let new = newString {
+            self.lines = Self.computeEditDiff(old: old, new: new)
+        } else if let content = newString {
+            self.lines = Self.computeWriteDiff(content: content)
+        } else {
+            self.lines = []
+        }
+
+        let added = self.lines.filter { $0.kind == .added }.count
+        let removed = self.lines.filter { $0.kind == .removed }.count
+        self.stats = DiffStats(additions: added, deletions: removed)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header: file path + stats
+            header
+
+            // Diff lines
+            ScrollView(.vertical, showsIndicators: true) {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(lines) { line in
+                        diffLineView(line)
+                    }
+                }
+            }
+            .frame(maxHeight: 160)
+        }
+        .background(Color.black.opacity(0.3))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            // File icon
+            Image(systemName: isWrite ? "doc.badge.plus" : "pencil.line")
+                .font(.system(size: 9))
+                .foregroundColor(TerminalColors.dim)
+
+            // File path (just filename for compact display)
+            Text(fileName)
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundColor(.white.opacity(0.7))
+                .lineLimit(1)
+
+            Spacer()
+
+            // Stats badge
+            statsLabel
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(Color.white.opacity(0.04))
+    }
+
+    private var fileName: String {
+        (filePath as NSString).lastPathComponent
+    }
+
+    @ViewBuilder
+    private var statsLabel: some View {
+        HStack(spacing: 4) {
+            if stats.additions > 0 {
+                Text("+\(stats.additions)")
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundColor(TerminalColors.green)
+            }
+            if stats.deletions > 0 {
+                Text("-\(stats.deletions)")
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundColor(TerminalColors.red)
+            }
+        }
+    }
+
+    // MARK: - Line Rendering
+
+    private func diffLineView(_ line: DiffLine) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            // Gutter (line numbers)
+            gutter(line)
+
+            // Prefix (+/-/space)
+            Text(linePrefix(line))
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundColor(prefixColor(line))
+                .frame(width: 12, alignment: .center)
+
+            // Code content
+            Text(line.text)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(textColor(line))
+                .lineLimit(1)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 1)
+        .background(backgroundColor(line))
+    }
+
+    private func gutter(_ line: DiffLine) -> some View {
+        HStack(spacing: 0) {
+            Text(line.oldLineNumber.map { String($0) } ?? "")
+                .frame(width: 24, alignment: .trailing)
+            Text(line.newLineNumber.map { String($0) } ?? "")
+                .frame(width: 24, alignment: .trailing)
+        }
+        .font(.system(size: 9, design: .monospaced))
+        .foregroundColor(.white.opacity(0.2))
+        .padding(.trailing, 4)
+    }
+
+    private func linePrefix(_ line: DiffLine) -> String {
+        switch line.kind {
+        case .added: return "+"
+        case .removed: return "-"
+        case .context: return " "
+        }
+    }
+
+    private func prefixColor(_ line: DiffLine) -> Color {
+        switch line.kind {
+        case .added: return TerminalColors.green
+        case .removed: return TerminalColors.red
+        case .context: return .clear
+        }
+    }
+
+    private func textColor(_ line: DiffLine) -> Color {
+        switch line.kind {
+        case .added: return TerminalColors.green.opacity(0.9)
+        case .removed: return TerminalColors.red.opacity(0.9)
+        case .context: return .white.opacity(0.5)
+        }
+    }
+
+    private func backgroundColor(_ line: DiffLine) -> Color {
+        switch line.kind {
+        case .added: return TerminalColors.green.opacity(0.08)
+        case .removed: return TerminalColors.red.opacity(0.08)
+        case .context: return .clear
+        }
+    }
+
+    // MARK: - Diff Computation
+
+    /// Compute diff for Edit tool (old_string → new_string) with line-level comparison.
+    /// Uses a simple LCS-based approach: identical lines become context, others are removed/added.
+    private static func computeEditDiff(old: String, new: String) -> [DiffLine] {
+        let oldLines = old.components(separatedBy: "\n")
+        let newLines = new.components(separatedBy: "\n")
+
+        // Compute LCS table
+        let lcs = computeLCS(oldLines, newLines)
+
+        // Walk LCS table to produce diff lines
+        var result: [DiffLine] = []
+        var lineId = 0
+        var i = oldLines.count
+        var j = newLines.count
+        var stack: [(kind: DiffLine.Kind, text: String, oldNum: Int?, newNum: Int?)] = []
+
+        while i > 0 || j > 0 {
+            if i > 0 && j > 0 && oldLines[i - 1] == newLines[j - 1] {
+                // Context line (same in both)
+                stack.append((.context, oldLines[i - 1], i, j))
+                i -= 1
+                j -= 1
+            } else if j > 0 && (i == 0 || lcs[i][j - 1] >= lcs[i - 1][j]) {
+                // Added line
+                stack.append((.added, newLines[j - 1], nil, j))
+                j -= 1
+            } else if i > 0 {
+                // Removed line
+                stack.append((.removed, oldLines[i - 1], i, nil))
+                i -= 1
+            }
+        }
+
+        // Reverse since we walked backwards
+        for entry in stack.reversed() {
+            result.append(DiffLine(
+                id: lineId,
+                kind: entry.kind,
+                text: entry.text,
+                oldLineNumber: entry.oldNum,
+                newLineNumber: entry.newNum
+            ))
+            lineId += 1
+        }
+
+        return result
+    }
+
+    /// Compute LCS length table for two arrays of strings
+    private static func computeLCS(_ a: [String], _ b: [String]) -> [[Int]] {
+        let m = a.count
+        let n = b.count
+        var table = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
+
+        for i in 1...m {
+            for j in 1...n {
+                if a[i - 1] == b[j - 1] {
+                    table[i][j] = table[i - 1][j - 1] + 1
+                } else {
+                    table[i][j] = max(table[i - 1][j], table[i][j - 1])
+                }
+            }
+        }
+
+        return table
+    }
+
+    /// Compute diff for Write tool (all lines are additions)
+    private static func computeWriteDiff(content: String) -> [DiffLine] {
+        let lines = content.components(separatedBy: "\n")
+        return lines.enumerated().map { (i, line) in
+            DiffLine(
+                id: i,
+                kind: .added,
+                text: line,
+                oldLineNumber: nil,
+                newLineNumber: i + 1
+            )
+        }
+    }
+}

--- a/ClaudeIsland/UI/Components/SoundPickerRow.swift
+++ b/ClaudeIsland/UI/Components/SoundPickerRow.swift
@@ -2,46 +2,68 @@
 //  SoundPickerRow.swift
 //  ClaudeIsland
 //
-//  Notification sound selection picker for settings menu
+//  Per-event-type notification sound configuration
 //
 
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
-struct SoundPickerRow: View {
+// MARK: - Sound Settings Section
+
+/// Top-level sound settings section shown in the menu
+struct SoundSettingsSection: View {
+    @ObservedObject var soundSelector: SoundSelector
+
+    var body: some View {
+        VStack(spacing: 2) {
+            ForEach(SoundEventType.allCases) { eventType in
+                EventSoundRow(
+                    eventType: eventType,
+                    soundSelector: soundSelector
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Event Sound Row
+
+/// A single event type's sound configuration row with expandable picker
+struct EventSoundRow: View {
+    let eventType: SoundEventType
     @ObservedObject var soundSelector: SoundSelector
     @State private var isHovered = false
-    @State private var selectedSound: NotificationSound = AppSettings.notificationSound
 
     private var isExpanded: Bool {
-        soundSelector.isPickerExpanded
+        soundSelector.expandedEventType == eventType
     }
 
-    private func setExpanded(_ value: Bool) {
-        soundSelector.isPickerExpanded = value
+    private var currentSound: SoundSource {
+        soundSelector.sound(for: eventType)
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            // Main row - shows current selection
+            // Main row — shows event type + current sound
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
-                    setExpanded(!isExpanded)
+                    soundSelector.toggleExpanded(for: eventType)
                 }
             } label: {
                 HStack(spacing: 10) {
-                    Image(systemName: "speaker.wave.2")
+                    Image(systemName: eventType.icon)
                         .font(.system(size: 12))
                         .foregroundColor(textColor)
                         .frame(width: 16)
 
-                    Text("Notification Sound")
+                    Text(eventType.rawValue)
                         .font(.system(size: 13, weight: .medium))
                         .foregroundColor(textColor)
 
                     Spacer()
 
-                    Text(selectedSound.rawValue)
+                    Text(currentSound.displayName)
                         .font(.system(size: 11))
                         .foregroundColor(.white.opacity(0.4))
                         .lineLimit(1)
@@ -60,32 +82,16 @@ struct SoundPickerRow: View {
             .buttonStyle(.plain)
             .onHover { isHovered = $0 }
 
-            // Expanded sound list
+            // Expanded sound picker
             if isExpanded {
-                ScrollView {
-                    VStack(spacing: 2) {
-                        ForEach(NotificationSound.allCases, id: \.self) { sound in
-                            SoundOptionRowInline(
-                                sound: sound,
-                                isSelected: selectedSound == sound
-                            ) {
-                                // Play preview sound
-                                if let soundName = sound.soundName {
-                                    NSSound(named: soundName)?.play()
-                                }
-                                selectedSound = sound
-                                AppSettings.notificationSound = sound
-                            }
-                        }
-                    }
-                }
-                .frame(maxHeight: CGFloat(min(NotificationSound.allCases.count, 6)) * 32)
+                SoundOptionsList(
+                    eventType: eventType,
+                    soundSelector: soundSelector,
+                    currentSound: currentSound
+                )
                 .padding(.leading, 28)
                 .padding(.top, 4)
             }
-        }
-        .onAppear {
-            selectedSound = AppSettings.notificationSound
         }
     }
 
@@ -94,33 +100,166 @@ struct SoundPickerRow: View {
     }
 }
 
-// MARK: - Sound Option Row (Inline version)
+// MARK: - Sound Options List
+
+/// Scrollable list of sound options: None + system sounds + custom sounds + import button
+private struct SoundOptionsList: View {
+    let eventType: SoundEventType
+    @ObservedObject var soundSelector: SoundSelector
+    let currentSound: SoundSource
+
+    private let maxVisibleRows = 6
+    private let rowHeight: CGFloat = 32
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 2) {
+                // "None" option
+                SoundOptionRowInline(
+                    label: "None",
+                    isSelected: currentSound == .none,
+                    icon: "speaker.slash"
+                ) {
+                    soundSelector.setSound(.none, for: eventType)
+                }
+
+                // System sounds
+                ForEach(SystemSound.allCases, id: \.self) { sound in
+                    SoundOptionRowInline(
+                        label: sound.rawValue,
+                        isSelected: currentSound == .system(sound.rawValue)
+                    ) {
+                        let source = SoundSource.system(sound.rawValue)
+                        source.play()
+                        soundSelector.setSound(source, for: eventType)
+                    }
+                }
+
+                // Custom sounds divider (only show if there are custom sounds)
+                if !soundSelector.customSounds.isEmpty {
+                    Divider()
+                        .background(Color.white.opacity(0.08))
+                        .padding(.vertical, 2)
+
+                    ForEach(soundSelector.customSounds, id: \.0) { url, name in
+                        SoundOptionRowInline(
+                            label: name,
+                            isSelected: currentSound == .custom(url, name),
+                            icon: "waveform",
+                            isDeletable: true
+                        ) {
+                            let source = SoundSource.custom(url, name)
+                            source.play()
+                            soundSelector.setSound(source, for: eventType)
+                        } onDelete: {
+                            soundSelector.deleteCustomSound(at: url)
+                        }
+                    }
+                }
+
+                // Import button
+                Divider()
+                    .background(Color.white.opacity(0.08))
+                    .padding(.vertical, 2)
+
+                ImportSoundButton(soundSelector: soundSelector, eventType: eventType)
+            }
+        }
+        .frame(maxHeight: CGFloat(min(allOptionsCount, maxVisibleRows)) * rowHeight)
+    }
+
+    private var allOptionsCount: Int {
+        1 + SystemSound.allCases.count + soundSelector.customSounds.count + 1
+    }
+}
+
+// MARK: - Sound Option Row
 
 private struct SoundOptionRowInline: View {
-    let sound: NotificationSound
+    let label: String
     let isSelected: Bool
+    var icon: String? = nil
+    var isDeletable: Bool = false
     let action: () -> Void
+    var onDelete: (() -> Void)? = nil
 
     @State private var isHovered = false
 
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Circle()
-                    .fill(isSelected ? TerminalColors.green : Color.white.opacity(0.2))
-                    .frame(width: 6, height: 6)
+        HStack(spacing: 8) {
+            Button(action: action) {
+                HStack(spacing: 8) {
+                    if let icon = icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 10))
+                            .foregroundColor(isSelected ? TerminalColors.green : .white.opacity(0.4))
+                            .frame(width: 12)
+                    } else {
+                        Circle()
+                            .fill(isSelected ? TerminalColors.green : Color.white.opacity(0.2))
+                            .frame(width: 6, height: 6)
+                            .frame(width: 12)
+                    }
 
-                Text(sound.rawValue)
+                    Text(label)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.7))
+
+                    Spacer()
+
+                    if isSelected {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundColor(TerminalColors.green)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+
+            // Delete button for custom sounds
+            if isDeletable && isHovered {
+                Button {
+                    onDelete?()
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+        )
+        .onHover { isHovered = $0 }
+    }
+}
+
+// MARK: - Import Sound Button
+
+private struct ImportSoundButton: View {
+    @ObservedObject var soundSelector: SoundSelector
+    let eventType: SoundEventType
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            openFilePicker()
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "plus.circle")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.5))
+                    .frame(width: 12)
+
+                Text("Import Custom Sound...")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.7))
+                    .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.5))
 
                 Spacer()
-
-                if isSelected {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 10, weight: .bold))
-                        .foregroundColor(TerminalColors.green)
-                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
@@ -131,5 +270,26 @@ private struct SoundOptionRowInline: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
+    }
+
+    private func openFilePicker() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose a Sound File"
+        panel.allowedContentTypes = [
+            UTType.wav,
+            UTType.mp3,
+            UTType.aiff,
+            UTType(filenameExtension: "m4a") ?? UTType.audio,
+            UTType(filenameExtension: "caf") ?? UTType.audio,
+        ]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        if panel.runModal() == .OK, let url = panel.url {
+            if let source = soundSelector.importCustomSound(from: url) {
+                source.play()
+                soundSelector.setSound(source, for: eventType)
+            }
+        }
     }
 }

--- a/ClaudeIsland/UI/Components/StatusIcons.swift
+++ b/ClaudeIsland/UI/Components/StatusIcons.swift
@@ -229,7 +229,7 @@ struct StatusIcon: View {
         switch phase {
         case .waitingForInput:
             WaitingForInputIcon(size: size)
-        case .waitingForApproval:
+        case .waitingForApproval, .waitingForAnswer:
             WaitingForApprovalIcon(size: size)
         case .processing, .compacting:
             RunningIcon(size: size)

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -95,7 +95,8 @@ struct ClaudeInstancesView: View {
             if let terminal = session.resolvedTerminal {
                 _ = await WindowFocuser.shared.focusTerminal(
                     info: terminal.appInfo,
-                    sessionPid: session.pid
+                    sessionPid: session.pid,
+                    cachedTTY: terminal.tty
                 )
                 return
             }

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -181,12 +181,13 @@ struct InstanceRow: View {
     }
 
     var body: some View {
+        let preview = toolPreview
         VStack(alignment: .leading, spacing: 0) {
             // Main row content
-            mainRow
+            mainRow(preview: preview)
 
             // Expandable tool preview (diff/command) below the row
-            if isWaitingForApproval, let preview = toolPreview, isPreviewExpanded {
+            if isWaitingForApproval, let preview, isPreviewExpanded {
                 toolPreviewSection(preview)
                     .transition(.opacity.combined(with: .move(edge: .top)))
             }
@@ -209,7 +210,7 @@ struct InstanceRow: View {
 
     // MARK: - Main Row
 
-    private var mainRow: some View {
+    private func mainRow(preview: ToolPreviewData?) -> some View {
         HStack(alignment: .center, spacing: 10) {
             // Terminal type icon + state indicator on left
             terminalTypeIcon
@@ -258,7 +259,7 @@ struct InstanceRow: View {
                                 .font(.system(size: 11))
                                 .foregroundColor(.white.opacity(0.5))
                                 .lineLimit(1)
-                        } else if toolPreview != nil {
+                        } else if preview != nil {
                             // Show toggle for preview instead of raw input
                             Button {
                                 isPreviewExpanded.toggle()

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -90,13 +90,23 @@ struct ClaudeInstancesView: View {
     // MARK: - Actions
 
     private func focusSession(_ session: SessionState) {
-        guard session.isInTmux else { return }
-
         Task {
-            if let pid = session.pid {
-                _ = await YabaiController.shared.focusWindow(forClaudePid: pid)
-            } else {
-                _ = await YabaiController.shared.focusWindow(forWorkingDirectory: session.cwd)
+            // Strategy 1: Use resolved terminal info for precise jumping
+            if let terminal = session.resolvedTerminal {
+                _ = await WindowFocuser.shared.focusTerminal(
+                    info: terminal.appInfo,
+                    sessionPid: session.pid
+                )
+                return
+            }
+
+            // Strategy 2: Legacy yabai path for tmux sessions
+            if session.isInTmux {
+                if let pid = session.pid {
+                    _ = await YabaiController.shared.focusWindow(forClaudePid: pid)
+                } else {
+                    _ = await YabaiController.shared.focusWindow(forWorkingDirectory: session.cwd)
+                }
             }
         }
     }
@@ -140,7 +150,6 @@ struct InstanceRow: View {
 
     @State private var isHovered = false
     @State private var spinnerPhase = 0
-    @State private var isYabaiAvailable = false
     @State private var isPreviewExpanded = true
 
     private let claudeOrange = Color(red: 0.85, green: 0.47, blue: 0.34)
@@ -195,25 +204,35 @@ struct InstanceRow: View {
                 .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
         )
         .onHover { isHovered = $0 }
-        .task {
-            isYabaiAvailable = await WindowFinder.shared.isYabaiAvailable()
-        }
     }
 
     // MARK: - Main Row
 
     private var mainRow: some View {
         HStack(alignment: .center, spacing: 10) {
-            // State indicator on left
-            stateIndicator
+            // Terminal type icon + state indicator on left
+            terminalTypeIcon
                 .frame(width: 14)
 
             // Text content
             VStack(alignment: .leading, spacing: 2) {
-                Text(session.displayTitle)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.white)
-                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    Text(session.displayTitle)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+
+                    // Terminal badge (small, subtle)
+                    if let terminalName = session.terminalDisplayName {
+                        Text(terminalName)
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(.white.opacity(0.25))
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.white.opacity(0.06))
+                            .clipShape(Capsule())
+                    }
+                }
 
                 // Show tool call when waiting for approval/answer, otherwise last activity
                 if isWaitingForAnswer, let ctx = session.activeQuestion {
@@ -337,10 +356,11 @@ struct InstanceRow: View {
                         onChat()
                     }
 
-                    // Go to Terminal button (only if yabai available)
-                    if isYabaiAvailable {
-                        TerminalButton(
-                            isEnabled: session.isInTmux,
+                    // Go to Terminal button (available when we know the terminal app)
+                    if session.canJumpToTerminal {
+                        TerminalJumpButton(
+                            iconName: session.terminalIconName,
+                            terminalName: session.terminalDisplayName,
                             onTap: { onFocus() }
                         )
                     }
@@ -360,9 +380,9 @@ struct InstanceRow: View {
                         onChat()
                     }
 
-                    // Focus icon (only for tmux instances with yabai)
-                    if session.isInTmux && isYabaiAvailable {
-                        IconButton(icon: "eye") {
+                    // Terminal jump button (for any session with a resolved terminal)
+                    if session.canJumpToTerminal {
+                        IconButton(icon: session.terminalIconName) {
                             onFocus()
                         }
                     }
@@ -406,8 +426,9 @@ struct InstanceRow: View {
         .padding(.bottom, 4)
     }
 
+    /// Terminal-aware state indicator: shows terminal icon when idle, phase indicator when active
     @ViewBuilder
-    private var stateIndicator: some View {
+    private var terminalTypeIcon: some View {
         switch session.phase {
         case .processing, .compacting:
             Text(spinnerSymbols[spinnerPhase % spinnerSymbols.count])
@@ -428,13 +449,13 @@ struct InstanceRow: View {
                 .font(.system(size: 12, weight: .bold))
                 .foregroundColor(TerminalColors.amber)
         case .waitingForInput:
-            Circle()
-                .fill(TerminalColors.green)
-                .frame(width: 6, height: 6)
+            Image(systemName: session.terminalIconName)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(TerminalColors.green)
         case .idle, .ended:
-            Circle()
-                .fill(Color.white.opacity(0.2))
-                .frame(width: 6, height: 6)
+            Image(systemName: session.terminalIconName)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.white.opacity(0.25))
         }
     }
 
@@ -559,7 +580,35 @@ struct CompactTerminalButton: View {
     }
 }
 
-// MARK: - Terminal Button
+// MARK: - Terminal Jump Button
+
+/// Button to jump to a terminal app, showing the terminal's icon and name
+struct TerminalJumpButton: View {
+    let iconName: String
+    let terminalName: String?
+    let onTap: () -> Void
+
+    var body: some View {
+        Button {
+            onTap()
+        } label: {
+            HStack(spacing: 3) {
+                Image(systemName: iconName)
+                    .font(.system(size: 9, weight: .medium))
+                Text(terminalName ?? "Terminal")
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundColor(.black)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(Color.white.opacity(0.95))
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Terminal Button (legacy)
 
 struct TerminalButton: View {
     let isEnabled: Bool

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -56,10 +56,10 @@ struct ClaudeInstancesView: View {
     }
 
     /// Lower number = higher priority
-    /// Approval requests share priority with processing to maintain stable ordering
+    /// Approval/question requests share priority with processing to maintain stable ordering
     private func phasePriority(_ phase: SessionPhase) -> Int {
         switch phase {
-        case .waitingForApproval, .processing, .compacting: return 0
+        case .waitingForApproval, .waitingForAnswer, .processing, .compacting: return 0
         case .waitingForInput: return 1
         case .idle, .ended: return 2
         }
@@ -75,7 +75,9 @@ struct ClaudeInstancesView: View {
                         onChat: { openChat(session) },
                         onArchive: { archiveSession(session) },
                         onApprove: { approveSession(session) },
-                        onReject: { rejectSession(session) }
+                        onReject: { rejectSession(session) },
+                        onAnswer: { answers in answerQuestion(session, answers: answers) },
+                        onOpenQuestion: { openQuestion(session) }
                     )
                     .id(session.stableId)
                 }
@@ -114,6 +116,14 @@ struct ClaudeInstancesView: View {
     private func archiveSession(_ session: SessionState) {
         sessionMonitor.archiveSession(sessionId: session.sessionId)
     }
+
+    private func answerQuestion(_ session: SessionState, answers: [String: String]) {
+        sessionMonitor.answerQuestion(sessionId: session.sessionId, answers: answers)
+    }
+
+    private func openQuestion(_ session: SessionState) {
+        viewModel.showQuestion(for: session)
+    }
 }
 
 // MARK: - Instance Row
@@ -125,6 +135,8 @@ struct InstanceRow: View {
     let onArchive: () -> Void
     let onApprove: () -> Void
     let onReject: () -> Void
+    let onAnswer: ([String: String]) -> Void
+    let onOpenQuestion: () -> Void
 
     @State private var isHovered = false
     @State private var spinnerPhase = 0
@@ -137,6 +149,11 @@ struct InstanceRow: View {
     /// Whether we're showing the approval UI
     private var isWaitingForApproval: Bool {
         session.phase.isWaitingForApproval
+    }
+
+    /// Whether we're showing the question UI
+    private var isWaitingForAnswer: Bool {
+        session.phase.isWaitingForAnswer
     }
 
     /// Whether the pending tool requires interactive input (not just approve/deny)
@@ -158,8 +175,19 @@ struct InstanceRow: View {
                     .foregroundColor(.white)
                     .lineLimit(1)
 
-                // Show tool call when waiting for approval, otherwise last activity
-                if isWaitingForApproval, let toolName = session.pendingToolName {
+                // Show tool call when waiting for approval/answer, otherwise last activity
+                if isWaitingForAnswer, let ctx = session.activeQuestion {
+                    // Show question summary in amber
+                    HStack(spacing: 4) {
+                        Text("Question")
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundColor(TerminalColors.amber.opacity(0.9))
+                        Text(ctx.questionText)
+                            .font(.system(size: 11))
+                            .foregroundColor(.white.opacity(0.5))
+                            .lineLimit(1)
+                    }
+                } else if isWaitingForApproval, let toolName = session.pendingToolName {
                     // Show tool name in amber + input on same line
                     HStack(spacing: 4) {
                         Text(MCPToolFormatter.formatToolName(toolName))
@@ -226,8 +254,29 @@ struct InstanceRow: View {
 
             Spacer(minLength: 0)
 
-            // Action icons or approval buttons
-            if isWaitingForApproval && isInteractiveTool {
+            // Action icons or approval/question buttons
+            if isWaitingForAnswer {
+                // Question - show "Answer" button that opens question view
+                HStack(spacing: 8) {
+                    Button {
+                        onOpenQuestion()
+                    } label: {
+                        HStack(spacing: 3) {
+                            Image(systemName: "questionmark.circle")
+                                .font(.system(size: 9, weight: .medium))
+                            Text("Answer")
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                        .foregroundColor(.black)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(TerminalColors.amber.opacity(0.9))
+                        .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+                .transition(.opacity.combined(with: .scale(scale: 0.9)))
+            } else if isWaitingForApproval && isInteractiveTool {
                 // Interactive tools like AskUserQuestion - show chat + terminal buttons
                 HStack(spacing: 8) {
                     IconButton(icon: "bubble.left") {
@@ -309,6 +358,10 @@ struct InstanceRow: View {
                 .onReceive(spinnerTimer) { _ in
                     spinnerPhase = (spinnerPhase + 1) % spinnerSymbols.count
                 }
+        case .waitingForAnswer:
+            Text("?")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(TerminalColors.amber)
         case .waitingForInput:
             Circle()
                 .fill(TerminalColors.green)

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -141,6 +141,7 @@ struct InstanceRow: View {
     @State private var isHovered = false
     @State private var spinnerPhase = 0
     @State private var isYabaiAvailable = false
+    @State private var isPreviewExpanded = true
 
     private let claudeOrange = Color(red: 0.85, green: 0.47, blue: 0.34)
     private let spinnerSymbols = ["·", "✢", "✳", "∗", "✻", "✽"]
@@ -162,7 +163,46 @@ struct InstanceRow: View {
         return toolName == "AskUserQuestion"
     }
 
+    /// Extract tool preview data from the active permission context
+    private var toolPreview: ToolPreviewData? {
+        guard isWaitingForApproval,
+              let permission = session.activePermission else { return nil }
+        return ToolPreviewData.from(permission: permission)
+    }
+
     var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Main row content
+            mainRow
+
+            // Expandable tool preview (diff/command) below the row
+            if isWaitingForApproval, let preview = toolPreview, isPreviewExpanded {
+                toolPreviewSection(preview)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(.leading, 8)
+        .padding(.trailing, 14)
+        .padding(.vertical, 10)
+        .contentShape(Rectangle())
+        .onTapGesture(count: 2) {
+            onChat()
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isWaitingForApproval)
+        .animation(.easeInOut(duration: 0.2), value: isPreviewExpanded)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+        )
+        .onHover { isHovered = $0 }
+        .task {
+            isYabaiAvailable = await WindowFinder.shared.isYabaiAvailable()
+        }
+    }
+
+    // MARK: - Main Row
+
+    private var mainRow: some View {
         HStack(alignment: .center, spacing: 10) {
             // State indicator on left
             stateIndicator
@@ -198,6 +238,20 @@ struct InstanceRow: View {
                                 .font(.system(size: 11))
                                 .foregroundColor(.white.opacity(0.5))
                                 .lineLimit(1)
+                        } else if toolPreview != nil {
+                            // Show toggle for preview instead of raw input
+                            Button {
+                                isPreviewExpanded.toggle()
+                            } label: {
+                                HStack(spacing: 2) {
+                                    Image(systemName: isPreviewExpanded ? "chevron.down" : "chevron.right")
+                                        .font(.system(size: 8, weight: .medium))
+                                    Text(isPreviewExpanded ? "Hide preview" : "Show preview")
+                                        .font(.system(size: 10))
+                                }
+                                .foregroundColor(.white.opacity(0.35))
+                            }
+                            .buttonStyle(.plain)
                         } else if let input = session.pendingToolInput {
                             Text(input)
                                 .font(.system(size: 11))
@@ -323,22 +377,33 @@ struct InstanceRow: View {
                 .transition(.opacity.combined(with: .scale(scale: 0.9)))
             }
         }
-        .padding(.leading, 8)
-        .padding(.trailing, 14)
-        .padding(.vertical, 10)
-        .contentShape(Rectangle())
-        .onTapGesture(count: 2) {
-            onChat()
+    }
+
+    // MARK: - Tool Preview Section
+
+    @ViewBuilder
+    private func toolPreviewSection(_ preview: ToolPreviewData) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Divider()
+                .background(Color.white.opacity(0.06))
+
+            switch preview {
+            case .diff(let filePath, let oldString, let newString):
+                ApprovalDiffView(
+                    filePath: filePath,
+                    oldString: oldString,
+                    newString: newString
+                )
+                .padding(.top, 6)
+                .padding(.horizontal, 4)
+
+            case .command(let cmd):
+                CommandHighlightView(command: cmd)
+                    .padding(.top, 6)
+                    .padding(.horizontal, 4)
+            }
         }
-        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isWaitingForApproval)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
-        )
-        .onHover { isHovered = $0 }
-        .task {
-            isYabaiAvailable = await WindowFinder.shared.isYabaiAvailable()
-        }
+        .padding(.bottom, 4)
     }
 
     @ViewBuilder
@@ -519,5 +584,49 @@ struct TerminalButton: View {
             .clipShape(Capsule())
         }
         .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Tool Preview Data
+
+/// Extracted preview data for diff/command display in the approval panel
+enum ToolPreviewData {
+    /// Edit or Write tool — shows a code diff
+    case diff(filePath: String, oldString: String?, newString: String?)
+    /// Bash tool — shows a highlighted command
+    case command(String)
+
+    /// Extract preview data from a permission context.
+    /// Returns nil for tools that don't have a meaningful preview.
+    static func from(permission: PermissionContext) -> ToolPreviewData? {
+        let toolName = permission.toolName
+        guard let input = permission.toolInput else { return nil }
+
+        switch toolName {
+        case "Edit":
+            guard let filePath = stringValue(input["file_path"]),
+                  let oldString = stringValue(input["old_string"]),
+                  let newString = stringValue(input["new_string"]) else { return nil }
+            return .diff(filePath: filePath, oldString: oldString, newString: newString)
+
+        case "Write":
+            guard let filePath = stringValue(input["file_path"]),
+                  let content = stringValue(input["content"]) else { return nil }
+            // Write = all new content, no old string
+            return .diff(filePath: filePath, oldString: nil, newString: content)
+
+        case "Bash", "BashOutput":
+            guard let cmd = stringValue(input["command"]) else { return nil }
+            return .command(cmd)
+
+        default:
+            return nil
+        }
+    }
+
+    /// Extract a String value from an AnyCodable
+    private static func stringValue(_ value: AnyCodable?) -> String? {
+        guard let v = value else { return nil }
+        return v.value as? String
     }
 }

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -37,7 +37,13 @@ struct NotchMenuView: View {
 
             // Appearance settings
             ScreenPickerRow(screenSelector: screenSelector)
-            SoundPickerRow(soundSelector: soundSelector)
+
+            Divider()
+                .background(Color.white.opacity(0.08))
+                .padding(.vertical, 4)
+
+            // Sound settings — per-event-type configuration
+            SoundSettingsSection(soundSelector: soundSelector)
 
             Divider()
                 .background(Color.white.opacity(0.08))

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -40,6 +40,11 @@ struct NotchView: View {
         sessionMonitor.instances.contains { $0.phase.isWaitingForApproval }
     }
 
+    /// Whether any Claude session has a pending question (AskUserQuestion)
+    private var hasPendingQuestion: Bool {
+        sessionMonitor.instances.contains { $0.phase.isWaitingForAnswer }
+    }
+
     /// Whether any Claude session is waiting for user input (done/ready state) within the display window
     private var hasWaitingForInput: Bool {
         let now = Date()
@@ -66,23 +71,23 @@ struct NotchView: View {
 
     /// Extra width for expanding activities (like Dynamic Island)
     private var expansionWidth: CGFloat {
-        // Permission indicator adds width on left side only
-        let permissionIndicatorWidth: CGFloat = hasPendingPermission ? 18 : 0
+        // Permission/question indicator adds width on left side only
+        let indicatorWidth: CGFloat = (hasPendingPermission || hasPendingQuestion) ? 18 : 0
 
         // Expand for processing activity
         if activityCoordinator.expandingActivity.show {
             switch activityCoordinator.expandingActivity.type {
             case .claude:
                 let baseWidth = 2 * max(0, closedNotchSize.height - 12) + 20
-                return baseWidth + permissionIndicatorWidth
+                return baseWidth + indicatorWidth
             case .none:
                 break
             }
         }
 
-        // Expand for pending permissions (left indicator) or waiting for input (checkmark on right)
-        if hasPendingPermission {
-            return 2 * max(0, closedNotchSize.height - 12) + 20 + permissionIndicatorWidth
+        // Expand for pending permissions/questions (left indicator) or waiting for input (checkmark on right)
+        if hasPendingPermission || hasPendingQuestion {
+            return 2 * max(0, closedNotchSize.height - 12) + 20 + indicatorWidth
         }
 
         // Waiting for input just shows checkmark on right, no extra left indicator
@@ -171,6 +176,7 @@ struct NotchView: View {
                     .animation(openAnimation, value: notchSize) // Animate container size changes between content types
                     .animation(.smooth, value: activityCoordinator.expandingActivity)
                     .animation(.smooth, value: hasPendingPermission)
+                    .animation(.smooth, value: hasPendingQuestion)
                     .animation(.smooth, value: hasWaitingForInput)
                     .animation(.spring(response: 0.3, dampingFraction: 0.5), value: isBouncing)
                     .contentShape(Rectangle())
@@ -214,9 +220,9 @@ struct NotchView: View {
         activityCoordinator.expandingActivity.show && activityCoordinator.expandingActivity.type == .claude
     }
 
-    /// Whether to show the expanded closed state (processing, pending permission, or waiting for input)
+    /// Whether to show the expanded closed state (processing, pending permission/question, or waiting for input)
     private var showClosedActivity: Bool {
-        isProcessing || hasPendingPermission || hasWaitingForInput
+        isProcessing || hasPendingPermission || hasPendingQuestion || hasWaitingForInput
     }
 
     @ViewBuilder
@@ -253,13 +259,19 @@ struct NotchView: View {
                     ClaudeCrabIcon(size: 14, animateLegs: isProcessing)
                         .matchedGeometryEffect(id: "crab", in: activityNamespace, isSource: showClosedActivity)
 
-                    // Permission indicator only (amber) - waiting for input shows checkmark on right
+                    // Permission/question indicator (amber) - waiting for input shows checkmark on right
                     if hasPendingPermission {
                         PermissionIndicatorIcon(size: 14, color: Color(red: 0.85, green: 0.47, blue: 0.34))
                             .matchedGeometryEffect(id: "status-indicator", in: activityNamespace, isSource: showClosedActivity)
+                    } else if hasPendingQuestion {
+                        // Question mark indicator for pending questions
+                        Text("?")
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundColor(TerminalColors.amber)
+                            .matchedGeometryEffect(id: "status-indicator", in: activityNamespace, isSource: showClosedActivity)
                     }
                 }
-                .frame(width: viewModel.status == .opened ? nil : sideWidth + (hasPendingPermission ? 18 : 0))
+                .frame(width: viewModel.status == .opened ? nil : sideWidth + ((hasPendingPermission || hasPendingQuestion) ? 18 : 0))
                 .padding(.leading, viewModel.status == .opened ? 8 : 0)
             }
 
@@ -279,10 +291,17 @@ struct NotchView: View {
                     .frame(width: closedNotchSize.width - cornerRadiusInsets.closed.top + (isBouncing ? 16 : 0))
             }
 
-            // Right side - spinner when processing/pending, checkmark when waiting for input
+            // Right side - spinner when processing/pending, question mark for questions, checkmark when waiting for input
             if showClosedActivity {
                 if isProcessing || hasPendingPermission {
                     ProcessingSpinner()
+                        .matchedGeometryEffect(id: "spinner", in: activityNamespace, isSource: showClosedActivity)
+                        .frame(width: viewModel.status == .opened ? 20 : sideWidth)
+                } else if hasPendingQuestion {
+                    // Pulsing question mark for pending questions
+                    Text("?")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundColor(TerminalColors.amber)
                         .matchedGeometryEffect(id: "spinner", in: activityNamespace, isSource: showClosedActivity)
                         .frame(width: viewModel.status == .opened ? 20 : sideWidth)
                 } else if hasWaitingForInput {
@@ -364,6 +383,26 @@ struct NotchView: View {
                     sessionMonitor: sessionMonitor,
                     viewModel: viewModel
                 )
+            case .question(let session):
+                if let ctx = session.activeQuestion {
+                    QuestionView(
+                        question: ctx,
+                        onAnswer: { answers in
+                            sessionMonitor.answerQuestion(
+                                sessionId: session.sessionId,
+                                answers: answers
+                            )
+                            // Return to instances list after answering
+                            viewModel.exitChat()
+                        }
+                    )
+                } else {
+                    // Question was answered externally, show instances
+                    ClaudeInstancesView(
+                        sessionMonitor: sessionMonitor,
+                        viewModel: viewModel
+                    )
+                }
             }
         }
         .frame(width: notchSize.width - 24) // Fixed width to prevent text reflow
@@ -373,8 +412,8 @@ struct NotchView: View {
     // MARK: - Event Handlers
 
     private func handleProcessingChange() {
-        if isAnyProcessing || hasPendingPermission {
-            // Show claude activity when processing or waiting for permission
+        if isAnyProcessing || hasPendingPermission || hasPendingQuestion {
+            // Show claude activity when processing, waiting for permission, or waiting for answer
             activityCoordinator.showActivity(type: .claude)
             isVisible = true
 
@@ -399,7 +438,7 @@ struct NotchView: View {
             // Don't hide on non-notched devices - users need a visible target
             if viewModel.status == .closed && viewModel.hasPhysicalNotch {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    if !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && viewModel.status == .closed {
+                    if !isAnyProcessing && !hasPendingPermission && !hasPendingQuestion && !hasWaitingForInput && viewModel.status == .closed {
                         isVisible = false
                     }
                 }
@@ -419,7 +458,7 @@ struct NotchView: View {
             // Don't hide on non-notched devices - users need a visible target
             guard viewModel.hasPhysicalNotch else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                if viewModel.status == .closed && !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !activityCoordinator.expandingActivity.show {
+                if viewModel.status == .closed && !isAnyProcessing && !hasPendingPermission && !hasPendingQuestion && !hasWaitingForInput && !activityCoordinator.expandingActivity.show {
                     isVisible = false
                 }
             }

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -26,6 +26,7 @@ struct NotchView: View {
     @State private var isVisible: Bool = false
     @State private var isHovering: Bool = false
     @State private var isBouncing: Bool = false
+    @State private var notificationSuppressedUntil: Date = Date()  // Suppress notifications during context resume
 
     @Namespace private var activityNamespace
 
@@ -376,6 +377,16 @@ struct NotchView: View {
             // Show claude activity when processing or waiting for permission
             activityCoordinator.showActivity(type: .claude)
             isVisible = true
+
+            // When a session starts processing, set a suppression window.
+            // This prevents sound/bounce from firing if the session quickly
+            // transitions through processing → waitingForInput during context
+            // resume or session restoration.
+            let suppressionDuration: TimeInterval = 2.0
+            let newSuppressedUntil = Date().addingTimeInterval(suppressionDuration)
+            if newSuppressedUntil > notificationSuppressedUntil {
+                notificationSuppressedUntil = newSuppressedUntil
+            }
         } else if hasWaitingForInput {
             // Keep visible for waiting-for-input but hide the processing spinner
             activityCoordinator.hideActivity()
@@ -446,30 +457,47 @@ struct NotchView: View {
             waitingForInputTimestamps.removeValue(forKey: staleId)
         }
 
-        // Bounce the notch when a session newly enters waitingForInput state
+        // Filter out sessions that still have active subagents — their waitingForInput
+        // is a transient state caused by SubagentStop, not a real "done" signal.
+        // Also filter sessions during notification suppression window (context resume).
+        let genuinelyWaitingSessions: [SessionState]
         if !newWaitingIds.isEmpty {
-            // Get the sessions that just entered waitingForInput
-            let newlyWaitingSessions = waitingForInputSessions.filter { newWaitingIds.contains($0.stableId) }
+            genuinelyWaitingSessions = waitingForInputSessions.filter { session in
+                guard newWaitingIds.contains(session.stableId) else { return false }
+                // Subagent stop causes a brief waitingForInput — ignore it
+                if session.subagentState.hasActiveSubagent { return false }
+                return true
+            }
+        } else {
+            genuinelyWaitingSessions = []
+        }
 
-            // Play notification sound if the session is not actively focused
-            if let soundName = AppSettings.notificationSound.soundName {
-                // Check if we should play sound (async check for tmux pane focus)
-                Task {
-                    let shouldPlaySound = await shouldPlayNotificationSound(for: newlyWaitingSessions)
-                    if shouldPlaySound {
-                        await MainActor.run {
-                            NSSound(named: soundName)?.play()
+        // Bounce the notch when a session genuinely enters waitingForInput state
+        if !genuinelyWaitingSessions.isEmpty {
+            // Suppress notifications during context resume window
+            let isSuppressed = now < notificationSuppressedUntil
+
+            if !isSuppressed {
+                // Play notification sound if the session is not actively focused
+                if let soundName = AppSettings.notificationSound.soundName {
+                    // Check if we should play sound (async check for tmux pane focus)
+                    Task {
+                        let shouldPlaySound = await shouldPlayNotificationSound(for: genuinelyWaitingSessions)
+                        if shouldPlaySound {
+                            await MainActor.run {
+                                NSSound(named: soundName)?.play()
+                            }
                         }
                     }
                 }
-            }
 
-            // Trigger bounce animation to get user's attention
-            DispatchQueue.main.async {
-                isBouncing = true
-                // Bounce back after a short delay
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                    isBouncing = false
+                // Trigger bounce animation to get user's attention
+                DispatchQueue.main.async {
+                    isBouncing = true
+                    // Bounce back after a short delay
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                        isBouncing = false
+                    }
                 }
             }
 

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -475,9 +475,18 @@ struct NotchView: View {
         let newPendingIds = currentIds.subtracting(previousPendingIds)
 
         if !newPendingIds.isEmpty {
-            // Play permission request sound for newly pending sessions
-            if soundSelector.hasSound(for: .permissionRequest) {
-                soundSelector.playSound(for: .permissionRequest)
+            // Play permission request sound (with suppression + focus check)
+            let isSuppressed = Date() < notificationSuppressedUntil
+            if !isSuppressed && soundSelector.hasSound(for: .permissionRequest) {
+                let newSessions = sessions.filter { newPendingIds.contains($0.stableId) }
+                Task {
+                    let shouldPlay = await shouldPlayNotificationSound(for: newSessions)
+                    if shouldPlay {
+                        await MainActor.run {
+                            soundSelector.playSound(for: .permissionRequest)
+                        }
+                    }
+                }
             }
 
             if viewModel.status == .closed &&
@@ -585,10 +594,22 @@ struct NotchView: View {
         let newQuestionIds = currentIds.subtracting(previousQuestionIds)
 
         if !newQuestionIds.isEmpty {
-            // Skip if within suppression window
             let isSuppressed = Date() < notificationSuppressedUntil
-            if !isSuppressed && soundSelector.hasSound(for: .questionWaiting) {
-                soundSelector.playSound(for: .questionWaiting)
+            // Filter out sessions with active subagents
+            let genuineSessions = questionSessions.filter { session in
+                guard newQuestionIds.contains(session.stableId) else { return false }
+                return !session.subagentState.hasActiveSubagent
+            }
+
+            if !isSuppressed && !genuineSessions.isEmpty && soundSelector.hasSound(for: .questionWaiting) {
+                Task {
+                    let shouldPlay = await shouldPlayNotificationSound(for: genuineSessions)
+                    if shouldPlay {
+                        await MainActor.run {
+                            soundSelector.playSound(for: .questionWaiting)
+                        }
+                    }
+                }
             }
         }
 
@@ -602,10 +623,18 @@ struct NotchView: View {
         let newEndedIds = currentIds.subtracting(previousEndedIds)
 
         if !newEndedIds.isEmpty {
-            // Skip if within suppression window
             let isSuppressed = Date() < notificationSuppressedUntil
-            if !isSuppressed && soundSelector.hasSound(for: .sessionEnded) {
-                soundSelector.playSound(for: .sessionEnded)
+            let newSessions = endedSessions.filter { newEndedIds.contains($0.stableId) }
+
+            if !isSuppressed && !newSessions.isEmpty && soundSelector.hasSound(for: .sessionEnded) {
+                Task {
+                    let shouldPlay = await shouldPlayNotificationSound(for: newSessions)
+                    if shouldPlay {
+                        await MainActor.run {
+                            soundSelector.playSound(for: .sessionEnded)
+                        }
+                    }
+                }
             }
         }
 

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -20,8 +20,11 @@ struct NotchView: View {
     @StateObject private var sessionMonitor = ClaudeSessionMonitor()
     @StateObject private var activityCoordinator = NotchActivityCoordinator.shared
     @ObservedObject private var updateManager = UpdateManager.shared
+    private let soundSelector = SoundSelector.shared
     @State private var previousPendingIds: Set<String> = []
     @State private var previousWaitingForInputIds: Set<String> = []
+    @State private var previousQuestionIds: Set<String> = []
+    @State private var previousEndedIds: Set<String> = []
     @State private var waitingForInputTimestamps: [String: Date] = [:]  // sessionId -> when it entered waitingForInput
     @State private var isVisible: Bool = false
     @State private var isHovering: Bool = false
@@ -211,6 +214,8 @@ struct NotchView: View {
         .onChange(of: sessionMonitor.instances) { _, instances in
             handleProcessingChange()
             handleWaitingForInputChange(instances)
+            handleQuestionChange(instances)
+            handleSessionEndedChange(instances)
         }
     }
 
@@ -469,10 +474,16 @@ struct NotchView: View {
         let currentIds = Set(sessions.map { $0.stableId })
         let newPendingIds = currentIds.subtracting(previousPendingIds)
 
-        if !newPendingIds.isEmpty &&
-           viewModel.status == .closed &&
-           !TerminalVisibilityDetector.isTerminalVisibleOnCurrentSpace() {
-            viewModel.notchOpen(reason: .notification)
+        if !newPendingIds.isEmpty {
+            // Play permission request sound for newly pending sessions
+            if soundSelector.hasSound(for: .permissionRequest) {
+                soundSelector.playSound(for: .permissionRequest)
+            }
+
+            if viewModel.status == .closed &&
+               !TerminalVisibilityDetector.isTerminalVisibleOnCurrentSpace() {
+                viewModel.notchOpen(reason: .notification)
+            }
         }
 
         previousPendingIds = currentIds
@@ -517,14 +528,13 @@ struct NotchView: View {
             let isSuppressed = now < notificationSuppressedUntil
 
             if !isSuppressed {
-                // Play notification sound if the session is not actively focused
-                if let soundName = AppSettings.notificationSound.soundName {
-                    // Check if we should play sound (async check for tmux pane focus)
+                // Play task complete notification sound
+                if soundSelector.hasSound(for: .taskComplete) {
                     Task {
                         let shouldPlaySound = await shouldPlayNotificationSound(for: genuinelyWaitingSessions)
                         if shouldPlaySound {
                             await MainActor.run {
-                                NSSound(named: soundName)?.play()
+                                soundSelector.playSound(for: .taskComplete)
                             }
                         }
                     }
@@ -566,5 +576,39 @@ struct NotchView: View {
         }
 
         return false
+    }
+
+    /// Handle sessions entering question-waiting state (AskUserQuestion)
+    private func handleQuestionChange(_ instances: [SessionState]) {
+        let questionSessions = instances.filter { $0.phase.isWaitingForAnswer }
+        let currentIds = Set(questionSessions.map { $0.stableId })
+        let newQuestionIds = currentIds.subtracting(previousQuestionIds)
+
+        if !newQuestionIds.isEmpty {
+            // Skip if within suppression window
+            let isSuppressed = Date() < notificationSuppressedUntil
+            if !isSuppressed && soundSelector.hasSound(for: .questionWaiting) {
+                soundSelector.playSound(for: .questionWaiting)
+            }
+        }
+
+        previousQuestionIds = currentIds
+    }
+
+    /// Handle sessions entering ended state
+    private func handleSessionEndedChange(_ instances: [SessionState]) {
+        let endedSessions = instances.filter { $0.phase == .ended }
+        let currentIds = Set(endedSessions.map { $0.stableId })
+        let newEndedIds = currentIds.subtracting(previousEndedIds)
+
+        if !newEndedIds.isEmpty {
+            // Skip if within suppression window
+            let isSuppressed = Date() < notificationSuppressedUntil
+            if !isSuppressed && soundSelector.hasSound(for: .sessionEnded) {
+                soundSelector.playSound(for: .sessionEnded)
+            }
+        }
+
+        previousEndedIds = currentIds
     }
 }

--- a/ClaudeIsland/UI/Views/QuestionView.swift
+++ b/ClaudeIsland/UI/Views/QuestionView.swift
@@ -1,0 +1,293 @@
+//
+//  QuestionView.swift
+//  ClaudeIsland
+//
+//  Inline question panel for AskUserQuestion tool.
+//  Displays question text, clickable option buttons, and optional free-text input.
+//  Supports keyboard shortcuts Cmd+1/2/3/4 for quick selection.
+//
+
+import SwiftUI
+
+struct QuestionView: View {
+    let question: QuestionContext
+    let onAnswer: ([String: String]) -> Void
+
+    @State private var selectedOptions: [String: Set<String>] = [:]
+    @State private var freeTextInput: String = ""
+    @State private var showFreeText: Bool = false
+    @FocusState private var isTextFieldFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(Array(question.questions.enumerated()), id: \.offset) { index, item in
+                questionItemView(item: item, index: index)
+            }
+
+            // Submit button for multi-select or free text
+            if needsSubmitButton {
+                HStack {
+                    Spacer()
+                    Button {
+                        submitAnswers()
+                    } label: {
+                        Text("Submit")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(.black)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 6)
+                            .background(Color.white.opacity(0.9))
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .keyboardShortcut(.return, modifiers: [])
+                }
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 8)
+        // Keyboard shortcuts for quick option selection (Cmd+1 through Cmd+4)
+        .background(
+            Group {
+                Button("") { selectOptionByIndex(0) }
+                    .keyboardShortcut("1", modifiers: .command)
+                    .hidden()
+                Button("") { selectOptionByIndex(1) }
+                    .keyboardShortcut("2", modifiers: .command)
+                    .hidden()
+                Button("") { selectOptionByIndex(2) }
+                    .keyboardShortcut("3", modifiers: .command)
+                    .hidden()
+                Button("") { selectOptionByIndex(3) }
+                    .keyboardShortcut("4", modifiers: .command)
+                    .hidden()
+            }
+        )
+    }
+
+    // MARK: - Question Item View
+
+    @ViewBuilder
+    private func questionItemView(item: QuestionItem, index: Int) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Question header + text
+            if let header = item.header, !header.isEmpty {
+                Text(header)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(TerminalColors.amber.opacity(0.7))
+                    .textCase(.uppercase)
+            }
+
+            Text(item.question)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // Option buttons
+            if !item.options.isEmpty {
+                optionsGrid(item: item, questionIndex: index)
+            }
+
+            // Free text input (shown when "Other" is selected or no options)
+            if showFreeText || item.options.isEmpty {
+                freeTextInputField(item: item)
+            }
+        }
+    }
+
+    // MARK: - Options Grid
+
+    @ViewBuilder
+    private func optionsGrid(item: QuestionItem, questionIndex: Int) -> some View {
+        let columns = item.options.count <= 3
+            ? [GridItem(.flexible())]
+            : [GridItem(.flexible()), GridItem(.flexible())]
+
+        LazyVGrid(columns: columns, spacing: 6) {
+            ForEach(Array(item.options.enumerated()), id: \.offset) { optionIndex, option in
+                optionButton(
+                    option: option,
+                    questionText: item.question,
+                    isMultiSelect: item.multiSelect,
+                    shortcutIndex: optionIndex
+                )
+            }
+
+            // "Other" option for free text
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    showFreeText.toggle()
+                    if showFreeText {
+                        isTextFieldFocused = true
+                    }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "pencil")
+                        .font(.system(size: 10))
+                    Text("Other")
+                        .font(.system(size: 12, weight: .medium))
+                }
+                .foregroundColor(showFreeText ? .black : .white.opacity(0.7))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(showFreeText ? Color.white.opacity(0.9) : Color.white.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(Color.white.opacity(0.15), lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Option Button
+
+    @ViewBuilder
+    private func optionButton(option: QuestionOption, questionText: String, isMultiSelect: Bool, shortcutIndex: Int) -> some View {
+        let isSelected = selectedOptions[questionText]?.contains(option.label) ?? false
+
+        Button {
+            if isMultiSelect {
+                toggleOption(questionText: questionText, label: option.label)
+            } else {
+                // Single select: immediately submit
+                onAnswer([questionText: option.label])
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    if isMultiSelect {
+                        Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                            .font(.system(size: 10))
+                    }
+
+                    Text(option.label)
+                        .font(.system(size: 12, weight: .medium))
+
+                    Spacer()
+
+                    // Keyboard shortcut hint
+                    if shortcutIndex < 4 {
+                        Text("\u{2318}\(shortcutIndex + 1)")
+                            .font(.system(size: 9, weight: .regular, design: .monospaced))
+                            .foregroundColor(.white.opacity(0.3))
+                    }
+                }
+
+                if let desc = option.description, !desc.isEmpty {
+                    Text(desc)
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                        .lineLimit(2)
+                }
+            }
+            .foregroundColor(isSelected ? .black : .white.opacity(0.85))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? Color.white.opacity(0.9) : Color.white.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(
+                        isSelected ? Color.clear : Color.white.opacity(0.15),
+                        lineWidth: 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Free Text Input
+
+    @ViewBuilder
+    private func freeTextInputField(item: QuestionItem) -> some View {
+        HStack(spacing: 8) {
+            TextField("Type your answer...", text: $freeTextInput)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundColor(.white)
+                .focused($isTextFieldFocused)
+                .onSubmit {
+                    if !freeTextInput.trimmingCharacters(in: .whitespaces).isEmpty {
+                        onAnswer([item.question: freeTextInput])
+                    }
+                }
+
+            if !freeTextInput.isEmpty {
+                Button {
+                    onAnswer([item.question: freeTextInput])
+                } label: {
+                    Image(systemName: "arrow.right.circle.fill")
+                        .font(.system(size: 16))
+                        .foregroundColor(.white.opacity(0.7))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.white.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(Color.white.opacity(0.15), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Helpers
+
+    private var needsSubmitButton: Bool {
+        question.questions.contains { $0.multiSelect }
+    }
+
+    private func toggleOption(questionText: String, label: String) {
+        if selectedOptions[questionText] == nil {
+            selectedOptions[questionText] = []
+        }
+        if selectedOptions[questionText]!.contains(label) {
+            selectedOptions[questionText]!.remove(label)
+        } else {
+            selectedOptions[questionText]!.insert(label)
+        }
+    }
+
+    private func selectOptionByIndex(_ index: Int) {
+        guard let firstQuestion = question.questions.first,
+              index < firstQuestion.options.count else { return }
+
+        let option = firstQuestion.options[index]
+
+        if firstQuestion.multiSelect {
+            toggleOption(questionText: firstQuestion.question, label: option.label)
+        } else {
+            // Single select: immediately submit
+            onAnswer([firstQuestion.question: option.label])
+        }
+    }
+
+    private func submitAnswers() {
+        var answers: [String: String] = [:]
+
+        for item in question.questions {
+            if let selected = selectedOptions[item.question], !selected.isEmpty {
+                // Join multi-select with comma
+                answers[item.question] = selected.joined(separator: ", ")
+            } else if !freeTextInput.trimmingCharacters(in: .whitespaces).isEmpty {
+                answers[item.question] = freeTextInput
+            }
+        }
+
+        if !answers.isEmpty {
+            onAnswer(answers)
+        }
+    }
+}

--- a/ClaudeIsland/UI/Views/QuestionView.swift
+++ b/ClaudeIsland/UI/Views/QuestionView.swift
@@ -4,7 +4,7 @@
 //
 //  Inline question panel for AskUserQuestion tool.
 //  Displays question text, clickable option buttons, and optional free-text input.
-//  Supports keyboard shortcuts Cmd+1/2/3/4 for quick selection.
+//  Supports keyboard shortcuts Cmd+1/2/3/4 for quick selection (first question only).
 //
 
 import SwiftUI
@@ -13,10 +13,13 @@ struct QuestionView: View {
     let question: QuestionContext
     let onAnswer: ([String: String]) -> Void
 
+    /// Per-question multi-select state, keyed by question text
     @State private var selectedOptions: [String: Set<String>] = [:]
-    @State private var freeTextInput: String = ""
-    @State private var showFreeText: Bool = false
-    @FocusState private var isTextFieldFocused: Bool
+    /// Per-question free-text input, keyed by question text
+    @State private var freeTextInputs: [String: String] = [:]
+    /// Per-question "Other" toggle, keyed by question text
+    @State private var showFreeText: [String: Bool] = [:]
+    @FocusState private var focusedQuestion: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -46,7 +49,9 @@ struct QuestionView: View {
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 8)
-        // Keyboard shortcuts for quick option selection (Cmd+1 through Cmd+4)
+        // Keyboard shortcuts Cmd+1-4 target the first question only.
+        // Multi-question scenarios are rare in practice; users interact
+        // via click for subsequent questions.
         .background(
             Group {
                 Button("") { selectOptionByIndex(0) }
@@ -69,6 +74,9 @@ struct QuestionView: View {
 
     @ViewBuilder
     private func questionItemView(item: QuestionItem, index: Int) -> some View {
+        let questionKey = item.question
+        let isFreeTextShown = showFreeText[questionKey] ?? false
+
         VStack(alignment: .leading, spacing: 8) {
             // Question header + text
             if let header = item.header, !header.isEmpty {
@@ -89,7 +97,7 @@ struct QuestionView: View {
             }
 
             // Free text input (shown when "Other" is selected or no options)
-            if showFreeText || item.options.isEmpty {
+            if isFreeTextShown || item.options.isEmpty {
                 freeTextInputField(item: item)
             }
         }
@@ -99,6 +107,9 @@ struct QuestionView: View {
 
     @ViewBuilder
     private func optionsGrid(item: QuestionItem, questionIndex: Int) -> some View {
+        let questionKey = item.question
+        let isFreeTextShown = showFreeText[questionKey] ?? false
+
         let columns = item.options.count <= 3
             ? [GridItem(.flexible())]
             : [GridItem(.flexible()), GridItem(.flexible())]
@@ -116,9 +127,10 @@ struct QuestionView: View {
             // "Other" option for free text
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
-                    showFreeText.toggle()
-                    if showFreeText {
-                        isTextFieldFocused = true
+                    let current = showFreeText[questionKey] ?? false
+                    showFreeText[questionKey] = !current
+                    if !current {
+                        focusedQuestion = questionKey
                     }
                 }
             } label: {
@@ -128,12 +140,12 @@ struct QuestionView: View {
                     Text("Other")
                         .font(.system(size: 12, weight: .medium))
                 }
-                .foregroundColor(showFreeText ? .black : .white.opacity(0.7))
+                .foregroundColor(isFreeTextShown ? .black : .white.opacity(0.7))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 8)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(showFreeText ? Color.white.opacity(0.9) : Color.white.opacity(0.08))
+                        .fill(isFreeTextShown ? Color.white.opacity(0.9) : Color.white.opacity(0.08))
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
@@ -170,7 +182,7 @@ struct QuestionView: View {
 
                     Spacer()
 
-                    // Keyboard shortcut hint
+                    // Keyboard shortcut hint (only for first question)
                     if shortcutIndex < 4 {
                         Text("\u{2318}\(shortcutIndex + 1)")
                             .font(.system(size: 9, weight: .regular, design: .monospaced))
@@ -208,21 +220,29 @@ struct QuestionView: View {
 
     @ViewBuilder
     private func freeTextInputField(item: QuestionItem) -> some View {
+        let questionKey = item.question
+        let binding = Binding<String>(
+            get: { freeTextInputs[questionKey] ?? "" },
+            set: { freeTextInputs[questionKey] = $0 }
+        )
+
         HStack(spacing: 8) {
-            TextField("Type your answer...", text: $freeTextInput)
+            TextField("Type your answer...", text: binding)
                 .textFieldStyle(.plain)
                 .font(.system(size: 12))
                 .foregroundColor(.white)
-                .focused($isTextFieldFocused)
+                .focused($focusedQuestion, equals: questionKey)
                 .onSubmit {
-                    if !freeTextInput.trimmingCharacters(in: .whitespaces).isEmpty {
-                        onAnswer([item.question: freeTextInput])
+                    let text = (freeTextInputs[questionKey] ?? "").trimmingCharacters(in: .whitespaces)
+                    if !text.isEmpty {
+                        onAnswer([questionKey: text])
                     }
                 }
 
-            if !freeTextInput.isEmpty {
+            if !(freeTextInputs[questionKey] ?? "").isEmpty {
                 Button {
-                    onAnswer([item.question: freeTextInput])
+                    let text = freeTextInputs[questionKey] ?? ""
+                    onAnswer([questionKey: text])
                 } label: {
                     Image(systemName: "arrow.right.circle.fill")
                         .font(.system(size: 16))
@@ -260,6 +280,9 @@ struct QuestionView: View {
         }
     }
 
+    /// Keyboard shortcuts (Cmd+1-4) only target the first question.
+    /// AskUserQuestion typically sends 1-4 questions; in multi-question
+    /// scenarios, subsequent questions are answered via mouse click.
     private func selectOptionByIndex(_ index: Int) {
         guard let firstQuestion = question.questions.first,
               index < firstQuestion.options.count else { return }
@@ -281,8 +304,12 @@ struct QuestionView: View {
             if let selected = selectedOptions[item.question], !selected.isEmpty {
                 // Join multi-select with comma
                 answers[item.question] = selected.joined(separator: ", ")
-            } else if !freeTextInput.trimmingCharacters(in: .whitespaces).isEmpty {
-                answers[item.question] = freeTextInput
+            } else {
+                // Check per-question free text input
+                let text = (freeTextInputs[item.question] ?? "").trimmingCharacters(in: .whitespaces)
+                if !text.isEmpty {
+                    answers[item.question] = text
+                }
             }
         }
 

--- a/ClaudeIsland/Utilities/SessionPhaseHelpers.swift
+++ b/ClaudeIsland/Utilities/SessionPhaseHelpers.swift
@@ -13,6 +13,8 @@ struct SessionPhaseHelpers {
         switch phase {
         case .waitingForApproval:
             return TerminalColors.amber
+        case .waitingForAnswer:
+            return TerminalColors.amber
         case .waitingForInput:
             return TerminalColors.green
         case .processing:
@@ -29,6 +31,8 @@ struct SessionPhaseHelpers {
         switch phase {
         case .waitingForApproval(let ctx):
             return "Waiting for approval: \(ctx.toolName)"
+        case .waitingForAnswer(let ctx):
+            return "Question: \(ctx.questionText)"
         case .waitingForInput:
             return "Ready for input"
         case .processing:

--- a/ClaudeIsland/Utilities/SessionPhaseHelpers.swift
+++ b/ClaudeIsland/Utilities/SessionPhaseHelpers.swift
@@ -11,9 +11,7 @@ struct SessionPhaseHelpers {
     /// Get color for session phase
     static func phaseColor(for phase: SessionPhase) -> Color {
         switch phase {
-        case .waitingForApproval:
-            return TerminalColors.amber
-        case .waitingForAnswer:
+        case .waitingForApproval, .waitingForAnswer:
             return TerminalColors.amber
         case .waitingForInput:
             return TerminalColors.green

--- a/claude-notify/.claude-plugin/plugin.json
+++ b/claude-notify/.claude-plugin/plugin.json
@@ -5,8 +5,8 @@
   "author": {
     "name": "ZhaoChaoqun"
   },
-  "homepage": "https://github.com/ZhaoChaoqun/claude-notify",
-  "repository": "https://github.com/ZhaoChaoqun/claude-notify",
+  "homepage": "https://github.com/ZhaoChaoqun/claude-island",
+  "repository": "https://github.com/ZhaoChaoqun/claude-island",
   "license": "MIT",
   "keywords": [
     "notification",

--- a/claude-notify/.claude-plugin/plugin.json
+++ b/claude-notify/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "claude-notify",
+  "version": "0.1.0",
+  "description": "Smart terminal notifications for Claude Code. Click a notification to jump back to the right terminal pane.",
+  "author": {
+    "name": "ZhaoChaoqun"
+  },
+  "homepage": "https://github.com/ZhaoChaoqun/claude-notify",
+  "repository": "https://github.com/ZhaoChaoqun/claude-notify",
+  "license": "MIT",
+  "keywords": [
+    "notification",
+    "terminal",
+    "iterm2",
+    "tmux",
+    "cmux",
+    "focus",
+    "jump"
+  ]
+}

--- a/claude-notify/LICENSE
+++ b/claude-notify/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ZhaoChaoqun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/claude-notify/README.md
+++ b/claude-notify/README.md
@@ -1,0 +1,110 @@
+# claude-notify
+
+Claude Code plugin -- click a notification, jump back to the right terminal pane.
+
+When Claude Code needs your attention, `claude-notify` sends a macOS notification. Click it and you're taken straight to the correct terminal window, tab, and pane -- no hunting through windows.
+
+## Supported Terminals
+
+| Terminal | Jump Level | How It Works |
+|----------|-----------|--------------|
+| **iTerm2** | Session (pane) | AppleScript TTY matching |
+| **tmux** | Pane | `tmux select-pane` + host terminal activation |
+| **cmux** | Native | `cmux notify` with built-in panel jump |
+| **Terminal.app** | Tab | AppleScript TTY matching |
+
+Terminal detection is automatic -- zero configuration needed.
+
+## Prerequisites
+
+- macOS
+- Python 3 (ships with macOS)
+- [terminal-notifier](https://github.com/julienXX/terminal-notifier) (not needed for cmux)
+
+```bash
+brew install terminal-notifier
+```
+
+## Install
+
+```bash
+claude plugin install claude-notify
+```
+
+Or install from source:
+
+```bash
+claude plugin install /path/to/claude-notify
+```
+
+## How It Works
+
+```
+Claude Code fires Notification hook
+        |
+   notify.py reads hook input
+        |
+   Detects terminal type (process tree walk)
+        |
+   +-- cmux? --> cmux notify (native, done)
+   |
+   +-- other --> terminal-notifier with -execute
+                        |
+                  User clicks notification
+                        |
+                  focusers/{terminal}.sh runs
+                        |
+                  Terminal pane activated
+```
+
+### Terminal Detection
+
+`notify.py` walks up the process tree from Claude's PID:
+
+1. **cmux** -- if a `cmux` process is found, use `cmux notify`
+2. **tmux** -- if a `tmux` process is found, use `tmux select-pane` + activate host terminal
+3. **iTerm2** -- if `iTerm2`/`iTermServer-main` is found, use AppleScript
+4. **Terminal.app** -- if `Terminal` is found, use AppleScript
+
+### tmux Two-Layer Jump
+
+tmux runs inside a host terminal. `claude-notify` handles both layers:
+
+1. `tmux select-window` + `tmux select-pane` -- switch to the correct tmux pane
+2. Detect and activate the host terminal app (iTerm2 or Terminal.app)
+
+## Project Structure
+
+```
+claude-notify/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin metadata
+├── hooks/
+│   └── hooks.json           # Notification hook declaration
+├── notify.py                # Entry point: detect terminal, send notification
+├── focusers/
+│   ├── iterm2.sh            # iTerm2 AppleScript focus
+│   ├── terminal_app.sh      # Terminal.app AppleScript focus
+│   ├── tmux.sh              # tmux pane select + host activation
+│   └── cmux.sh              # cmux native notify
+├── README.md
+└── LICENSE
+```
+
+## Troubleshooting
+
+**Notifications don't appear?**
+- Check that `terminal-notifier` is installed: `which terminal-notifier`
+- macOS may need notification permission for terminal-notifier. Open System Settings > Notifications and ensure terminal-notifier is allowed.
+
+**Click doesn't jump to the right pane?**
+- The plugin detects terminals by walking the process tree. If Claude Code is started in an unusual way (e.g., via `ssh`), detection may fail.
+- For tmux, make sure the `tmux` binary is in your `$PATH`.
+
+**cmux notifications?**
+- cmux has built-in notification support. The plugin calls `cmux notify` directly -- no terminal-notifier needed.
+- Make sure `cmux` is in your `$PATH`.
+
+## License
+
+MIT

--- a/claude-notify/focusers/cmux.sh
+++ b/claude-notify/focusers/cmux.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Send notification via cmux native notification system.
+# Usage: cmux.sh <tty> [pid]
+#
+# cmux has built-in notification support with panel highlighting
+# and a notification panel (⌘I). This script uses the cmux CLI
+# to trigger a native notification — no terminal-notifier needed.
+#
+# Note: This script is called by terminal-notifier -execute as a fallback.
+# Normally, notify.py calls `cmux notify` directly and skips terminal-notifier.
+# This file exists for consistency with the focuser interface.
+
+CMUX_BIN=$(command -v cmux 2>/dev/null)
+
+if [ -n "$CMUX_BIN" ]; then
+    "$CMUX_BIN" notify "Claude Code 需要你的关注" 2>/dev/null
+fi

--- a/claude-notify/focusers/iterm2.sh
+++ b/claude-notify/focusers/iterm2.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Focus iTerm2 session by TTY.
+# Usage: iterm2.sh <tty> [pid]
+#
+# Finds the iTerm2 session whose TTY matches, selects it,
+# and brings the containing window to front.
+
+TTY="$1"
+[ -z "$TTY" ] && exit 1
+
+# Escape backslashes and double quotes for AppleScript
+ESCAPED_TTY=$(printf '%s' "$TTY" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+osascript -e "
+tell application \"iTerm2\"
+    activate
+    repeat with w in windows
+        repeat with t in tabs of w
+            repeat with s in sessions of t
+                if tty of s is \"$ESCAPED_TTY\" then
+                    select t
+                    select s
+                    set index of w to 1
+                    return true
+                end if
+            end repeat
+        end repeat
+    end repeat
+end tell
+return false
+"

--- a/claude-notify/focusers/terminal_app.sh
+++ b/claude-notify/focusers/terminal_app.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Focus Terminal.app tab by TTY.
+# Usage: terminal_app.sh <tty> [pid]
+#
+# Terminal.app has tabs but no panes. Finds the tab whose TTY matches,
+# selects it, and brings the window to front.
+
+TTY="$1"
+[ -z "$TTY" ] && exit 1
+
+ESCAPED_TTY=$(printf '%s' "$TTY" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+osascript -e "
+tell application \"Terminal\"
+    activate
+    repeat with w in windows
+        repeat with t in tabs of w
+            if tty of t is \"$ESCAPED_TTY\" then
+                set selected tab of w to t
+                set index of w to 1
+                return true
+            end if
+        end repeat
+    end repeat
+end tell
+return false
+"

--- a/claude-notify/focusers/tmux.sh
+++ b/claude-notify/focusers/tmux.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Focus tmux pane by TTY, then activate the host terminal.
+# Usage: tmux.sh <tty> [pid]
+#
+# Two-layer jump:
+#   1. Find the tmux pane matching the TTY and select it
+#   2. Activate the host terminal app (iTerm2 / Terminal.app)
+
+TTY="$1"
+PID="$2"
+TMUX_BIN=$(command -v tmux 2>/dev/null)
+
+[ -z "$TMUX_BIN" ] && exit 1
+
+# --- Step 1: Find and select the tmux pane ---
+
+# Try TTY matching first
+if [ -n "$TTY" ]; then
+    TARGET=$("$TMUX_BIN" list-panes -a -F '#{pane_tty} #{session_name}:#{window_index}.#{pane_index}' 2>/dev/null \
+        | grep "^${TTY} " \
+        | head -1 \
+        | awk '{print $2}')
+fi
+
+# Fallback: PID matching via process tree
+if [ -z "$TARGET" ] && [ -n "$PID" ]; then
+    while IFS= read -r line; do
+        PANE_PID=$(echo "$line" | awk '{print $1}')
+        PANE_TARGET=$(echo "$line" | awk '{print $2}')
+
+        # Walk up from PID to check if it's a descendant of this pane's PID
+        CHECK_PID="$PID"
+        DEPTH=0
+        while [ "$CHECK_PID" -gt 1 ] 2>/dev/null && [ "$DEPTH" -lt 20 ]; do
+            if [ "$CHECK_PID" = "$PANE_PID" ]; then
+                TARGET="$PANE_TARGET"
+                break 2
+            fi
+            CHECK_PID=$(ps -p "$CHECK_PID" -o ppid= 2>/dev/null | tr -d ' ')
+            DEPTH=$((DEPTH + 1))
+        done
+    done <<< "$("$TMUX_BIN" list-panes -a -F '#{pane_pid} #{session_name}:#{window_index}.#{pane_index}' 2>/dev/null)"
+fi
+
+[ -z "$TARGET" ] && exit 1
+
+# Parse session:window.pane
+SESSION_WINDOW="${TARGET%.*}"
+"$TMUX_BIN" select-window -t "$SESSION_WINDOW" 2>/dev/null
+"$TMUX_BIN" select-pane -t "$TARGET" 2>/dev/null
+
+# --- Step 2: Activate host terminal app ---
+# tmux client's parent process tells us which terminal app is hosting it.
+
+# Find the tmux client PID
+CLIENT_PID=$("$TMUX_BIN" list-clients -F '#{client_pid}' 2>/dev/null | head -1)
+
+if [ -n "$CLIENT_PID" ]; then
+    # Walk up from client PID to find the terminal app
+    CHECK="$CLIENT_PID"
+    DEPTH=0
+    while [ "$CHECK" -gt 1 ] 2>/dev/null && [ "$DEPTH" -lt 15 ]; do
+        COMM=$(ps -p "$CHECK" -o comm= 2>/dev/null | xargs basename 2>/dev/null)
+        COMM_LOWER=$(echo "$COMM" | tr '[:upper:]' '[:lower:]')
+
+        case "$COMM_LOWER" in
+            iterm2|iterm|itermserver-main)
+                osascript -e 'tell application "iTerm2" to activate' 2>/dev/null
+                exit 0
+                ;;
+            terminal|terminal.app)
+                osascript -e 'tell application "Terminal" to activate' 2>/dev/null
+                exit 0
+                ;;
+        esac
+
+        CHECK=$(ps -p "$CHECK" -o ppid= 2>/dev/null | tr -d ' ')
+        DEPTH=$((DEPTH + 1))
+    done
+fi
+
+# Fallback: try to activate iTerm2, then Terminal.app
+osascript -e 'tell application "iTerm2" to activate' 2>/dev/null \
+    || osascript -e 'tell application "Terminal" to activate' 2>/dev/null
+
+exit 0

--- a/claude-notify/hooks/hooks.json
+++ b/claude-notify/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/notify.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/claude-notify/notify.py
+++ b/claude-notify/notify.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+claude-notify — Claude Code plugin for terminal-aware notifications.
+
+Detects the current terminal emulator, sends a macOS notification,
+and jumps to the correct terminal pane/tab when the user clicks it.
+
+Supported terminals: iTerm2, tmux, cmux, Terminal.app
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+PLUGIN_ROOT = os.path.dirname(os.path.abspath(__file__))
+FOCUSERS_DIR = os.path.join(PLUGIN_ROOT, "focusers")
+
+
+# ---------------------------------------------------------------------------
+# TTY detection
+# ---------------------------------------------------------------------------
+
+def get_tty():
+    """Get the TTY of the Claude process (our parent)."""
+    ppid = os.getppid()
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(ppid), "-o", "tty="],
+            capture_output=True, text=True, timeout=2,
+        )
+        tty = result.stdout.strip()
+        if tty and tty not in ("??", "-"):
+            return tty if tty.startswith("/dev/") else f"/dev/{tty}"
+    except Exception:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Terminal detection via process tree
+# ---------------------------------------------------------------------------
+
+def get_process_tree():
+    """Build pid -> (ppid, command) mapping from ps."""
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,comm="],
+            capture_output=True, text=True, timeout=3,
+        )
+        tree = {}
+        for line in result.stdout.strip().splitlines():
+            parts = line.split(None, 2)
+            if len(parts) >= 3:
+                try:
+                    tree[int(parts[0])] = (int(parts[1]), parts[2])
+                except ValueError:
+                    pass
+        return tree
+    except Exception:
+        return {}
+
+
+def walk_ancestors(pid, tree, max_depth=30):
+    """Yield (pid, command) walking up the process tree."""
+    current = pid
+    depth = 0
+    while current > 1 and depth < max_depth:
+        info = tree.get(current)
+        if info is None:
+            break
+        ppid, comm = info
+        yield current, comm
+        current = ppid
+        depth += 1
+
+
+def detect_terminal(pid=None):
+    """Detect terminal type by walking the process tree from Claude's PID.
+
+    Returns one of: "cmux", "tmux", "iterm2", "terminal_app", "unknown".
+    Detection order matters — tmux and cmux are checked first because they
+    can be nested inside any terminal app.
+    """
+    if pid is None:
+        pid = os.getppid()
+
+    tree = get_process_tree()
+
+    found_tmux = False
+    host_terminal = "unknown"
+
+    for _, comm in walk_ancestors(pid, tree):
+        name = os.path.basename(comm).lower()
+
+        # cmux check — highest priority
+        if "cmux" in name:
+            return "cmux"
+
+        # tmux check — remember we found it, but keep looking for host
+        if name.startswith("tmux"):
+            found_tmux = True
+            continue
+
+        # Terminal emulator checks
+        if name in ("iterm2", "iterm", "itermserver-main"):
+            host_terminal = "iterm2"
+            if found_tmux:
+                break
+        elif name == "terminal" or name == "terminal.app":
+            host_terminal = "terminal_app"
+            if found_tmux:
+                break
+
+    if found_tmux:
+        return "tmux"
+    return host_terminal
+
+
+# ---------------------------------------------------------------------------
+# Notification dispatch
+# ---------------------------------------------------------------------------
+
+def find_notifier():
+    """Find terminal-notifier binary."""
+    path = shutil.which("terminal-notifier")
+    if path:
+        return path
+    for p in ("/opt/homebrew/bin/terminal-notifier", "/usr/local/bin/terminal-notifier"):
+        if os.path.isfile(p):
+            return p
+    return None
+
+
+def send_notification(terminal, tty, pid):
+    """Send notification with click-to-focus behavior."""
+
+    # cmux — use native cmux notify, no need for terminal-notifier
+    if terminal == "cmux":
+        cmux_bin = shutil.which("cmux")
+        if cmux_bin:
+            subprocess.Popen(
+                [cmux_bin, "notify", "Claude Code 需要你的关注"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            return
+        # cmux binary not found, fall through to terminal-notifier
+
+    notifier = find_notifier()
+
+    # Build the focus command for -execute
+    focus_script = os.path.join(FOCUSERS_DIR, f"{terminal}.sh")
+    if not os.path.isfile(focus_script):
+        focus_script = None
+
+    if notifier and focus_script and tty:
+        # Determine sender bundle ID for notification icon
+        sender = {
+            "iterm2": "com.googlecode.iterm2",
+            "terminal_app": "com.apple.Terminal",
+            "tmux": "com.googlecode.iterm2",  # tmux usually runs inside iTerm2
+        }.get(terminal, "com.apple.Terminal")
+
+        cmd = [
+            notifier,
+            "-title", "Claude Code",
+            "-message", "Claude Code 需要你的关注",
+            "-sound", "Glass",
+            "-group", f"claude-notify-{tty}",
+            "-sender", sender,
+            "-execute", f'"{focus_script}" "{tty}" "{pid or ""}"',
+        ]
+        subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    elif notifier:
+        # No focus script or no TTY — plain notification
+        cmd = [
+            notifier,
+            "-title", "Claude Code",
+            "-message", "Claude Code 需要你的关注",
+            "-sound", "Glass",
+            "-sender", "com.apple.Terminal",
+        ]
+        subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    else:
+        # Final fallback — osascript
+        subprocess.Popen(
+            [
+                "osascript", "-e",
+                'display notification "Claude Code 需要你的关注" '
+                'with title "Claude Code" sound name "Glass"',
+            ],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        data = {}
+
+    # Skip permission_prompt — PermissionRequest hook handles it
+    if data.get("notification_type") == "permission_prompt":
+        sys.exit(0)
+
+    tty = get_tty()
+    pid = os.getppid()
+    terminal = detect_terminal(pid)
+
+    send_notification(terminal, tty, pid)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `claude-notify` — a Claude Code plugin that sends macOS notifications with click-to-focus support for multiple terminals
- Supports **iTerm2** (AppleScript session targeting), **tmux** (two-layer pane jump + host terminal activation), **cmux** (native `cmux notify`), and **Terminal.app** (AppleScript tab targeting)
- Automatic terminal detection via process tree walk — zero configuration needed
- Plugin format (`.claude-plugin/plugin.json` + `hooks/hooks.json`) for easy installation via `claude plugin install`

## Architecture

```
notify.py (entry) → detect_terminal() → focusers/{terminal}.sh
```

- `notify.py`: Reads hook stdin, detects terminal type, dispatches notification via `terminal-notifier` with `-execute` callback
- `focusers/iterm2.sh`: AppleScript TTY matching across windows/tabs/sessions
- `focusers/tmux.sh`: TTY/PID matching via `tmux list-panes`, then host terminal activation
- `focusers/cmux.sh`: Direct `cmux notify` CLI call (bypasses terminal-notifier)
- `focusers/terminal_app.sh`: AppleScript TTY matching across windows/tabs

## Test plan

- [ ] Verify `notify.py` syntax and JSON configs are valid
- [ ] Test terminal detection logic with mocked process trees
- [ ] Test iTerm2 focuser: notification click → correct session activated
- [ ] Test tmux focuser: pane selection + host terminal activation
- [ ] Test cmux focuser: `cmux notify` called correctly
- [ ] Test Terminal.app focuser: correct tab selected
- [ ] Test fallback: osascript notification when terminal-notifier missing
- [ ] Verify plugin.json and hooks.json conform to Claude Code plugin spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)