### PR TITLE
feat: minimal notch indicator with unacknowledged session state

### DIFF
--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -45,6 +45,7 @@ class NotchViewModel: ObservableObject {
     @Published var openReason: NotchOpenReason = .unknown
     @Published var contentType: NotchContentType = .instances
     @Published var isHovering: Bool = false
+    @Published var hasSessions: Bool = false
 
     // MARK: - Dependencies
 

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -23,6 +23,7 @@ struct NotchView: View {
     @State private var previousPendingIds: Set<String> = []
     @State private var previousWaitingForInputIds: Set<String> = []
     @State private var waitingForInputTimestamps: [String: Date] = [:]  // sessionId -> when it entered waitingForInput
+    @State private var acknowledgedSessionIds: Set<String> = []          // sessions user has seen (clicked/opened)
     @State private var isVisible: Bool = false
     @State private var isHovering: Bool = false
     @State private var isBouncing: Bool = false
@@ -32,6 +33,18 @@ struct NotchView: View {
     /// Whether there are any active Claude sessions
     private var hasSessions: Bool {
         !sessionMonitor.instances.isEmpty
+    }
+
+    /// Sessions that finished (waitingForInput) but user hasn't acknowledged yet
+    private var hasUnacknowledgedDone: Bool {
+        sessionMonitor.instances.contains {
+            $0.phase == .waitingForInput && !acknowledgedSessionIds.contains($0.stableId)
+        }
+    }
+
+    /// Minimal indicator mode: sessions exist, no ongoing activity, notch is closed
+    private var isMinimalMode: Bool {
+        hasSessions && !showClosedActivity && viewModel.status == .closed
     }
 
     /// Whether any Claude session is currently processing or compacting
@@ -188,6 +201,23 @@ struct NotchView: View {
                             viewModel.notchOpen(reason: .click)
                         }
                     }
+                    .scaleEffect(
+                        x: isMinimalMode ? 0.65 : 1.0,
+                        y: isMinimalMode ? 0.22 : 1.0,
+                        anchor: .top
+                    )
+                    .opacity(isMinimalMode ? (hasUnacknowledgedDone ? 0.85 : 0.55) : 1.0)
+                    .overlay(alignment: .top) {
+                        // Subtle green glow when a task finished but user hasn't opened yet
+                        if isMinimalMode && hasUnacknowledgedDone {
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(TerminalColors.green.opacity(0.5))
+                                .frame(width: closedNotchSize.width * 0.65 * 0.5, height: 2)
+                                .blur(radius: 2)
+                        }
+                    }
+                    .animation(.spring(response: 0.45, dampingFraction: 0.9), value: isMinimalMode)
+                    .animation(.easeInOut(duration: 0.3), value: hasUnacknowledgedDone)
             }
         }
         .opacity(isVisible ? 1 : 0)
@@ -413,9 +443,13 @@ struct NotchView: View {
         switch newStatus {
         case .opened, .popping:
             isVisible = true
-            // Clear waiting-for-input timestamps only when manually opened (user acknowledged)
+            // Mark done sessions as acknowledged and clear timestamps when user opens manually
             if viewModel.openReason == .click || viewModel.openReason == .hover {
                 waitingForInputTimestamps.removeAll()
+                let doneIds = sessionMonitor.instances
+                    .filter { $0.phase == .waitingForInput }
+                    .map { $0.stableId }
+                acknowledgedSessionIds.formUnion(doneIds)
             }
         case .closed:
             // Don't hide on non-notched devices - users need a visible target
@@ -449,6 +483,12 @@ struct NotchView: View {
         let waitingForInputSessions = instances.filter { $0.phase == .waitingForInput }
         let currentIds = Set(waitingForInputSessions.map { $0.stableId })
         let newWaitingIds = currentIds.subtracting(previousWaitingForInputIds)
+
+        // When a session leaves waitingForInput (starts processing again), clear its acknowledged flag
+        let noLongerWaiting = previousWaitingForInputIds.subtracting(currentIds)
+        for staleId in noLongerWaiting {
+            acknowledgedSessionIds.remove(staleId)
+        }
 
         // Track timestamps for newly waiting sessions
         let now = Date()

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -29,6 +29,11 @@ struct NotchView: View {
 
     @Namespace private var activityNamespace
 
+    /// Whether there are any active Claude sessions
+    private var hasSessions: Bool {
+        !sessionMonitor.instances.isEmpty
+    }
+
     /// Whether any Claude session is currently processing or compacting
     private var isAnyProcessing: Bool {
         sessionMonitor.instances.contains { $0.phase == .processing || $0.phase == .compacting }
@@ -194,6 +199,7 @@ struct NotchView: View {
             if !viewModel.hasPhysicalNotch {
                 isVisible = true
             }
+            viewModel.hasSessions = !sessionMonitor.instances.isEmpty
         }
         .onChange(of: viewModel.status) { oldStatus, newStatus in
             handleStatusChange(from: oldStatus, to: newStatus)
@@ -202,6 +208,7 @@ struct NotchView: View {
             handlePendingSessionsChange(sessions)
         }
         .onChange(of: sessionMonitor.instances) { _, instances in
+            viewModel.hasSessions = !instances.isEmpty
             handleProcessingChange()
             handleWaitingForInputChange(instances)
         }
@@ -384,11 +391,17 @@ struct NotchView: View {
             // Hide activity when done
             activityCoordinator.hideActivity()
 
+            // Keep visible as long as sessions exist — notch stays accessible
+            if hasSessions {
+                isVisible = true
+                return
+            }
+
             // Delay hiding the notch until animation completes
             // Don't hide on non-notched devices - users need a visible target
             if viewModel.status == .closed && viewModel.hasPhysicalNotch {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    if !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && viewModel.status == .closed {
+                    if !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !hasSessions && viewModel.status == .closed {
                         isVisible = false
                     }
                 }
@@ -409,7 +422,10 @@ struct NotchView: View {
             guard viewModel.hasPhysicalNotch else { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
                 if viewModel.status == .closed && !isAnyProcessing && !hasPendingPermission && !hasWaitingForInput && !activityCoordinator.expandingActivity.show {
-                    isVisible = false
+                    // Only hide if no sessions remain
+                    if !hasSessions {
+                        isVisible = false
+                    }
                 }
             }
         }

--- a/ClaudeIsland/UI/Window/NotchWindowController.swift
+++ b/ClaudeIsland/UI/Window/NotchWindowController.swift
@@ -62,23 +62,23 @@ class NotchWindowController: NSWindowController {
         notchWindow.setFrame(windowFrame, display: true)
 
         // Dynamically toggle mouse event handling based on notch state:
-        // - Closed: ignoresMouseEvents = true (clicks pass through to menu bar/apps)
+        // - Closed, no sessions: ignoresMouseEvents = true (clicks pass through to menu bar/apps)
+        // - Closed, has sessions: ignoresMouseEvents = false (visible notch is interactive)
         // - Opened: ignoresMouseEvents = false (buttons inside panel work)
         viewModel.$status
+            .combineLatest(viewModel.$hasSessions)
             .receive(on: DispatchQueue.main)
-            .sink { [weak notchWindow, weak viewModel] status in
+            .sink { [weak notchWindow, weak viewModel] (status, hasSessions) in
                 switch status {
                 case .opened:
-                    // Accept mouse events when opened so buttons work
                     notchWindow?.ignoresMouseEvents = false
-                    // Don't steal focus when opened by notification (task finished)
                     if viewModel?.openReason != .notification {
                         NSApp.activate(ignoringOtherApps: false)
                         notchWindow?.makeKey()
                     }
                 case .closed, .popping:
-                    // Ignore mouse events when closed so clicks pass through
-                    notchWindow?.ignoresMouseEvents = true
+                    // Accept events when sessions exist so the notch remains clickable
+                    notchWindow?.ignoresMouseEvents = !hasSessions
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## Summary

When sessions are idle (not processing, no pending approval), the notch shrinks to a thin minimal trace at the top of the screen rather than staying at full size. This keeps a subtle entry point always accessible without cluttering the menu bar.

Two visual states for the minimal trace:

| State | Appearance |
|-------|-----------|
| Idle, user has seen results | Faint thin trace, opacity 0.55 |
| Task done, user hasn't opened yet | Brighter trace (0.85) + soft green glow |

The green glow disappears once the user opens the notch. If a session starts processing again, the unacknowledged flag resets so the glow can reappear on next completion.

> **⚠️ Depends on:** #74 — this PR builds on the session-aware visibility logic introduced there. It is best reviewed after #74 is merged.

## Changes

`NotchView` only:
- `acknowledgedSessionIds` state: tracks which done sessions the user has seen
- `hasUnacknowledgedDone` computed: `true` if any `waitingForInput` session hasn't been acknowledged
- `isMinimalMode` computed: `true` when sessions exist, no activity, notch is closed
- Visual: `scaleEffect(y: 0.22)` + opacity + green glow overlay when in minimal mode
- `handleStatusChange`: mark done sessions as acknowledged on manual open
- `handleWaitingForInputChange`: clear acknowledged flag when a session starts processing again

## Test plan

- [ ] Start a Claude session, let it go idle — notch should shrink to a thin trace
- [ ] Complete a task without opening the notch — trace should glow green
- [ ] Click the notch — opens normally, glow disappears after closing
- [ ] Start another task and complete it — glow reappears
- [ ] Open the notch and close it — quiet trace remains while session is still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)