### PR TITLE
feat: hide notch when no active Claude sessions

### DIFF
--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -45,6 +45,7 @@ class NotchViewModel: ObservableObject {
     @Published var openReason: NotchOpenReason = .unknown
     @Published var contentType: NotchContentType = .instances
     @Published var isHovering: Bool = false
+    @Published var hasSessions: Bool = false
 
     // MARK: - Dependencies
 

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -29,6 +29,11 @@ struct NotchView: View {
 
     @Namespace private var activityNamespace
 
+    /// Whether there are any active Claude sessions
+    private var hasSessions: Bool {
+        !sessionMonitor.instances.isEmpty
+    }
+
     /// Whether any Claude session is currently processing or compacting
     private var isAnyProcessing: Bool {
         sessionMonitor.instances.contains { $0.phase == .processing || $0.phase == .compacting }
@@ -194,6 +199,7 @@ struct NotchView: View {
             if !viewModel.hasPhysicalNotch {
                 isVisible = true
             }
+            viewModel.hasSessions = !sessionMonitor.instances.isEmpty
         }
         .onChange(of: viewModel.status) { oldStatus, newStatus in
             handleStatusChange(from: oldStatus, to: newStatus)
@@ -202,6 +208,7 @@ struct NotchView: View {
             handlePendingSessionsChange(sessions)
         }
         .onChange(of: sessionMonitor.instances) { _, instances in
+            viewModel.hasSessions = !instances.isEmpty
             handleProcessingChange()
             handleWaitingForInputChange(instances)
         }
@@ -384,11 +391,17 @@ struct NotchView: View {
             // Hide activity when done
             activityCoordinator.hideActivity()
 
+            // Keep visible as long as sessions exist — notch stays accessible
+            if hasSessions {
+                isVisible = true
+                return
+            }
+
             // Delay hiding the notch until animation completes
             // Don't hide on non-notched devices - users need a visible target
             if viewModel.status == .closed && viewModel.hasPhysicalNotch {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    if !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && viewModel.status == .closed {
+                    if !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !hasSessions && viewModel.status == .closed {
                         isVisible = false
                     }
                 }
@@ -409,7 +422,10 @@ struct NotchView: View {
             guard viewModel.hasPhysicalNotch else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
                 if viewModel.status == .closed && !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !activityCoordinator.expandingActivity.show {
-                    isVisible = false
+                    // Only hide if no sessions remain
+                    if !hasSessions {
+                        isVisible = false
+                    }
                 }
             }
         }

--- a/ClaudeIsland/UI/Window/NotchWindowController.swift
+++ b/ClaudeIsland/UI/Window/NotchWindowController.swift
@@ -62,23 +62,23 @@ class NotchWindowController: NSWindowController {
         notchWindow.setFrame(windowFrame, display: true)
 
         // Dynamically toggle mouse event handling based on notch state:
-        // - Closed: ignoresMouseEvents = true (clicks pass through to menu bar/apps)
+        // - Closed, no sessions: ignoresMouseEvents = true (clicks pass through to menu bar/apps)
+        // - Closed, has sessions: ignoresMouseEvents = false (visible notch is interactive)
         // - Opened: ignoresMouseEvents = false (buttons inside panel work)
         viewModel.$status
+            .combineLatest(viewModel.$hasSessions)
             .receive(on: DispatchQueue.main)
-            .sink { [weak notchWindow, weak viewModel] status in
+            .sink { [weak notchWindow, weak viewModel] (status, hasSessions) in
                 switch status {
                 case .opened:
-                    // Accept mouse events when opened so buttons work
                     notchWindow?.ignoresMouseEvents = false
-                    // Don't steal focus when opened by notification (task finished)
                     if viewModel?.openReason != .notification {
                         NSApp.activate(ignoringOtherApps: false)
                         notchWindow?.makeKey()
                     }
                 case .closed, .popping:
-                    // Ignore mouse events when closed so clicks pass through
-                    notchWindow?.ignoresMouseEvents = true
+                    // Accept events when sessions exist so the notch remains clickable
+                    notchWindow?.ignoresMouseEvents = !hasSessions
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## Summary

- The notch is now completely hidden when no Claude sessions are running
- As soon as any session exists, the notch becomes visible and interactive
- Removes the confusing state where the notch would appear/disappear based only on activity rather than session presence

## Problem

Previously the notch hid itself after activity finished, even if a Claude session was still open and idle. This meant the notch could vanish mid-session, leaving users without an entry point until the next activity event.

## Changes

- `NotchViewModel`: add `@Published var hasSessions: Bool` (synced from `NotchView`)
- `NotchWindowController`: use `combineLatest` on `$status` + `$hasSessions` to set `ignoresMouseEvents` — accepts mouse events whenever sessions exist (not just when opened)
- `NotchView`:
  - Add `hasSessions` computed property
  - Sync `hasSessions` to `viewModel` in `onAppear` and `onChange`
  - `handleProcessingChange`: return early (stay visible) when sessions exist
  - `handleStatusChange`: skip hiding on close when sessions remain

## Test plan

- [ ] Launch app with no Claude sessions — notch should not be visible
- [ ] Start a Claude session — notch should appear
- [ ] Let Claude finish a task and become idle — notch should stay visible
- [ ] Close all Claude sessions — notch should disappear
- [ ] Click the notch while Claude is idle — should open normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)