### PR TITLE
feat: draggable notch horizontal position

### DIFF
--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -45,6 +45,7 @@ class NotchViewModel: ObservableObject {
     @Published var openReason: NotchOpenReason = .unknown
     @Published var contentType: NotchContentType = .instances
     @Published var isHovering: Bool = false
+    @Published var horizontalOffset: CGFloat = 0
 
     // MARK: - Dependencies
 
@@ -147,8 +148,9 @@ class NotchViewModel: ObservableObject {
     private var currentChatSession: SessionState?
 
     private func handleMouseMove(_ location: CGPoint) {
-        let inNotch = geometry.isPointInNotch(location)
-        let inOpened = status == .opened && geometry.isPointInOpenedPanel(location, size: openedSize)
+        let adjusted = CGPoint(x: location.x - horizontalOffset, y: location.y)
+        let inNotch = geometry.isPointInNotch(adjusted)
+        let inOpened = status == .opened && geometry.isPointInOpenedPanel(adjusted, size: openedSize)
 
         let newHovering = inNotch || inOpened
 
@@ -174,21 +176,22 @@ class NotchViewModel: ObservableObject {
 
     private func handleMouseDown() {
         let location = NSEvent.mouseLocation
+        let adjusted = CGPoint(x: location.x - horizontalOffset, y: location.y)
 
         switch status {
         case .opened:
-            if geometry.isPointOutsidePanel(location, size: openedSize) {
+            if geometry.isPointOutsidePanel(adjusted, size: openedSize) {
                 notchClose()
                 // Re-post the click so it reaches the window/app behind us
                 repostClickAt(location)
-            } else if geometry.notchScreenRect.contains(location) {
+            } else if geometry.notchScreenRect.contains(adjusted) {
                 // Clicking notch while opened - only close if NOT in chat mode
                 if !isInChatMode {
                     notchClose()
                 }
             }
         case .closed, .popping:
-            if geometry.isPointInNotch(location) {
+            if geometry.isPointInNotch(adjusted) {
                 notchOpen(reason: .click)
             }
         }

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -26,6 +26,7 @@ struct NotchView: View {
     @State private var isVisible: Bool = false
     @State private var isHovering: Bool = false
     @State private var isBouncing: Bool = false
+    @State private var dragOffset: CGFloat = 0
 
     @Namespace private var activityNamespace
 
@@ -183,6 +184,20 @@ struct NotchView: View {
                             viewModel.notchOpen(reason: .click)
                         }
                     }
+                    .gesture(
+                        DragGesture(minimumDistance: 5)
+                            .onChanged { value in
+                                guard viewModel.status != .opened else { return }
+                                let maxOffset = (viewModel.screenRect.width / 2) - (closedContentWidth / 2) - 20
+                                let newOffset = dragOffset + value.translation.width
+                                viewModel.horizontalOffset = min(max(newOffset, -maxOffset), maxOffset)
+                            }
+                            .onEnded { _ in
+                                guard viewModel.status != .opened else { return }
+                                dragOffset = viewModel.horizontalOffset
+                            }
+                    )
+                    .offset(x: viewModel.horizontalOffset)
             }
         }
         .opacity(isVisible ? 1 : 0)


### PR DESCRIPTION
## Summary

- Allows the notch to be repositioned along the top of the screen by dragging it left or right
- Position is clamped to screen bounds so the notch can't be dragged out of reach
- Drag threshold is 5px so taps still open the notch normally
- Hit-testing (hover, click-to-close) is updated to account for the offset, so interaction works correctly at any position

## Changes

- `NotchViewModel`: add `@Published var horizontalOffset: CGFloat` and adjust mouse hit-test geometry by the offset
- `NotchView`: add `DragGesture` + `dragOffset` state accumulator; apply `.offset(x:)` to the notch container

## Test plan

- [ ] Drag notch left/right — it should move smoothly and stay put after releasing
- [ ] Tap the notch at its new position — it should open normally
- [ ] Click outside the opened panel at the new position — it should close
- [ ] Drag to the very edge — should stop at screen boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)