### PR TITLE
Fix 8 bugs: security, correctness, and performance issues

### DIFF
--- a/ClaudeIsland/Models/ChatMessage.swift
+++ b/ClaudeIsland/Models/ChatMessage.swift
@@ -6,6 +6,17 @@
 //
 
 import Foundation
+import CryptoKit
+
+/// Produces a stable hex hash string that is consistent across app launches.
+/// Swift's hashValue is randomized per process, making it unsuitable for identifiers.
+enum StableHash {
+    static func hash(_ string: Substring) -> String {
+        let data = Data(string.utf8)
+        let digest = SHA256.hash(data: data)
+        return digest.compactMap { String(format: "%02x", $0) }.prefix(8).joined()
+    }
+}
 
 struct ChatMessage: Identifiable, Equatable {
     let id: String
@@ -43,11 +54,11 @@ enum MessageBlock: Equatable, Identifiable {
     var id: String {
         switch self {
         case .text(let text):
-            return "text-\(text.prefix(20).hashValue)"
+            return "text-\(StableHash.hash(text.prefix(100)))"
         case .toolUse(let block):
             return "tool-\(block.id)"
         case .thinking(let text):
-            return "thinking-\(text.prefix(20).hashValue)"
+            return "thinking-\(StableHash.hash(text.prefix(100)))"
         case .interrupted:
             return "interrupted"
         }

--- a/ClaudeIsland/Models/ToolResultData.swift
+++ b/ClaudeIsland/Models/ToolResultData.swift
@@ -253,7 +253,12 @@ struct GenericResult: Equatable, @unchecked Sendable {
     let rawData: [String: Any]?
 
     static func == (lhs: GenericResult, rhs: GenericResult) -> Bool {
-        lhs.rawContent == rhs.rawContent
+        guard lhs.rawContent == rhs.rawContent else { return false }
+        // Compare rawData dictionaries if both present
+        if let lhsData = lhs.rawData, let rhsData = rhs.rawData {
+            return NSDictionary(dictionary: lhsData).isEqual(to: rhsData)
+        }
+        return lhs.rawData == nil && rhs.rawData == nil
     }
 }
 

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -174,7 +174,7 @@ class HookSocketServer {
             return
         }
 
-        chmod(Self.socketPath, 0o777)
+        chmod(Self.socketPath, 0o600)
 
         guard listen(serverSocket, 10) == 0 else {
             logger.error("Failed to listen: \(errno)")

--- a/ClaudeIsland/Services/Session/ConversationParser.swift
+++ b/ClaudeIsland/Services/Session/ConversationParser.swift
@@ -24,6 +24,13 @@ actor ConversationParser {
     /// Logger for conversation parser (nonisolated static for cross-context access)
     nonisolated static let logger = Logger(subsystem: "com.claudeisland", category: "Parser")
 
+    /// Shared ISO8601 date formatter (expensive to create, reused across all message parsing)
+    nonisolated private static let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
     /// Cache of parsed conversation info, keyed by session file path
     private var cache: [String: CachedInfo] = [:]
 
@@ -108,8 +115,7 @@ actor ConversationParser {
         var firstUserMessage: String?
         var lastUserMessageDate: Date?
 
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let formatter = Self.isoFormatter
 
         for line in lines {
             guard let lineData = line.data(using: .utf8),
@@ -483,9 +489,7 @@ actor ConversationParser {
 
         let timestamp: Date
         if let timestampStr = json["timestamp"] as? String {
-            let formatter = ISO8601DateFormatter()
-            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            timestamp = formatter.date(from: timestampStr) ?? Date()
+            timestamp = Self.isoFormatter.date(from: timestampStr) ?? Date()
         } else {
             timestamp = Date()
         }

--- a/ClaudeIsland/Utilities/MCPToolFormatter.swift
+++ b/ClaudeIsland/Utilities/MCPToolFormatter.swift
@@ -114,10 +114,10 @@ struct MCPToolFormatter {
             let stringValue: String
             if let str = value as? String {
                 stringValue = str
-            } else if let num = value as? NSNumber {
-                stringValue = num.stringValue
             } else if let bool = value as? Bool {
                 stringValue = bool ? "true" : "false"
+            } else if let num = value as? NSNumber {
+                stringValue = num.stringValue
             } else {
                 stringValue = String(describing: value)
             }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Build Claude Island for release
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -26,13 +26,17 @@ xcodebuild archive \
     -destination "generic/platform=macOS" \
     ENABLE_HARDENED_RUNTIME=YES \
     CODE_SIGN_STYLE=Automatic \
-    | xcpretty || xcodebuild archive \
-    -scheme ClaudeIsland \
-    -configuration Release \
-    -archivePath "$ARCHIVE_PATH" \
-    -destination "generic/platform=macOS" \
-    ENABLE_HARDENED_RUNTIME=YES \
-    CODE_SIGN_STYLE=Automatic
+    2>&1 | xcpretty || {
+    echo "ERROR: Archive failed. Re-running with full output..."
+    xcodebuild archive \
+        -scheme ClaudeIsland \
+        -configuration Release \
+        -archivePath "$ARCHIVE_PATH" \
+        -destination "generic/platform=macOS" \
+        ENABLE_HARDENED_RUNTIME=YES \
+        CODE_SIGN_STYLE=Automatic
+    exit 1
+}
 
 # Create ExportOptions.plist if it doesn't exist
 EXPORT_OPTIONS="$BUILD_DIR/ExportOptions.plist"
@@ -58,10 +62,14 @@ xcodebuild -exportArchive \
     -archivePath "$ARCHIVE_PATH" \
     -exportPath "$EXPORT_PATH" \
     -exportOptionsPlist "$EXPORT_OPTIONS" \
-    | xcpretty || xcodebuild -exportArchive \
-    -archivePath "$ARCHIVE_PATH" \
-    -exportPath "$EXPORT_PATH" \
-    -exportOptionsPlist "$EXPORT_OPTIONS"
+    2>&1 | xcpretty || {
+    echo "ERROR: Export failed. Re-running with full output..."
+    xcodebuild -exportArchive \
+        -archivePath "$ARCHIVE_PATH" \
+        -exportPath "$EXPORT_PATH" \
+        -exportOptionsPlist "$EXPORT_OPTIONS"
+    exit 1
+}
 
 echo ""
 echo "=== Build Complete ==="

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -249,19 +249,26 @@ if [ -d "$WEBSITE_PUBLIC" ] && [ -f "$RELEASE_DIR/appcast/appcast.xml" ]; then
         echo "Updated appcast.xml with GitHub download URL"
     fi
 
-    # Update src/config.ts with latest version and download URL
+    # Update src/config.ts with latest version and download URL (preserve other content)
     CONFIG_FILE="$WEBSITE_DIR/src/config.ts"
     if [ -n "$GITHUB_DOWNLOAD_URL" ]; then
-        cat > "$CONFIG_FILE" << EOF
+        if [ -f "$CONFIG_FILE" ]; then
+            # Update existing constants in-place
+            sed -i '' "s|export const LATEST_VERSION = .*|export const LATEST_VERSION = \"$VERSION\";|" "$CONFIG_FILE"
+            sed -i '' "s|export const DOWNLOAD_URL = .*|export const DOWNLOAD_URL = \"$GITHUB_DOWNLOAD_URL\";|" "$CONFIG_FILE"
+        else
+            # Create new config file
+            cat > "$CONFIG_FILE" << EOF
 // Auto-updated by create-release.sh
 export const LATEST_VERSION = "$VERSION";
 export const DOWNLOAD_URL = "$GITHUB_DOWNLOAD_URL";
 EOF
+        fi
         echo "Updated src/config.ts with version $VERSION"
     fi
 
     # Commit and push website changes
-    cd "$WEBSITE_DIR"
+    cd "$WEBSITE_DIR" || exit 1
     if [ -d ".git" ]; then
         git add public/appcast.xml src/config.ts
         if ! git diff --cached --quiet; then

--- a/scripts/generate-keys.sh
+++ b/scripts/generate-keys.sh
@@ -65,11 +65,15 @@ echo ""
 
 # Generate the key pair (stores in Keychain, prints public key)
 echo "Generating EdDSA key pair..."
-PUBLIC_KEY=$("$GENERATE_KEYS" | grep -oE '[A-Za-z0-9+/=]{40,}')
+PUBLIC_KEY=$("$GENERATE_KEYS" -p 2>/dev/null | grep -oE '[A-Za-z0-9+/=]{40,}')
 
-# Export private key to file
+# Export the private key from Keychain to file (same key pair as above)
 echo "Exporting private key to file..."
 "$GENERATE_KEYS" -x "$KEYS_DIR/eddsa_private_key"
+
+# Restrict permissions on private key
+chmod 600 "$KEYS_DIR/eddsa_private_key"
+chmod 700 "$KEYS_DIR"
 
 echo ""
 echo "=== IMPORTANT ==="


### PR DESCRIPTION
## Summary

Found and fixed 8 bugs across Swift, shell scripts during a thorough code review:

### Security
- **HookSocketServer.swift**: Unix domain socket created with `0o777` (world-writable) — any process could send forged hook events including fake permission approvals. Changed to `0o600` (owner-only).

### Correctness
- **MCPToolFormatter.swift**: `Bool` check was unreachable — `as? NSNumber` matches before `as? Bool`, so boolean values were formatted as `"1"/"0"` instead of `"true"/"false"`. Swapped check order.
- **ToolResultData.swift**: `GenericResult.==` only compared `rawContent`, ignoring `rawData`. SwiftUI could miss state changes when only `rawData` differed. Added `rawData` comparison via `NSDictionary.isEqual(to:)`.
- **ChatMessage.swift**: `MessageBlock.id` used `hashValue` which is randomized per process launch in Swift 4.2+, causing unstable IDs and potential UI flickering across app restarts. Replaced with deterministic SHA256-based hash.
- **generate-keys.sh**: `generate_keys` was called twice — first to capture public key, second to export private key. The second call generated a **new** key pair, so the public key (printed to terminal for Info.plist) and the exported private key were from different pairs. Fixed by using `-p` flag on the first call. Also added `chmod 600/700` on private key and directory.
- **create-release.sh**: `cat >` completely overwrote `src/config.ts`, destroying any other exports in the file. Changed to use `sed` for in-place updates when file exists.

### Performance
- **ConversationParser.swift**: `ISO8601DateFormatter` was created per message line (~2μs each, expensive). For JSONL files with hundreds of lines, this was significant. Extracted to a reusable static property.

### Build Reliability
- **build.sh**: Added `set -o pipefail` so xcodebuild failures propagate through `xcpretty` pipe. Improved fallback pattern to show full build output on failure instead of silently retrying.

## Test plan
- [ ] Build the project in Xcode — verify no compile errors
- [ ] Verify MCP tool args display "true"/"false" instead of "1"/"0" for boolean values
- [ ] Verify socket file at `/tmp/claude-island.sock` has `600` permissions after launch
- [ ] Verify chat history loads without flickering on second app launch
- [ ] Verify `generate-keys.sh` produces matching key pairs (public key matches private key)
- [ ] Verify private key file has `600` permissions
- [ ] Verify `build.sh` correctly fails and shows full xcodebuild output on error
- [ ] Verify `create-release.sh` preserves other exports in `src/config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)