### PR TITLE
feat: add zellij support for session focus

### DIFF
--- a/ClaudeIsland/Models/SessionState.swift
+++ b/ClaudeIsland/Models/SessionState.swift
@@ -21,7 +21,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
 
     var pid: Int?
     var tty: String?
-    var isInTmux: Bool
+    var multiplexer: TerminalMultiplexer
 
     // MARK: - State Machine
 
@@ -70,7 +70,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         projectName: String? = nil,
         pid: Int? = nil,
         tty: String? = nil,
-        isInTmux: Bool = false,
+        multiplexer: TerminalMultiplexer = .none,
         phase: SessionPhase = .idle,
         chatItems: [ChatHistoryItem] = [],
         toolTracker: ToolTracker = ToolTracker(),
@@ -88,7 +88,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         self.projectName = projectName ?? URL(fileURLWithPath: cwd).lastPathComponent
         self.pid = pid
         self.tty = tty
-        self.isInTmux = isInTmux
+        self.multiplexer = multiplexer
         self.phase = phase
         self.chatItems = chatItems
         self.toolTracker = toolTracker
@@ -100,6 +100,9 @@ struct SessionState: Equatable, Identifiable, Sendable {
     }
 
     // MARK: - Derived Properties
+
+    /// Whether this session is running inside a terminal multiplexer (tmux or zellij)
+    var isMultiplexed: Bool { multiplexer != .none }
 
     /// Whether this session needs user attention
     var needsAttention: Bool {

--- a/ClaudeIsland/Models/TerminalMultiplexer.swift
+++ b/ClaudeIsland/Models/TerminalMultiplexer.swift
@@ -1,0 +1,11 @@
+//
+//  TerminalMultiplexer.swift
+//  ClaudeIsland
+//
+
+/// The terminal multiplexer a Claude session is running inside
+enum TerminalMultiplexer: Equatable, Sendable {
+    case tmux
+    case zellij
+    case none
+}

--- a/ClaudeIsland/Services/Shared/ProcessTreeBuilder.swift
+++ b/ClaudeIsland/Services/Shared/ProcessTreeBuilder.swift
@@ -54,21 +54,21 @@ struct ProcessTreeBuilder: Sendable {
         return tree
     }
 
-    /// Check if a process has tmux in its parent chain
-    nonisolated func isInTmux(pid: Int, tree: [Int: ProcessInfo]) -> Bool {
+    /// Detect which terminal multiplexer (if any) a process is running inside
+    nonisolated func detectMultiplexer(pid: Int, tree: [Int: ProcessInfo]) -> TerminalMultiplexer {
         var current = pid
         var depth = 0
 
         while current > 1 && depth < 20 {
             guard let info = tree[current] else { break }
-            if info.command.lowercased().contains("tmux") {
-                return true
-            }
+            let cmd = info.command.lowercased()
+            if cmd.contains("tmux") { return .tmux }
+            if cmd.contains("zellij") { return .zellij }
             current = info.ppid
             depth += 1
         }
 
-        return false
+        return .none
     }
 
     /// Walk up the process tree to find the terminal app PID

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -128,7 +128,7 @@ actor SessionStore {
         session.pid = event.pid
         if let pid = event.pid {
             let tree = ProcessTreeBuilder.shared.buildTree()
-            session.isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: pid, tree: tree)
+            session.multiplexer = ProcessTreeBuilder.shared.detectMultiplexer(pid: pid, tree: tree)
         }
         if let tty = event.tty {
             session.tty = tty.replacingOccurrences(of: "/dev/", with: "")
@@ -176,7 +176,7 @@ actor SessionStore {
             projectName: URL(fileURLWithPath: event.cwd).lastPathComponent,
             pid: event.pid,
             tty: event.tty?.replacingOccurrences(of: "/dev/", with: ""),
-            isInTmux: false,  // Will be updated
+            multiplexer: .none,  // Will be updated
             phase: .idle
         )
     }

--- a/ClaudeIsland/Services/Zellij/ZellijController.swift
+++ b/ClaudeIsland/Services/Zellij/ZellijController.swift
@@ -1,0 +1,150 @@
+//
+//  ZellijController.swift
+//  ClaudeIsland
+//
+//  Focus zellij panes and activate the terminal window for a Claude session.
+//
+
+import AppKit
+import Foundation
+
+actor ZellijController {
+    static let shared = ZellijController()
+
+    private var cachedPath: String?
+
+    private init() {}
+
+    // MARK: - Public API
+
+    func focusPane(forClaudePid claudePid: Int) async -> Bool {
+        guard let zellijPath = getZellijPath() else { return false }
+        guard let sessionName = readZellijSessionName(forPid: claudePid) else { return false }
+        let cwd = ProcessTreeBuilder.shared.getWorkingDirectory(forPid: claudePid)
+        let tabName = cwd.flatMap { findTabName(forCwd: $0, sessionName: sessionName, zellijPath: zellijPath) }
+        return await switchToTab(sessionName, tabName: tabName, zellijPath: zellijPath)
+    }
+
+    func focusPane(forWorkingDirectory cwd: String) async -> Bool {
+        guard let zellijPath = getZellijPath() else { return false }
+        let tree = ProcessTreeBuilder.shared.buildTree()
+
+        for zellijPid in tree.values.filter({ $0.command.lowercased().contains("zellij") }).map({ $0.pid }) {
+            for pid in ProcessTreeBuilder.shared.findDescendants(of: zellijPid, tree: tree) {
+                guard let sessionName = readZellijSessionName(forPid: pid),
+                      let processCwd = ProcessTreeBuilder.shared.getWorkingDirectory(forPid: pid),
+                      processCwd == cwd else { continue }
+                let tabName = findTabName(forCwd: cwd, sessionName: sessionName, zellijPath: zellijPath)
+                return await switchToTab(sessionName, tabName: tabName, zellijPath: zellijPath)
+            }
+        }
+        return false
+    }
+
+    // MARK: - Path
+
+    func getZellijPath() -> String? {
+        if let cached = cachedPath { return cached }
+        let candidates = ["/opt/homebrew/bin/zellij", "/usr/local/bin/zellij", "/usr/bin/zellij"]
+        if let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            cachedPath = found
+            return found
+        }
+        return nil
+    }
+
+    // MARK: - Session Name
+
+    private nonisolated func readZellijSessionName(forPid pid: Int) -> String? {
+        guard let output = ProcessExecutor.shared.runSyncOrNil(
+            "/bin/ps", arguments: ["eww", "-p", String(pid)]
+        ) else { return nil }
+
+        for token in output.split(separator: " ") {
+            let s = String(token)
+            if s.hasPrefix("ZELLIJ_SESSION_NAME=") {
+                return String(s.dropFirst("ZELLIJ_SESSION_NAME=".count))
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Tab Discovery
+
+    /// Find the tab name in `dump-layout` whose pane cwd matches `targetCwd`.
+    private nonisolated func findTabName(forCwd targetCwd: String, sessionName: String, zellijPath: String) -> String? {
+        guard let layout = ProcessExecutor.shared.runSyncOrNil(
+            zellijPath, arguments: ["--session", sessionName, "action", "dump-layout"]
+        ) else { return nil }
+        return parseTabContaining(cwd: targetCwd, fromLayout: layout)
+    }
+
+    /// Single-pass KDL layout parser.
+    ///
+    /// Layout structure (relevant lines):
+    ///   layout {
+    ///     cwd "/absolute/base"          ← least-indented cwd line is the base
+    ///     tab name="foo" { ... }
+    ///       pane cwd="relative/path"    ← relative to base
+    ///   }
+    private nonisolated func parseTabContaining(cwd targetCwd: String, fromLayout layout: String) -> String? {
+        var baseCwd = ""
+        var baseCwdIndent = Int.max
+        var currentTab: String? = nil
+
+        for line in layout.components(separatedBy: "\n") {
+            guard !line.trimmingCharacters(in: .whitespaces).isEmpty else { continue }
+            let indent = line.prefix(while: { $0 == " " }).count
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("cwd \"") && indent < baseCwdIndent {
+                baseCwdIndent = indent
+                baseCwd = extractKDLString(from: trimmed, after: "cwd ")
+            } else if trimmed.hasPrefix("tab ") {
+                currentTab = extractKDLStringAttr(key: "name", from: trimmed)
+            } else if trimmed.hasPrefix("pane "), let paneCwd = extractKDLStringAttr(key: "cwd", from: trimmed) {
+                let absolute = paneCwd.hasPrefix("/") ? paneCwd : "\(baseCwd)/\(paneCwd)"
+                if absolute == targetCwd, let tab = currentTab { return tab }
+            }
+        }
+        return nil
+    }
+
+    /// Extract a quoted string value: `key="value"` → `"value"`.
+    private nonisolated func extractKDLStringAttr(key: String, from line: String) -> String? {
+        guard let range = line.range(of: "\(key)=\"", options: .literal) else { return nil }
+        let after = line[range.upperBound...]
+        guard let end = after.firstIndex(of: "\"") else { return nil }
+        return String(after[..<end])
+    }
+
+    /// Extract a bare quoted string: `prefix "value"` → `"value"`.
+    private nonisolated func extractKDLString(from line: String, after prefix: String) -> String {
+        let trimmed = line.hasPrefix(prefix) ? String(line.dropFirst(prefix.count)) : line
+        return trimmed.trimmingCharacters(in: .init(charactersIn: "\" "))
+            .components(separatedBy: "\"").first ?? ""
+    }
+
+    // MARK: - Focus
+
+    private func switchToTab(_ sessionName: String, tabName: String?, zellijPath: String) async -> Bool {
+        if let tab = tabName {
+            _ = try? await ProcessExecutor.shared.run(
+                zellijPath,
+                arguments: ["--session", sessionName, "action", "go-to-tab-name", tab]
+            )
+        }
+        return activateTerminalWindow()
+    }
+
+    @discardableResult
+    private nonisolated func activateTerminalWindow() -> Bool {
+        for bundleId in TerminalAppRegistry.bundleIdentifiers {
+            if let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first {
+                app.activate(options: .activateIgnoringOtherApps)
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -355,7 +355,7 @@ struct ChatView: View {
 
     /// Can send messages only if session is in tmux
     private var canSendMessages: Bool {
-        session.isInTmux && session.tty != nil
+        session.isMultiplexed && session.tty != nil
     }
 
     private var inputBar: some View {
@@ -422,7 +422,7 @@ struct ChatView: View {
     /// Bar for interactive tools like AskUserQuestion that need terminal input
     private var interactivePromptBar: some View {
         ChatInteractivePromptBar(
-            isInTmux: session.isInTmux,
+            isInTmux: session.isMultiplexed,
             onGoToTerminal: { focusTerminal() }
         )
     }
@@ -479,7 +479,7 @@ struct ChatView: View {
     }
 
     private func sendToSession(_ text: String) async {
-        guard session.isInTmux else { return }
+        guard session.isMultiplexed else { return }
         guard let tty = session.tty else { return }
 
         if let target = await findTmuxTarget(tty: tty) {

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -353,9 +353,9 @@ struct ChatView: View {
 
     // MARK: - Input Bar
 
-    /// Can send messages only if session is in tmux
+    /// Messaging is only supported in tmux (zellij lacks per-pane write support)
     private var canSendMessages: Bool {
-        session.isMultiplexed && session.tty != nil
+        session.multiplexer == .tmux && session.tty != nil
     }
 
     private var inputBar: some View {
@@ -422,7 +422,7 @@ struct ChatView: View {
     /// Bar for interactive tools like AskUserQuestion that need terminal input
     private var interactivePromptBar: some View {
         ChatInteractivePromptBar(
-            isInTmux: session.isMultiplexed,
+            isInTmux: session.multiplexer == .tmux,
             onGoToTerminal: { focusTerminal() }
         )
     }
@@ -479,9 +479,7 @@ struct ChatView: View {
     }
 
     private func sendToSession(_ text: String) async {
-        guard session.isMultiplexed else { return }
-        guard let tty = session.tty else { return }
-
+        guard session.multiplexer == .tmux, let tty = session.tty else { return }
         if let target = await findTmuxTarget(tty: tty) {
             _ = await ToolApprovalHandler.shared.sendMessage(text, to: target)
         }

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -88,13 +88,18 @@ struct ClaudeInstancesView: View {
     // MARK: - Actions
 
     private func focusSession(_ session: SessionState) {
-        guard session.isInTmux else { return }
-
+        let pid = session.pid
+        let cwd = session.cwd
         Task {
-            if let pid = session.pid {
-                _ = await YabaiController.shared.focusWindow(forClaudePid: pid)
-            } else {
-                _ = await YabaiController.shared.focusWindow(forWorkingDirectory: session.cwd)
+            switch session.multiplexer {
+            case .tmux:
+                if let pid { _ = await YabaiController.shared.focusWindow(forClaudePid: pid) }
+                else { _ = await YabaiController.shared.focusWindow(forWorkingDirectory: cwd) }
+            case .zellij:
+                if let pid { _ = await ZellijController.shared.focusPane(forClaudePid: pid) }
+                else { _ = await ZellijController.shared.focusPane(forWorkingDirectory: cwd) }
+            case .none:
+                break
             }
         }
     }
@@ -128,8 +133,6 @@ struct InstanceRow: View {
 
     @State private var isHovered = false
     @State private var spinnerPhase = 0
-    @State private var isYabaiAvailable = false
-
     private let claudeOrange = Color(red: 0.85, green: 0.47, blue: 0.34)
     private let spinnerSymbols = ["·", "✢", "✳", "∗", "✻", "✽"]
     private let spinnerTimer = Timer.publish(every: 0.15, on: .main, in: .common).autoconnect()
@@ -234,10 +237,10 @@ struct InstanceRow: View {
                         onChat()
                     }
 
-                    // Go to Terminal button (only if yabai available)
-                    if isYabaiAvailable {
+                    // Go to Terminal button (available for tmux and zellij)
+                    if session.isMultiplexed {
                         TerminalButton(
-                            isEnabled: session.isInTmux,
+                            isEnabled: true,
                             onTap: { onFocus() }
                         )
                     }
@@ -257,8 +260,8 @@ struct InstanceRow: View {
                         onChat()
                     }
 
-                    // Focus icon (only for tmux instances with yabai)
-                    if session.isInTmux && isYabaiAvailable {
+                    // Focus icon (available for tmux and zellij)
+                    if session.isMultiplexed {
                         IconButton(icon: "eye") {
                             onFocus()
                         }
@@ -287,9 +290,6 @@ struct InstanceRow: View {
                 .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
         )
         .onHover { isHovered = $0 }
-        .task {
-            isYabaiAvailable = await WindowFinder.shared.isYabaiAvailable()
-        }
     }
 
     @ViewBuilder

--- a/ClaudeIsland/Utilities/TerminalVisibilityDetector.swift
+++ b/ClaudeIsland/Utilities/TerminalVisibilityDetector.swift
@@ -50,9 +50,9 @@ struct TerminalVisibilityDetector {
         }
 
         let tree = ProcessTreeBuilder.shared.buildTree()
-        let isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: sessionPid, tree: tree)
+        let multiplexer = ProcessTreeBuilder.shared.detectMultiplexer(pid: sessionPid, tree: tree)
 
-        if isInTmux {
+        if multiplexer == .tmux {
             // For tmux sessions, check if the session's pane is active
             return await TmuxTargetFinder.shared.isSessionPaneActive(claudePid: sessionPid)
         } else {

--- a/not a tty
+++ b/not a tty
@@ -1,0 +1,1 @@
+test message from claude island

--- a/not a tty
+++ b/not a tty
@@ -1,1 +1,0 @@
-test message from claude island


### PR DESCRIPTION
## Summary

- Replaces `isInTmux: Bool` with `multiplexer: TerminalMultiplexer` enum (`.tmux` / `.zellij` / `.none`) — auto-detected by walking the process tree, no user configuration needed
- Adds `ZellijController` that focuses the correct zellij tab by matching pane `cwd` against `dump-layout` output, then activates the terminal window via `NSWorkspace`
- Focus button is now shown for both tmux and zellij sessions, removing the yabai dependency for button visibility
- Messaging remains tmux-only — zellij's `write-chars` action targets the focused pane only (no per-pane targeting without a plugin), so enabling it would silently send to the wrong pane

## How it works

**Focus (zellij):**
1. Read `ZELLIJ_SESSION_NAME` from the Claude process environment via `ps eww`
2. Run `zellij action dump-layout` to parse tab → pane cwd mappings
3. Match the Claude process cwd against pane cwds (resolving relative paths against the layout base cwd)
4. Switch to the matching tab with `go-to-tab-name`, then activate the terminal window

**Detection:**
Process tree is walked upward from the Claude PID. First ancestor matching `tmux` → `.tmux`, `zellij` → `.zellij`, neither → `.none`.

## Test plan

- [ ] tmux: focus button appears, clicking switches to correct pane and activates terminal
- [ ] tmux: messaging works as before
- [ ] zellij: focus button appears, clicking switches to correct tab and activates terminal
- [ ] zellij: input bar shows "Open Claude Code in tmux to enable messaging" (disabled)
- [ ] neither: focus button hidden, messaging disabled