### PR TITLE
feat: multi-profile usage monitoring with real-time rate limit bars

### DIFF
--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -50,6 +50,7 @@ class NotchViewModel: ObservableObject {
 
     private let screenSelector = ScreenSelector.shared
     private let soundSelector = SoundSelector.shared
+    private let usageSettings = UsageSettings.shared
 
     // MARK: - Geometry
 
@@ -74,7 +75,7 @@ class NotchViewModel: ObservableObject {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
+                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight + usageSettings.expandedPickerHeight
             )
         case .instances:
             return CGSize(
@@ -115,6 +116,10 @@ class NotchViewModel: ObservableObject {
             .store(in: &cancellables)
 
         soundSelector.$isPickerExpanded
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+
+        usageSettings.$isPickerExpanded
             .sink { [weak self] _ in self?.objectWillChange.send() }
             .store(in: &cancellables)
     }

--- a/ClaudeIsland/Core/UsageSettings.swift
+++ b/ClaudeIsland/Core/UsageSettings.swift
@@ -11,6 +11,10 @@ import os.log
 
 private let logger = Logger(subsystem: "com.claudeisland", category: "UsageSettings")
 
+extension Notification.Name {
+    static let usagePlanDidChange = Notification.Name("usagePlanDidChange")
+}
+
 @MainActor
 class UsageSettings: ObservableObject {
     static let shared = UsageSettings()
@@ -66,10 +70,13 @@ class UsageSettings: ObservableObject {
         return detected
     }
 
-    /// Set plan for a profile (manual override)
+    /// Set plan for a profile (manual override).
+    /// Invalidates cached lifetime savings so they're recomputed with the new fee.
     func setPlan(_ plan: PlanType, for profile: String) {
         profilePlans[profile] = plan
         savePreferences()
+        // Trigger lifetime savings recomputation on next refresh
+        NotificationCenter.default.post(name: .usagePlanDidChange, object: profile)
     }
 
     /// Get the most recent weekly reset date for a profile

--- a/ClaudeIsland/Core/UsageSettings.swift
+++ b/ClaudeIsland/Core/UsageSettings.swift
@@ -1,0 +1,151 @@
+//
+//  UsageSettings.swift
+//  ClaudeIsland
+//
+//  Manages usage display preferences and per-profile plan configuration.
+//
+
+import Combine
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.claudeisland", category: "UsageSettings")
+
+@MainActor
+class UsageSettings: ObservableObject {
+    static let shared = UsageSettings()
+
+    // MARK: - Published State
+
+    @Published var profilePlans: [String: PlanType] = [:]
+    @Published var displayConfig: UsageDisplayConfig = .defaults
+    @Published var isPickerExpanded: Bool = false
+
+    /// Weekly reset day (1=Sunday, 2=Monday, ..., 6=Friday, 7=Saturday) per profile
+    /// Defaults to Friday (6) which is common for Anthropic's weekly reset
+    @Published var weeklyResetDay: [String: Int] = [:]
+
+    /// Weekly reset hour (0-23, in local time) per profile
+    @Published var weeklyResetHour: [String: Int] = [:]
+
+    // MARK: - Constants
+
+    private let plansKey = "usageProfilePlans"
+    private let displayConfigKey = "usageDisplayConfig"
+    private let weeklyResetDayKey = "usageWeeklyResetDay"
+    private let weeklyResetHourKey = "usageWeeklyResetHour"
+    private let rowHeight: CGFloat = 32
+
+    private init() {
+        loadPreferences()
+    }
+
+    // MARK: - Public API
+
+    /// Extra height needed when picker is expanded
+    var expandedPickerHeight: CGFloat {
+        guard isPickerExpanded else { return 0 }
+        let profileCount = max(profilePlans.count, 1)
+        let planOptions = 4  // Pro, Max 5x, Max 20x, Team
+        let toggleCount = 3  // showCost, showBurnRate, showSavings
+        let totalRows = toggleCount + profileCount * planOptions
+        let visibleRows = min(totalRows, 8)
+        return CGFloat(visibleRows) * rowHeight + 16
+    }
+
+    /// Get the plan for a profile, auto-detecting if not set
+    func getPlan(for profile: String) -> PlanType {
+        if let plan = profilePlans[profile] {
+            return plan
+        }
+        // Auto-detect and cache
+        let detected = PlanDetector.detectPlan(profile: profile)
+        profilePlans[profile] = detected
+        savePreferences()
+        logger.info("Auto-detected plan '\(detected.displayName, privacy: .public)' for profile '\(profile, privacy: .public)'")
+        return detected
+    }
+
+    /// Set plan for a profile (manual override)
+    func setPlan(_ plan: PlanType, for profile: String) {
+        profilePlans[profile] = plan
+        savePreferences()
+    }
+
+    /// Get the most recent weekly reset date for a profile
+    func lastWeeklyReset(for profile: String) -> Date {
+        let resetDay = weeklyResetDay[profile] ?? 6  // Default: Friday
+        let resetHour = weeklyResetHour[profile] ?? 14  // Default: 2 PM
+
+        let calendar = Calendar.current
+        let now = Date()
+        let currentWeekday = calendar.component(.weekday, from: now)
+        let currentHour = calendar.component(.hour, from: now)
+
+        // Calculate days since last reset day
+        var daysSinceReset = (currentWeekday - resetDay + 7) % 7
+        // If it's the reset day but before the reset hour, go back a full week
+        if daysSinceReset == 0 && currentHour < resetHour {
+            daysSinceReset = 7
+        }
+
+        guard let resetDate = calendar.date(byAdding: .day, value: -daysSinceReset, to: now) else { return now }
+        return calendar.date(bySettingHour: resetHour, minute: 0, second: 0, of: resetDate) ?? now
+    }
+
+    /// Re-detect plans for all registered profiles
+    func redetectPlans() {
+        for profile in profilePlans.keys {
+            let detected = PlanDetector.detectPlan(profile: profile)
+            profilePlans[profile] = detected
+        }
+        savePreferences()
+    }
+
+    /// Update display config
+    func updateDisplayConfig(_ config: UsageDisplayConfig) {
+        displayConfig = config
+        savePreferences()
+    }
+
+    // MARK: - Persistence
+
+    private func loadPreferences() {
+        // Load display config
+        if let data = UserDefaults.standard.data(forKey: displayConfigKey),
+           let config = try? JSONDecoder().decode(UsageDisplayConfig.self, from: data) {
+            displayConfig = config
+        }
+
+        // Load profile plans
+        if let data = UserDefaults.standard.data(forKey: plansKey),
+           let plans = try? JSONDecoder().decode([String: PlanType].self, from: data) {
+            profilePlans = plans
+        }
+
+        // Load weekly reset config
+        if let data = UserDefaults.standard.data(forKey: weeklyResetDayKey),
+           let days = try? JSONDecoder().decode([String: Int].self, from: data) {
+            weeklyResetDay = days
+        }
+        if let data = UserDefaults.standard.data(forKey: weeklyResetHourKey),
+           let hours = try? JSONDecoder().decode([String: Int].self, from: data) {
+            weeklyResetHour = hours
+        }
+    }
+
+    private func savePreferences() {
+        if let data = try? JSONEncoder().encode(displayConfig) {
+            UserDefaults.standard.set(data, forKey: displayConfigKey)
+        }
+        if let data = try? JSONEncoder().encode(profilePlans) {
+            UserDefaults.standard.set(data, forKey: plansKey)
+        }
+        if let data = try? JSONEncoder().encode(weeklyResetDay) {
+            UserDefaults.standard.set(data, forKey: weeklyResetDayKey)
+        }
+        if let data = try? JSONEncoder().encode(weeklyResetHour) {
+            UserDefaults.standard.set(data, forKey: weeklyResetHourKey)
+        }
+    }
+}

--- a/ClaudeIsland/Models/SessionState.swift
+++ b/ClaudeIsland/Models/SessionState.swift
@@ -22,6 +22,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
     var pid: Int?
     var tty: String?
     var isInTmux: Bool
+    var profile: String?
 
     // MARK: - State Machine
 
@@ -71,6 +72,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         pid: Int? = nil,
         tty: String? = nil,
         isInTmux: Bool = false,
+        profile: String? = nil,
         phase: SessionPhase = .idle,
         chatItems: [ChatHistoryItem] = [],
         toolTracker: ToolTracker = ToolTracker(),
@@ -89,6 +91,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         self.pid = pid
         self.tty = tty
         self.isInTmux = isInTmux
+        self.profile = profile
         self.phase = phase
         self.chatItems = chatItems
         self.toolTracker = toolTracker

--- a/ClaudeIsland/Models/UsageModels.swift
+++ b/ClaudeIsland/Models/UsageModels.swift
@@ -1,0 +1,318 @@
+//
+//  UsageModels.swift
+//  ClaudeIsland
+//
+//  Data models for usage monitoring, cost estimation, and plan configuration.
+//
+
+import Foundation
+
+// MARK: - Claude Model
+
+/// Normalized Claude model family for pricing lookups
+enum ClaudeModel: String, Sendable, Equatable, Codable, CaseIterable {
+    case opus
+    case sonnet
+    case haiku
+    case unknown
+
+    /// Normalize an API model name to a model family using prefix matching
+    static func from(apiModelName: String) -> ClaudeModel {
+        let name = apiModelName.lowercased()
+        if name.contains("opus") { return .opus }
+        if name.contains("sonnet") { return .sonnet }
+        if name.contains("haiku") { return .haiku }
+        return .unknown
+    }
+}
+
+// MARK: - Model Pricing
+
+/// Per-million-token pricing for a Claude model family
+struct ModelPricing: Sendable, Equatable {
+    let inputPerMillion: Double
+    let outputPerMillion: Double
+    let cacheCreatePerMillion: Double
+    let cacheReadPerMillion: Double
+
+    static let opus = ModelPricing(
+        inputPerMillion: 15.0,
+        outputPerMillion: 75.0,
+        cacheCreatePerMillion: 18.75,
+        cacheReadPerMillion: 1.50
+    )
+
+    static let sonnet = ModelPricing(
+        inputPerMillion: 3.0,
+        outputPerMillion: 15.0,
+        cacheCreatePerMillion: 3.75,
+        cacheReadPerMillion: 0.30
+    )
+
+    static let haiku = ModelPricing(
+        inputPerMillion: 0.25,
+        outputPerMillion: 1.25,
+        cacheCreatePerMillion: 0.30,
+        cacheReadPerMillion: 0.03
+    )
+
+    /// Get pricing for a model family. Unknown models use Sonnet pricing as a reasonable default.
+    static func pricing(for model: ClaudeModel) -> ModelPricing {
+        switch model {
+        case .opus: return .opus
+        case .sonnet: return .sonnet
+        case .haiku: return .haiku
+        case .unknown: return .sonnet
+        }
+    }
+}
+
+// MARK: - Plan Type
+
+/// Claude subscription plan type
+enum PlanType: Sendable, Equatable, Codable {
+    case pro
+    case max5x
+    case max20x
+    case team
+    case enterprise
+
+    var displayName: String {
+        switch self {
+        case .pro: return "Pro"
+        case .max5x: return "Max 5x"
+        case .max20x: return "Max 20x"
+        case .team: return "Team"
+        case .enterprise: return "Enterprise"
+        }
+    }
+
+    var monthlyFee: Double {
+        switch self {
+        case .pro: return 20.0
+        case .max5x: return 100.0
+        case .max20x: return 200.0
+        case .team: return 100.0
+        case .enterprise: return 0.0  // Custom pricing
+        }
+    }
+
+    /// Session cost limit (USD) per 5-hour window
+    /// From claude-monitor's observed plan limits. Rate-limit cost excludes cache_read tokens.
+    var sessionCostLimit: Double {
+        switch self {
+        case .pro: return 18.0
+        case .max5x: return 35.0
+        case .max20x: return 140.0
+        case .team: return 35.0      // Team with max_5x tier uses same limit
+        case .enterprise: return 140.0
+        }
+    }
+
+}
+
+// MARK: - Token Breakdown
+
+/// Token counts broken down by type, used for per-model tracking
+struct TokenBreakdown: Sendable, Equatable {
+    var input: Int
+    var output: Int
+    var cacheRead: Int
+    var cacheCreation: Int
+
+    var total: Int { input + output + cacheRead + cacheCreation }
+
+    static let zero = TokenBreakdown(input: 0, output: 0, cacheRead: 0, cacheCreation: 0)
+
+    /// Calculate full API cost using the given pricing
+    func cost(using pricing: ModelPricing) -> Double {
+        (Double(input) / 1_000_000) * pricing.inputPerMillion
+            + (Double(output) / 1_000_000) * pricing.outputPerMillion
+            + (Double(cacheCreation) / 1_000_000) * pricing.cacheCreatePerMillion
+            + (Double(cacheRead) / 1_000_000) * pricing.cacheReadPerMillion
+    }
+
+    /// Calculate rate-limit cost (excludes cache_read tokens, which Anthropic
+    /// does not count toward subscription rate limits)
+    func rateLimitCost(using pricing: ModelPricing) -> Double {
+        (Double(input) / 1_000_000) * pricing.inputPerMillion
+            + (Double(output) / 1_000_000) * pricing.outputPerMillion
+            + (Double(cacheCreation) / 1_000_000) * pricing.cacheCreatePerMillion
+    }
+
+    mutating func add(_ other: TokenBreakdown) {
+        input += other.input
+        output += other.output
+        cacheRead += other.cacheRead
+        cacheCreation += other.cacheCreation
+    }
+}
+
+// MARK: - Burn Rate
+
+/// Token consumption rate for a profile's 5-hour window
+struct BurnRate: Sendable, Equatable {
+    let tokensPerMinute: Double
+    let costPerHour: Double
+    let windowElapsedMinutes: Double
+
+    /// Utilization as a fraction (0.0-1.0+) of plan output token limit
+    let utilizationPercent: Double
+
+    /// Color tier based on utilization
+    var tier: UsageTier {
+        if utilizationPercent >= 0.9 { return .critical }
+        if utilizationPercent >= 0.5 { return .warning }
+        return .normal
+    }
+
+    static let zero = BurnRate(
+        tokensPerMinute: 0, costPerHour: 0,
+        windowElapsedMinutes: 0, utilizationPercent: 0
+    )
+}
+
+/// Usage severity tier for color coding
+enum UsageTier: Sendable, Equatable {
+    case normal   // green, < 50%
+    case warning  // amber, 50-90%
+    case critical // red, >= 90%
+}
+
+// MARK: - Cost Estimate
+
+/// Aggregated cost estimates for a profile
+struct CostEstimate: Sendable, Equatable {
+    let windowCost: Double         // 5h rolling window (full API cost for display)
+    let windowRateLimitCost: Double // 5h window excluding cache_read (for limit bars)
+    let dailyCost: Double          // Today
+    let monthlyCost: Double        // This calendar month
+    let monthlySavings: Double     // API cost - subscription fee (negative = losing money)
+
+    /// Formatted window cost
+    var formattedWindowCost: String {
+        String(format: "$%.2f", windowCost)
+    }
+
+    /// Formatted monthly cost
+    var formattedMonthlyCost: String {
+        String(format: "$%.2f", monthlyCost)
+    }
+
+    /// Formatted savings (only meaningful when positive)
+    var formattedSavings: String {
+        String(format: "$%.0f", max(0, monthlySavings))
+    }
+
+    static let zero = CostEstimate(
+        windowCost: 0, windowRateLimitCost: 0,
+        dailyCost: 0, monthlyCost: 0, monthlySavings: 0
+    )
+}
+
+// MARK: - Usage Display Config
+
+/// User preferences for what usage info to show in profile headers
+struct UsageDisplayConfig: Sendable, Equatable, Codable {
+    var showCost: Bool
+    var showBurnRate: Bool
+    var showSavings: Bool
+    var showLifetimeSavings: Bool
+    var showSessionBar: Bool
+    var showWeeklyBar: Bool
+
+    static let defaults = UsageDisplayConfig(
+        showCost: true, showBurnRate: true, showSavings: false,
+        showLifetimeSavings: true, showSessionBar: true,
+        showWeeklyBar: true
+    )
+}
+
+// MARK: - Period Usage
+
+/// Aggregated usage for a calendar period (day or month)
+struct PeriodUsage: Sendable, Equatable, Identifiable {
+    let id: String          // Period key (e.g., "2026-04-10" or "2026-04")
+    let label: String       // Display label
+    let tokens: TokenBreakdown
+    let cost: Double
+    let messageCount: Int
+    let models: Set<String> // Model families used
+}
+
+// MARK: - Lifetime Savings
+
+/// Lifetime savings data for a profile
+struct LifetimeSavings: Sendable, Equatable {
+    let totalAPICost: Double         // What it would have cost on API pricing
+    let totalSubscriptionCost: Double // What was paid in subscription fees
+    let monthsSubscribed: Int
+    let subscribedSince: Date?
+
+    var savings: Double { totalAPICost - totalSubscriptionCost }
+
+    var formattedSavings: String {
+        String(format: "$%.0f", max(0, savings))
+    }
+
+    var formattedAPICost: String {
+        let cost = totalAPICost
+        if cost >= 1000 {
+            return String(format: "$%.1fK", cost / 1000)
+        }
+        return String(format: "$%.0f", cost)
+    }
+
+    var sinceLabel: String {
+        guard let date = subscribedSince else { return "" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM yyyy"
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Usage Limit Info
+
+/// A single usage limit bar's data, with percentage from Anthropic's backend
+struct UsageLimitInfo: Sendable, Equatable, Identifiable {
+    let id: String              // "session" or "weekly"
+    let label: String           // Display label
+    let usedPercentage: Double  // 0-100, from Anthropic's rate_limits API
+    let resetsAt: Date?         // When this window resets
+
+    var fraction: Double {
+        min(usedPercentage / 100.0, 1.0)
+    }
+
+    var percentage: Int {
+        Int(usedPercentage.rounded())
+    }
+
+    var tier: UsageTier {
+        if fraction >= 0.9 { return .critical }
+        if fraction >= 0.5 { return .warning }
+        return .normal
+    }
+
+    var resetLabel: String {
+        guard let resetsAt = resetsAt else { return "" }
+        let remaining = resetsAt.timeIntervalSinceNow
+        guard remaining > 0 else { return "" }
+        let hours = Int(remaining / 3600)
+        let mins = Int(remaining.truncatingRemainder(dividingBy: 3600) / 60)
+        if hours > 0 { return "\(hours)h \(mins)m" }
+        return "\(mins)m"
+    }
+}
+
+// MARK: - Rate Limits State (from Anthropic's status line API)
+
+/// Rate limit data read from ~/.claude-island/{profile}.json
+/// Written by the statusline script, sourced from Claude Code's rate_limits
+struct RateLimitsState: Sendable, Equatable {
+    let fiveHourUsedPercentage: Double?
+    let fiveHourResetsAt: Date?
+    let sevenDayUsedPercentage: Double?
+    let sevenDayResetsAt: Date?
+    let timestamp: Date
+}

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -4,6 +4,7 @@ Claude Island Hook
 - Sends session state to ClaudeIsland.app via Unix socket
 - For PermissionRequest: waits for user decision from the app
 """
+import argparse
 import json
 import os
 import socket
@@ -11,6 +12,13 @@ import sys
 
 SOCKET_PATH = "/tmp/claude-island.sock"
 TIMEOUT_SECONDS = 300  # 5 minutes for permission decisions
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", default=None,
+                        help="Profile name (e.g., home, work)")
+    return parser.parse_args()
 
 
 def get_tty():
@@ -72,6 +80,8 @@ def send_event(state):
 
 
 def main():
+    args = parse_args()
+
     try:
         data = json.load(sys.stdin)
     except json.JSONDecodeError:
@@ -94,6 +104,10 @@ def main():
         "pid": claude_pid,
         "tty": tty,
     }
+
+    # Include profile if provided
+    if args.profile:
+        state["profile"] = args.profile
 
     # Map events to status
     if event == "UserPromptSubmit":

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -25,10 +25,11 @@ struct HookEvent: Codable, Sendable {
     let toolUseId: String?
     let notificationType: String?
     let message: String?
+    let profile: String?
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
-        case cwd, event, status, pid, tty, tool
+        case cwd, event, status, pid, tty, tool, profile
         case toolInput = "tool_input"
         case toolUseId = "tool_use_id"
         case notificationType = "notification_type"
@@ -36,7 +37,7 @@ struct HookEvent: Codable, Sendable {
     }
 
     /// Create a copy with updated toolUseId
-    init(sessionId: String, cwd: String, event: String, status: String, pid: Int?, tty: String?, tool: String?, toolInput: [String: AnyCodable]?, toolUseId: String?, notificationType: String?, message: String?) {
+    init(sessionId: String, cwd: String, event: String, status: String, pid: Int?, tty: String?, tool: String?, toolInput: [String: AnyCodable]?, toolUseId: String?, notificationType: String?, message: String?, profile: String? = nil) {
         self.sessionId = sessionId
         self.cwd = cwd
         self.event = event
@@ -48,6 +49,7 @@ struct HookEvent: Codable, Sendable {
         self.toolUseId = toolUseId
         self.notificationType = notificationType
         self.message = message
+        self.profile = profile
     }
 
     var sessionPhase: SessionPhase {
@@ -447,7 +449,8 @@ class HookSocketServer {
                 toolInput: event.toolInput,
                 toolUseId: toolUseId,  // Use resolved toolUseId
                 notificationType: event.notificationType,
-                message: event.message
+                message: event.message,
+                profile: event.profile
             )
 
             let pending = PendingPermission(

--- a/ClaudeIsland/Services/Hooks/PlanDetector.swift
+++ b/ClaudeIsland/Services/Hooks/PlanDetector.swift
@@ -1,0 +1,195 @@
+//
+//  PlanDetector.swift
+//  ClaudeIsland
+//
+//  Auto-detects Claude subscription plan from local config files and macOS Keychain.
+//
+
+import Foundation
+import os.log
+import Security
+
+private let logger = Logger(subsystem: "com.claudeisland", category: "PlanDetector")
+
+/// Detects the Claude subscription plan for a given profile
+enum PlanDetector {
+
+    // MARK: - Public API
+
+    /// Detect plan type for a profile by reading its config directory
+    static func detectPlan(configDir: String) -> PlanType {
+        // Step 1: Read .claude.json for heuristics
+        let heuristic = readConfigHeuristics(configDir: configDir)
+
+        // Step 2: Check keychain for precise plan info
+        let keychainPlans = readKeychainPlans()
+
+        // Step 3: Match keychain entry to this profile's heuristic
+        if let matched = matchKeychainToHeuristic(heuristic: heuristic, keychainPlans: keychainPlans) {
+            logger.info("Detected plan '\(matched.displayName, privacy: .public)' for \(configDir, privacy: .public) via keychain")
+            return matched
+        }
+
+        // Step 4: Fall back to heuristic-only detection
+        let fallback = heuristic.inferredPlan
+        logger.info("Inferred plan '\(fallback.displayName, privacy: .public)' for \(configDir, privacy: .public) via heuristics")
+        return fallback
+    }
+
+    /// Detect plan for a profile name using conventional directory naming
+    static func detectPlan(profile: String) -> PlanType {
+        return detectPlan(configDir: UsageTracker.configDir(for: profile))
+    }
+
+    // MARK: - Config File Reading
+
+    private struct ConfigHeuristic {
+        let penguinModeOrgEnabled: Bool
+        let organizationRole: String?
+        let subscriptionType: String? // Not stored in .claude.json, but kept for future
+
+        var inferredPlan: PlanType {
+            if penguinModeOrgEnabled {
+                return .max20x  // Can't distinguish 5x vs 20x from config alone; default to 20x
+            }
+            if organizationRole == "membership_admin" {
+                return .team
+            }
+            return .pro
+        }
+
+        var isMaxPlan: Bool { penguinModeOrgEnabled }
+        var isTeamPlan: Bool { organizationRole == "membership_admin" }
+    }
+
+    private static func readConfigHeuristics(configDir: String) -> ConfigHeuristic {
+        let configPath = configDir + "/.claude.json"
+        guard let data = FileManager.default.contents(atPath: configPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return ConfigHeuristic(penguinModeOrgEnabled: false, organizationRole: nil, subscriptionType: nil)
+        }
+
+        let penguinMode = json["penguinModeOrgEnabled"] as? Bool ?? false
+        let account = json["oauthAccount"] as? [String: Any]
+        let orgRole = account?["organizationRole"] as? String
+
+        return ConfigHeuristic(
+            penguinModeOrgEnabled: penguinMode,
+            organizationRole: orgRole,
+            subscriptionType: nil
+        )
+    }
+
+    // MARK: - Keychain Reading
+
+    private struct KeychainPlan {
+        let subscriptionType: String
+        let rateLimitTier: String?
+    }
+
+    /// Read all Claude Code credential entries from the keychain.
+    /// Uses a two-pass approach: first finds matching service names (no credential data),
+    /// then fetches data only for matched items.
+    private static func readKeychainPlans() -> [KeychainPlan] {
+        // Pass 1: Find services matching "Claude Code-credentials-*" (attributes only, no data)
+        let findQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: false,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+
+        var findResult: AnyObject?
+        let findStatus = SecItemCopyMatching(findQuery as CFDictionary, &findResult)
+
+        guard findStatus == errSecSuccess,
+              let items = findResult as? [[String: Any]] else {
+            logger.debug("Keychain query returned no items or failed: \(findStatus)")
+            return []
+        }
+
+        // Filter to Claude Code services
+        let matchingServices = items.compactMap { item -> String? in
+            guard let service = item[kSecAttrService as String] as? String,
+                  service.hasPrefix("Claude Code-credentials-") else { return nil }
+            return service
+        }
+
+        // Pass 2: Fetch credential data only for matched services
+        var plans: [KeychainPlan] = []
+
+        for service in matchingServices {
+            let dataQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecReturnData as String: true,
+                kSecMatchLimit as String: kSecMatchLimitOne
+            ]
+
+            var dataResult: AnyObject?
+            guard SecItemCopyMatching(dataQuery as CFDictionary, &dataResult) == errSecSuccess,
+                  let data = dataResult as? Data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let oauth = json["claudeAiOauth"] as? [String: Any],
+                  let subType = oauth["subscriptionType"] as? String else {
+                continue
+            }
+
+            let rateLimitTier = oauth["rateLimitTier"] as? String
+
+            plans.append(KeychainPlan(
+                subscriptionType: subType,
+                rateLimitTier: rateLimitTier
+            ))
+
+            logger.debug("Found keychain plan: \(subType, privacy: .public) tier: \(rateLimitTier ?? "none", privacy: .public)")
+        }
+
+        return plans
+    }
+
+    /// Convert a keychain plan to a PlanType
+    private static func keychainPlanToPlanType(_ plan: KeychainPlan) -> PlanType {
+        switch plan.subscriptionType {
+        case "max":
+            if plan.rateLimitTier == "default_claude_max_5x" {
+                return .max5x
+            }
+            return .max20x
+        case "team":
+            return .team
+        case "enterprise":
+            return .enterprise
+        case "pro":
+            return .pro
+        default:
+            return .pro
+        }
+    }
+
+    /// Match a keychain entry to a profile's heuristic
+    private static func matchKeychainToHeuristic(heuristic: ConfigHeuristic, keychainPlans: [KeychainPlan]) -> PlanType? {
+        // If only one keychain entry, use it directly
+        if keychainPlans.count == 1 {
+            return keychainPlanToPlanType(keychainPlans[0])
+        }
+
+        // Multiple entries: match by subscription type category
+        for plan in keychainPlans {
+            let isMaxEntry = plan.subscriptionType == "max"
+            let isTeamEntry = plan.subscriptionType == "team"
+
+            if heuristic.isMaxPlan && isMaxEntry {
+                return keychainPlanToPlanType(plan)
+            }
+            if heuristic.isTeamPlan && isTeamEntry {
+                return keychainPlanToPlanType(plan)
+            }
+            if !heuristic.isMaxPlan && !heuristic.isTeamPlan && plan.subscriptionType == "pro" {
+                return keychainPlanToPlanType(plan)
+            }
+        }
+
+        return nil
+    }
+}

--- a/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
+++ b/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
@@ -35,6 +35,16 @@ class ClaudeSessionMonitor: ObservableObject {
 
         InterruptWatcherManager.shared.delegate = self
 
+        // Invalidate lifetime savings cache when plan changes
+        NotificationCenter.default.publisher(for: .usagePlanDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                if let profile = notification.object as? String {
+                    self?.profileLifetimeSavings.removeValue(forKey: profile)
+                }
+            }
+            .store(in: &cancellables)
+
         // Refresh usage data every 60 seconds
         usageRefreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in

--- a/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
+++ b/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
@@ -14,8 +14,16 @@ import Foundation
 class ClaudeSessionMonitor: ObservableObject {
     @Published var instances: [SessionState] = []
     @Published var pendingInstances: [SessionState] = []
+    @Published var profileUsage: [String: ProfileUsage] = [:]
+    @Published var profileCosts: [String: CostEstimate] = [:]
+    @Published var profileBurnRates: [String: BurnRate] = [:]
+    @Published var profileLimits: [String: [UsageLimitInfo]] = [:]
+    @Published var profileLifetimeSavings: [String: LifetimeSavings] = [:]
 
     private var cancellables = Set<AnyCancellable>()
+    private var usageRefreshTimer: Timer?
+    private var lastUsageRefresh: Date = .distantPast
+    private let usageRefreshMinInterval: TimeInterval = 30
 
     init() {
         SessionStore.shared.sessionsPublisher
@@ -26,6 +34,13 @@ class ClaudeSessionMonitor: ObservableObject {
             .store(in: &cancellables)
 
         InterruptWatcherManager.shared.delegate = self
+
+        // Refresh usage data every 60 seconds
+        usageRefreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.refreshUsage()
+            }
+        }
     }
 
     // MARK: - Monitoring Lifecycle
@@ -125,6 +140,84 @@ class ClaudeSessionMonitor: ObservableObject {
     private func updateFromSessions(_ sessions: [SessionState]) {
         instances = sessions
         pendingInstances = sessions.filter { $0.needsAttention }
+
+        // Throttle: only refresh usage if enough time has passed since last refresh
+        if Date().timeIntervalSince(lastUsageRefresh) >= usageRefreshMinInterval {
+            Task { await refreshUsage() }
+        }
+    }
+
+    func refreshUsage() async {
+        lastUsageRefresh = Date()
+        await UsageTracker.shared.refreshAll()
+        profileUsage = await UsageTracker.shared.getAllUsage()
+
+        // Calculate costs, burn rates, and limit bars per profile
+        let settings = UsageSettings.shared
+        var costs: [String: CostEstimate] = [:]
+        var rates: [String: BurnRate] = [:]
+        var limits: [String: [UsageLimitInfo]] = [:]
+
+        for (profile, usage) in profileUsage {
+            let plan = settings.getPlan(for: profile)
+            let extended = await UsageTracker.shared.getExtendedUsage(for: profile)
+            costs[profile] = UsageTracker.calculateCost(for: usage, plan: plan, extendedUsage: extended)
+            rates[profile] = UsageTracker.calculateBurnRate(for: usage, plan: plan)
+
+            // Build limit bars from Anthropic's actual rate_limits data
+            var bars: [UsageLimitInfo] = []
+            let rl = await UsageTracker.shared.getRateLimits(for: profile)
+
+            if let fiveHour = rl?.fiveHourUsedPercentage {
+                bars.append(UsageLimitInfo(
+                    id: "session",
+                    label: "Session",
+                    usedPercentage: fiveHour,
+                    resetsAt: rl?.fiveHourResetsAt
+                ))
+            }
+
+            if let sevenDay = rl?.sevenDayUsedPercentage {
+                bars.append(UsageLimitInfo(
+                    id: "weekly",
+                    label: "Weekly",
+                    usedPercentage: sevenDay,
+                    resetsAt: rl?.sevenDayResetsAt
+                ))
+            }
+
+            limits[profile] = bars
+        }
+
+        profileCosts = costs
+        profileBurnRates = rates
+        profileLimits = limits
+
+        // Calculate lifetime savings for any profiles we haven't computed yet
+        let missingProfiles = profileUsage.keys.filter { profileLifetimeSavings[$0] == nil }
+        if !missingProfiles.isEmpty {
+            var lt = profileLifetimeSavings
+            for profile in missingProfiles {
+                let plan = settings.getPlan(for: profile)
+                let totalAPICost = await UsageTracker.shared.getLifetimeCost(for: profile)
+                let configDir = UsageTracker.configDir(for: profile)
+                let subStart = UsageTracker.getSubscriptionStartDate(configDir: configDir)
+                let months: Int
+                if let start = subStart {
+                    let components = Calendar.current.dateComponents([.month], from: start, to: Date())
+                    months = max(1, (components.month ?? 1))
+                } else {
+                    months = 1
+                }
+                lt[profile] = LifetimeSavings(
+                    totalAPICost: totalAPICost,
+                    totalSubscriptionCost: plan.monthlyFee * Double(months),
+                    monthsSubscribed: months,
+                    subscribedSince: subStart
+                )
+            }
+            profileLifetimeSavings = lt
+        }
     }
 
     // MARK: - History Loading (for UI)

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -126,10 +126,9 @@ actor SessionStore {
         }
 
         session.pid = event.pid
-        if let profile = event.profile {
-            session.profile = profile
-            Task { await UsageTracker.shared.registerProfile(profile) }
-        }
+        let profile = event.profile ?? "default"
+        session.profile = profile
+        Task { await UsageTracker.shared.registerProfile(profile) }
         if let pid = event.pid {
             let tree = ProcessTreeBuilder.shared.buildTree()
             session.isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: pid, tree: tree)

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -126,6 +126,10 @@ actor SessionStore {
         }
 
         session.pid = event.pid
+        if let profile = event.profile {
+            session.profile = profile
+            Task { await UsageTracker.shared.registerProfile(profile) }
+        }
         if let pid = event.pid {
             let tree = ProcessTreeBuilder.shared.buildTree()
             session.isInTmux = ProcessTreeBuilder.shared.isInTmux(pid: pid, tree: tree)
@@ -177,6 +181,7 @@ actor SessionStore {
             pid: event.pid,
             tty: event.tty?.replacingOccurrences(of: "/dev/", with: ""),
             isInTmux: false,  // Will be updated
+            profile: event.profile,
             phase: .idle
         )
     }

--- a/ClaudeIsland/Services/State/UsageTracker.swift
+++ b/ClaudeIsland/Services/State/UsageTracker.swift
@@ -215,8 +215,11 @@ actor UsageTracker {
             return nil
         }
 
+        // Try with fractional seconds first, then without
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: dateStr) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: dateStr)
     }
 

--- a/ClaudeIsland/Services/State/UsageTracker.swift
+++ b/ClaudeIsland/Services/State/UsageTracker.swift
@@ -1,0 +1,558 @@
+//
+//  UsageTracker.swift
+//  ClaudeIsland
+//
+//  Tracks token usage per profile by reading Claude Code's local JSONL files.
+//
+
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.claudeisland", category: "Usage")
+
+/// Aggregated usage data for a profile
+struct ProfileUsage: Equatable, Sendable {
+    let profile: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheReadTokens: Int
+    let cacheCreationTokens: Int
+    let messageCount: Int
+    let lastUpdated: Date
+    let windowStartDate: Date?
+    let modelBreakdown: [String: TokenBreakdown]
+
+    var totalTokens: Int {
+        inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens
+    }
+
+    /// Formatted total tokens for display (e.g., "1.2M", "450K")
+    var formattedTotal: String {
+        Self.formatTokenCount(totalTokens)
+    }
+
+    /// Formatted output tokens for display
+    var formattedOutput: String {
+        Self.formatTokenCount(outputTokens)
+    }
+
+    static func formatTokenCount(_ count: Int) -> String {
+        let value = Double(count)
+        if value >= 1_000_000 {
+            return String(format: "%.1fM", value / 1_000_000)
+        } else if value >= 1_000 {
+            return String(format: "%.0fK", value / 1_000)
+        }
+        return "\(count)"
+    }
+
+    static let empty = ProfileUsage(
+        profile: "", inputTokens: 0, outputTokens: 0,
+        cacheReadTokens: 0, cacheCreationTokens: 0,
+        messageCount: 0, lastUpdated: Date(),
+        windowStartDate: nil, modelBreakdown: [:]
+    )
+}
+
+/// Tracks token usage across Claude Code profiles by reading local JSONL conversation logs
+actor UsageTracker {
+    static let shared = UsageTracker()
+
+    /// Profile name -> config directory path
+    private var profileDirs: [String: String] = [:]
+
+    /// Cached usage per profile
+    private var usage: [String: ProfileUsage] = [:]
+
+    /// Rate limits from Anthropic's status line API (written to ~/.claude-island/)
+    private var rateLimits: [String: RateLimitsState] = [:]
+
+    /// State directory for rate limit files
+    private let stateDir = NSHomeDirectory() + "/.claude-island"
+
+    /// How far back to look (5-hour rolling window matches Claude's rate limit window)
+    private let lookbackInterval: TimeInterval = 5 * 60 * 60
+
+    /// Weekly window (7 days)
+    private let weeklyInterval: TimeInterval = 7 * 24 * 60 * 60
+
+    /// Extended usage cache (daily/monthly) with TTL
+    private var extendedUsageCache: [String: (data: ExtendedUsage, fetchedAt: Date)] = [:]
+    private let extendedCacheTTL: TimeInterval = 300  // 5 minutes
+
+    private init() {}
+
+    /// Resolve the config directory for a profile name
+    nonisolated static func configDir(for profile: String) -> String {
+        switch profile {
+        case "default": return NSHomeDirectory() + "/.claude"
+        default: return NSHomeDirectory() + "/.claude-\(profile)"
+        }
+    }
+
+    // MARK: - Profile Registration
+
+    /// Register a profile's config directory (called when we first see a session with a profile)
+    func registerProfile(_ profile: String, configDir: String) {
+        guard profileDirs[profile] == nil else { return }
+        profileDirs[profile] = configDir
+        logger.info("Registered profile '\(profile, privacy: .public)' at \(configDir, privacy: .public)")
+        Task { await refreshProfile(profile) }
+    }
+
+    /// Register a profile using the conventional directory naming
+    func registerProfile(_ profile: String) {
+        registerProfile(profile, configDir: Self.configDir(for: profile))
+    }
+
+    // MARK: - Usage Queries
+
+    /// Get current usage for a profile
+    func getUsage(for profile: String) -> ProfileUsage? {
+        return usage[profile]
+    }
+
+    /// Get usage for all registered profiles
+    func getAllUsage() -> [String: ProfileUsage] {
+        return usage
+    }
+
+    /// Get rate limits from Anthropic's status line for a profile
+    func getRateLimits(for profile: String) -> RateLimitsState? {
+        return rateLimits[profile]
+    }
+
+    /// Get rate limits for all profiles
+    func getAllRateLimits() -> [String: RateLimitsState] {
+        return rateLimits
+    }
+
+    /// Read rate limit state files written by the statusline script
+    func refreshRateLimits() {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(atPath: stateDir) else { return }
+
+        for file in files where file.hasSuffix(".json") {
+            let profile = String(file.dropLast(5))  // Remove .json
+            let path = stateDir + "/" + file
+
+            guard let data = fm.contents(atPath: path),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                continue
+            }
+
+            let rl = json["rate_limits"] as? [String: Any]
+            let fiveHour = rl?["five_hour"] as? [String: Any]
+            let sevenDay = rl?["seven_day"] as? [String: Any]
+
+            let fiveHourResets: Date? = (fiveHour?["resets_at"] as? Double).map { Date(timeIntervalSince1970: $0) }
+            let sevenDayResets: Date? = (sevenDay?["resets_at"] as? Double).map { Date(timeIntervalSince1970: $0) }
+
+            rateLimits[profile] = RateLimitsState(
+                fiveHourUsedPercentage: fiveHour?["used_percentage"] as? Double,
+                fiveHourResetsAt: fiveHourResets,
+                sevenDayUsedPercentage: sevenDay?["used_percentage"] as? Double,
+                sevenDayResetsAt: sevenDayResets,
+                timestamp: Date()
+            )
+        }
+    }
+
+    /// Get extended (daily/monthly) usage for a profile
+    func getExtendedUsage(for profile: String) async -> ExtendedUsage {
+        // Check cache
+        if let cached = extendedUsageCache[profile],
+           Date().timeIntervalSince(cached.fetchedAt) < extendedCacheTTL {
+            return cached.data
+        }
+
+        guard let configDir = profileDirs[profile] else {
+            return ExtendedUsage(daily: [], monthly: [])
+        }
+
+        let extended = parseExtendedUsage(configDir: configDir)
+        extendedUsageCache[profile] = (data: extended, fetchedAt: Date())
+        return extended
+    }
+
+    /// Get lifetime API cost for a profile (all JSONL files, no date cutoff)
+    func getLifetimeCost(for profile: String) async -> Double {
+        guard let configDir = profileDirs[profile] else { return 0 }
+
+        let projectsDir = configDir + "/projects"
+        let fm = FileManager.default
+        guard let projectDirs = try? fm.contentsOfDirectory(atPath: projectsDir) else { return 0 }
+
+        var seenIds = Set<String>()
+        var totalCost = 0.0
+        let distantPast = Date.distantPast
+
+        for projectDir in projectDirs {
+            let projectPath = projectsDir + "/" + projectDir
+            guard let files = try? fm.contentsOfDirectory(atPath: projectPath) else { continue }
+
+            for file in files where file.hasSuffix(".jsonl") {
+                let filePath = projectPath + "/" + file
+                let result = parseJSONLFile(filePath, cutoff: distantPast, seenIds: &seenIds)
+                for (modelName, breakdown) in result.modelBreakdown {
+                    let model = ClaudeModel.from(apiModelName: modelName)
+                    let pricing = ModelPricing.pricing(for: model)
+                    totalCost += breakdown.cost(using: pricing)
+                }
+            }
+        }
+
+        return totalCost
+    }
+
+    /// Get subscription start date from .claude.json for a profile
+    nonisolated static func getSubscriptionStartDate(configDir: String) -> Date? {
+        let configPath = configDir + "/.claude.json"
+        guard let data = FileManager.default.contents(atPath: configPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let account = json["oauthAccount"] as? [String: Any],
+              let dateStr = account["subscriptionCreatedAt"] as? String else {
+            return nil
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: dateStr)
+    }
+
+    // MARK: - Refresh
+
+    /// Refresh usage data for all registered profiles
+    func refreshAll() async {
+        refreshRateLimits()
+        for profile in profileDirs.keys {
+            await refreshProfile(profile)
+        }
+    }
+
+    /// Refresh usage data for a specific profile
+    func refreshProfile(_ profile: String) async {
+        guard let configDir = profileDirs[profile] else { return }
+
+        let projectsDir = configDir + "/projects"
+        let cutoff = Date().addingTimeInterval(-lookbackInterval)
+
+        var totalBreakdown: [String: TokenBreakdown] = [:]
+        var messageCount = 0
+        var earliestDate: Date?
+        var seenIds = Set<String>()
+
+        let fm = FileManager.default
+        guard let projectDirs = try? fm.contentsOfDirectory(atPath: projectsDir) else {
+            logger.debug("No projects dir for profile '\(profile, privacy: .public)'")
+            return
+        }
+
+        for projectDir in projectDirs {
+            let projectPath = projectsDir + "/" + projectDir
+            guard let files = try? fm.contentsOfDirectory(atPath: projectPath) else { continue }
+
+            for file in files where file.hasSuffix(".jsonl") {
+                let filePath = projectPath + "/" + file
+                guard let attrs = try? fm.attributesOfItem(atPath: filePath),
+                      let modDate = attrs[.modificationDate] as? Date,
+                      modDate > cutoff else { continue }
+
+                let result = parseJSONLFile(filePath, cutoff: cutoff, seenIds: &seenIds)
+                for (model, breakdown) in result.modelBreakdown {
+                    totalBreakdown[model, default: .zero].add(breakdown)
+                }
+                messageCount += result.messages
+                if let date = result.earliestDate {
+                    if earliestDate == nil || date < earliestDate! {
+                        earliestDate = date
+                    }
+                }
+            }
+        }
+
+        // Compute totals from model breakdown
+        var totalInput = 0, totalOutput = 0, totalCacheRead = 0, totalCacheCreation = 0
+        for (_, breakdown) in totalBreakdown {
+            totalInput += breakdown.input
+            totalOutput += breakdown.output
+            totalCacheRead += breakdown.cacheRead
+            totalCacheCreation += breakdown.cacheCreation
+        }
+
+        usage[profile] = ProfileUsage(
+            profile: profile,
+            inputTokens: totalInput,
+            outputTokens: totalOutput,
+            cacheReadTokens: totalCacheRead,
+            cacheCreationTokens: totalCacheCreation,
+            messageCount: messageCount,
+            lastUpdated: Date(),
+            windowStartDate: earliestDate,
+            modelBreakdown: totalBreakdown
+        )
+
+        logger.debug("Profile '\(profile, privacy: .public)': \(messageCount) messages, \(totalInput + totalOutput)+ tokens in last 5h")
+    }
+
+    // MARK: - Cost & Burn Rate Calculations
+
+    /// Calculate cost estimate for a profile's usage
+    /// dailyCost and monthlyCost come from actual aggregated data when available
+    nonisolated static func calculateCost(
+        for usage: ProfileUsage,
+        plan: PlanType,
+        extendedUsage: ExtendedUsage? = nil
+    ) -> CostEstimate {
+        // Window cost from model breakdown
+        var windowCost = 0.0
+        var windowRateLimitCost = 0.0
+        for (modelName, breakdown) in usage.modelBreakdown {
+            let model = ClaudeModel.from(apiModelName: modelName)
+            let pricing = ModelPricing.pricing(for: model)
+            windowCost += breakdown.cost(using: pricing)
+            windowRateLimitCost += breakdown.rateLimitCost(using: pricing)
+        }
+
+        // Use actual aggregated data for daily/monthly when available
+        let dailyCost = extendedUsage?.daily.first?.cost ?? windowCost
+        let monthlyCost = extendedUsage?.monthly.first?.cost ?? windowCost
+        let monthlySavings = monthlyCost - plan.monthlyFee
+
+        return CostEstimate(
+            windowCost: windowCost,
+            windowRateLimitCost: windowRateLimitCost,
+            dailyCost: dailyCost,
+            monthlyCost: monthlyCost,
+            monthlySavings: monthlySavings
+        )
+    }
+
+    /// Calculate burn rate for a profile's usage
+    nonisolated static func calculateBurnRate(for usage: ProfileUsage, plan: PlanType) -> BurnRate {
+        guard let windowStart = usage.windowStartDate else {
+            return .zero
+        }
+
+        let elapsed = Date().timeIntervalSince(windowStart) / 60.0  // minutes
+        guard elapsed > 1.0 else { return .zero }
+
+        let tokensPerMinute = Double(usage.outputTokens) / elapsed
+
+        // Cost-based utilization (exclude cache_read for rate limit calculation)
+        var windowCost = 0.0
+        var rateLimitCost = 0.0
+        for (modelName, breakdown) in usage.modelBreakdown {
+            let model = ClaudeModel.from(apiModelName: modelName)
+            let pricing = ModelPricing.pricing(for: model)
+            windowCost += breakdown.cost(using: pricing)
+            rateLimitCost += breakdown.rateLimitCost(using: pricing)
+        }
+        let costPerHour = (windowCost / elapsed) * 60.0
+        let utilization = plan.sessionCostLimit > 0 ? rateLimitCost / plan.sessionCostLimit : 0
+
+        return BurnRate(
+            tokensPerMinute: tokensPerMinute,
+            costPerHour: costPerHour,
+            windowElapsedMinutes: elapsed,
+            utilizationPercent: utilization
+        )
+    }
+
+    // MARK: - JSONL Parsing
+
+    private struct ParseResult {
+        let modelBreakdown: [String: TokenBreakdown]
+        let messages: Int
+        let earliestDate: Date?
+    }
+
+    /// Parse a single JSONL file for usage data with model tracking and deduplication.
+    /// Pass a shared `seenIds` set across files to deduplicate entries that appear in multiple JSONL files.
+    private func parseJSONLFile(_ path: String, cutoff: Date, seenIds: inout Set<String>) -> ParseResult {
+        guard let data = FileManager.default.contents(atPath: path),
+              let content = String(data: data, encoding: .utf8) else {
+            return ParseResult(modelBreakdown: [:], messages: 0, earliestDate: nil)
+        }
+
+        var modelBreakdown: [String: TokenBreakdown] = [:]
+        var messages = 0
+        var earliestDate: Date?
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        for line in content.split(separator: "\n") where line.contains("\"usage\"") {
+            guard let lineData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
+                continue
+            }
+
+            // Check timestamp
+            if let timestamp = json["timestamp"] as? String {
+                guard let date = formatter.date(from: timestamp), date > cutoff else {
+                    continue
+                }
+                if earliestDate == nil || date < earliestDate! {
+                    earliestDate = date
+                }
+            } else {
+                continue
+            }
+
+            guard let message = json["message"] as? [String: Any],
+                  let usage = message["usage"] as? [String: Any] else {
+                continue
+            }
+
+            // Deduplicate by message_id:request_id (same approach as claude-monitor)
+            let msgId = message["id"] as? String ?? ""
+            let reqId = json["requestId"] as? String ?? ""
+            let dedupKey = "\(msgId):\(reqId)"
+            guard !dedupKey.isEmpty, dedupKey != ":", seenIds.insert(dedupKey).inserted else {
+                continue
+            }
+
+            // Extract model name
+            let modelName = message["model"] as? String ?? "unknown"
+
+            let breakdown = TokenBreakdown(
+                input: usage["input_tokens"] as? Int ?? 0,
+                output: usage["output_tokens"] as? Int ?? 0,
+                cacheRead: usage["cache_read_input_tokens"] as? Int ?? 0,
+                cacheCreation: usage["cache_creation_input_tokens"] as? Int ?? 0
+            )
+
+            modelBreakdown[modelName, default: .zero].add(breakdown)
+            messages += 1
+        }
+
+        return ParseResult(modelBreakdown: modelBreakdown, messages: messages, earliestDate: earliestDate)
+    }
+
+    // MARK: - Extended Usage (Daily/Monthly)
+
+    /// Extended usage data for daily and monthly views
+    struct ExtendedUsage: Sendable, Equatable {
+        let daily: [PeriodUsage]
+        let monthly: [PeriodUsage]
+    }
+
+    /// Parse all JSONL files for extended daily/monthly aggregation
+    private func parseExtendedUsage(configDir: String) -> ExtendedUsage {
+        let projectsDir = configDir + "/projects"
+        let fm = FileManager.default
+
+        guard let projectDirs = try? fm.contentsOfDirectory(atPath: projectsDir) else {
+            return ExtendedUsage(daily: [], monthly: [])
+        }
+
+        // Collect all entries with timestamps
+        var dailyAgg: [String: (tokens: [String: TokenBreakdown], messages: Int, models: Set<String>)] = [:]
+        var monthlyAgg: [String: (tokens: [String: TokenBreakdown], messages: Int, models: Set<String>)] = [:]
+        var seenIds = Set<String>()
+
+        let dateFormatter = DateFormatter()
+        let monthFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        monthFormatter.dateFormat = "yyyy-MM"
+
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        // Only look back 90 days for extended usage
+        let cutoff = Date().addingTimeInterval(-90 * 24 * 60 * 60)
+
+        for projectDir in projectDirs {
+            let projectPath = projectsDir + "/" + projectDir
+            guard let files = try? fm.contentsOfDirectory(atPath: projectPath) else { continue }
+
+            for file in files where file.hasSuffix(".jsonl") {
+                let filePath = projectPath + "/" + file
+                guard let attrs = try? fm.attributesOfItem(atPath: filePath),
+                      let modDate = attrs[.modificationDate] as? Date,
+                      modDate > cutoff else { continue }
+
+                guard let data = fm.contents(atPath: filePath),
+                      let content = String(data: data, encoding: .utf8) else { continue }
+
+                for line in content.split(separator: "\n") where line.contains("\"usage\"") {
+                    guard let lineData = line.data(using: .utf8),
+                          let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                          let timestamp = json["timestamp"] as? String,
+                          let date = isoFormatter.date(from: timestamp),
+                          date > cutoff,
+                          let message = json["message"] as? [String: Any],
+                          let usage = message["usage"] as? [String: Any] else {
+                        continue
+                    }
+
+                    // Deduplicate
+                    let msgId = message["id"] as? String ?? ""
+                    let reqId = json["requestId"] as? String ?? ""
+                    let dedupKey = "\(msgId):\(reqId)"
+                    guard !dedupKey.isEmpty, dedupKey != ":", seenIds.insert(dedupKey).inserted else {
+                        continue
+                    }
+
+                    let modelName = message["model"] as? String ?? "unknown"
+                    let modelFamily = ClaudeModel.from(apiModelName: modelName).rawValue
+                    let dayKey = dateFormatter.string(from: date)
+                    let monthKey = monthFormatter.string(from: date)
+
+                    let breakdown = TokenBreakdown(
+                        input: usage["input_tokens"] as? Int ?? 0,
+                        output: usage["output_tokens"] as? Int ?? 0,
+                        cacheRead: usage["cache_read_input_tokens"] as? Int ?? 0,
+                        cacheCreation: usage["cache_creation_input_tokens"] as? Int ?? 0
+                    )
+
+                    // Daily
+                    var daily = dailyAgg[dayKey] ?? (tokens: [:], messages: 0, models: [])
+                    daily.tokens[modelName, default: .zero].add(breakdown)
+                    daily.messages += 1
+                    daily.models.insert(modelFamily)
+                    dailyAgg[dayKey] = daily
+
+                    // Monthly
+                    var monthly = monthlyAgg[monthKey] ?? (tokens: [:], messages: 0, models: [])
+                    monthly.tokens[modelName, default: .zero].add(breakdown)
+                    monthly.messages += 1
+                    monthly.models.insert(modelFamily)
+                    monthlyAgg[monthKey] = monthly
+                }
+            }
+        }
+
+        // Convert to PeriodUsage arrays
+        let dailyUsage = dailyAgg.map { key, value in
+            let totalTokens = value.tokens.values.reduce(TokenBreakdown.zero) { result, b in
+                var r = result; r.add(b); return r
+            }
+            let cost = value.tokens.reduce(0.0) { result, pair in
+                let model = ClaudeModel.from(apiModelName: pair.key)
+                return result + pair.value.cost(using: ModelPricing.pricing(for: model))
+            }
+            return PeriodUsage(
+                id: key, label: key, tokens: totalTokens,
+                cost: cost, messageCount: value.messages, models: value.models
+            )
+        }.sorted { $0.id > $1.id }  // Most recent first
+
+        let monthlyUsage = monthlyAgg.map { key, value in
+            let totalTokens = value.tokens.values.reduce(TokenBreakdown.zero) { result, b in
+                var r = result; r.add(b); return r
+            }
+            let cost = value.tokens.reduce(0.0) { result, pair in
+                let model = ClaudeModel.from(apiModelName: pair.key)
+                return result + pair.value.cost(using: ModelPricing.pricing(for: model))
+            }
+            return PeriodUsage(
+                id: key, label: key, tokens: totalTokens,
+                cost: cost, messageCount: value.messages, models: value.models
+            )
+        }.sorted { $0.id > $1.id }
+
+        return ExtendedUsage(daily: dailyUsage, monthly: monthlyUsage)
+    }
+}

--- a/ClaudeIsland/UI/Components/UsageHistorySection.swift
+++ b/ClaudeIsland/UI/Components/UsageHistorySection.swift
@@ -1,0 +1,231 @@
+//
+//  UsageHistorySection.swift
+//  ClaudeIsland
+//
+//  Collapsible daily/monthly cost history section for the settings menu.
+//
+
+import SwiftUI
+
+struct UsageHistorySection: View {
+    @ObservedObject var sessionMonitor: ClaudeSessionMonitor
+    @State private var isExpanded = false
+    @State private var isHovered = false
+    @State private var dailyUsage: [String: [PeriodUsage]] = [:]
+    @State private var monthlyUsage: [String: [PeriodUsage]] = [:]
+    @State private var lifetimeSavings: [String: LifetimeSavings] = [:]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header row
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                    if isExpanded { loadData() }
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "calendar.badge.clock")
+                        .font(.system(size: 12))
+                        .foregroundColor(textColor)
+                        .frame(width: 16)
+
+                    Text("Usage History")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(textColor)
+
+                    Spacer()
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+
+            // Expanded content
+            if isExpanded {
+                VStack(spacing: 8) {
+                    ForEach(Array(sessionMonitor.profileUsage.keys.sorted()), id: \.self) { profile in
+                        ProfileHistoryCard(
+                            profile: profile,
+                            daily: dailyUsage[profile] ?? [],
+                            monthly: monthlyUsage[profile] ?? [],
+                            lifetime: lifetimeSavings[profile],
+                            plan: UsageSettings.shared.getPlan(for: profile)
+                        )
+                    }
+
+                    if sessionMonitor.profileUsage.isEmpty {
+                        Text("No usage data")
+                            .font(.system(size: 11))
+                            .foregroundColor(.white.opacity(0.3))
+                            .padding(.vertical, 8)
+                    }
+                }
+                .padding(.leading, 28)
+                .padding(.top, 4)
+            }
+        }
+    }
+
+    private var textColor: Color {
+        .white.opacity(isHovered ? 1.0 : 0.7)
+    }
+
+    private func loadData() {
+        Task {
+            let settings = UsageSettings.shared
+            for profile in sessionMonitor.profileUsage.keys {
+                let extended = await UsageTracker.shared.getExtendedUsage(for: profile)
+                dailyUsage[profile] = extended.daily
+                monthlyUsage[profile] = extended.monthly
+
+                // Calculate lifetime savings
+                let plan = settings.getPlan(for: profile)
+                let totalAPICost = await UsageTracker.shared.getLifetimeCost(for: profile)
+
+                let configDir = UsageTracker.configDir(for: profile)
+
+                let subStart = UsageTracker.getSubscriptionStartDate(configDir: configDir)
+                let months: Int
+                if let start = subStart {
+                    let components = Calendar.current.dateComponents([.month], from: start, to: Date())
+                    months = max(1, (components.month ?? 1))
+                } else {
+                    months = 1
+                }
+
+                lifetimeSavings[profile] = LifetimeSavings(
+                    totalAPICost: totalAPICost,
+                    totalSubscriptionCost: plan.monthlyFee * Double(months),
+                    monthsSubscribed: months,
+                    subscribedSince: subStart
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Profile History Card
+
+private struct ProfileHistoryCard: View {
+    let profile: String
+    let daily: [PeriodUsage]
+    let monthly: [PeriodUsage]
+    let lifetime: LifetimeSavings?
+    let plan: PlanType
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Profile header
+            Text(profile.uppercased())
+                .font(.system(size: 9, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.4))
+                .tracking(0.6)
+
+            // Today
+            if let today = daily.first {
+                CostRow(label: "Today", cost: today.cost, tokens: today.tokens.total)
+            }
+
+            // This month
+            if let month = monthly.first {
+                CostRow(label: monthLabel(month.label), cost: month.cost, tokens: month.tokens.total)
+            }
+
+            // Previous days (last 3)
+            if daily.count > 1 {
+                Divider()
+                    .background(Color.white.opacity(0.06))
+
+                ForEach(daily.dropFirst().prefix(3)) { day in
+                    CostRow(label: day.label, cost: day.cost, tokens: day.tokens.total)
+                }
+            }
+
+            // Lifetime savings
+            if let lt = lifetime, lt.savings > 0 {
+                Divider()
+                    .background(Color.white.opacity(0.06))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 4) {
+                        Text("Lifetime")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(.white.opacity(0.5))
+
+                        Spacer()
+
+                        Text(lt.formattedSavings)
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            .foregroundColor(TerminalColors.green.opacity(0.7))
+
+                        Text("saved")
+                            .font(.system(size: 10))
+                            .foregroundColor(TerminalColors.green.opacity(0.4))
+                    }
+
+                    HStack(spacing: 4) {
+                        Text("\(lt.formattedAPICost) API cost")
+                            .font(.system(size: 9, weight: .medium, design: .monospaced))
+                            .foregroundColor(.white.opacity(0.25))
+
+                        Text("·")
+                            .foregroundColor(.white.opacity(0.15))
+
+                        Text("\(lt.monthsSubscribed)mo since \(lt.sinceLabel)")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundColor(.white.opacity(0.25))
+                    }
+                }
+            }
+        }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.white.opacity(0.04))
+        )
+    }
+
+    private func monthLabel(_ key: String) -> String {
+        let parts = key.split(separator: "-")
+        guard parts.count == 2, let month = Int(parts[1]) else { return key }
+        let months = ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                       "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+        return month < months.count ? months[month] : key
+    }
+}
+
+// MARK: - Cost Row
+
+private struct CostRow: View {
+    let label: String
+    let cost: Double
+    let tokens: Int
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.white.opacity(0.5))
+
+            Spacer()
+
+            Text(ProfileUsage.formatTokenCount(tokens))
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundColor(.white.opacity(0.3))
+
+            Text(String(format: "$%.2f", cost))
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
+                .foregroundColor(.white.opacity(0.5))
+        }
+    }
+}

--- a/ClaudeIsland/UI/Components/UsageSettingsRow.swift
+++ b/ClaudeIsland/UI/Components/UsageSettingsRow.swift
@@ -1,0 +1,273 @@
+//
+//  UsageSettingsRow.swift
+//  ClaudeIsland
+//
+//  Usage display settings and per-profile plan configuration for the settings menu.
+//
+
+import SwiftUI
+
+struct UsageSettingsRow: View {
+    @ObservedObject var usageSettings: UsageSettings
+    @State private var isHovered = false
+
+    private var isExpanded: Bool {
+        usageSettings.isPickerExpanded
+    }
+
+    private func setExpanded(_ value: Bool) {
+        usageSettings.isPickerExpanded = value
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Main row
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    setExpanded(!isExpanded)
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "chart.bar")
+                        .font(.system(size: 12))
+                        .foregroundColor(textColor)
+                        .frame(width: 16)
+
+                    Text("Usage Monitor")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(textColor)
+
+                    Spacer()
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+
+            // Expanded settings
+            if isExpanded {
+                VStack(spacing: 2) {
+                    // Display toggles
+                    UsageToggleRow(label: "Show Cost", isOn: usageSettings.displayConfig.showCost) {
+                        var config = usageSettings.displayConfig
+                        config.showCost.toggle()
+                        usageSettings.updateDisplayConfig(config)
+                    }
+
+                    UsageToggleRow(label: "Show Burn Rate", isOn: usageSettings.displayConfig.showBurnRate) {
+                        var config = usageSettings.displayConfig
+                        config.showBurnRate.toggle()
+                        usageSettings.updateDisplayConfig(config)
+                    }
+
+                    UsageToggleRow(label: "Show Savings", isOn: usageSettings.displayConfig.showSavings) {
+                        var config = usageSettings.displayConfig
+                        config.showSavings.toggle()
+                        usageSettings.updateDisplayConfig(config)
+                    }
+
+                    UsageToggleRow(label: "Lifetime Savings", isOn: usageSettings.displayConfig.showLifetimeSavings) {
+                        var config = usageSettings.displayConfig
+                        config.showLifetimeSavings.toggle()
+                        usageSettings.updateDisplayConfig(config)
+                    }
+
+                    Divider()
+                        .background(Color.white.opacity(0.06))
+                        .padding(.vertical, 4)
+
+                    // Limit bar toggles
+                    Text("LIMIT BARS")
+                        .font(.system(size: 9, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.3))
+                        .tracking(0.6)
+                        .padding(.leading, 10)
+
+                    UsageToggleRow(label: "Session (5h)", isOn: usageSettings.displayConfig.showSessionBar) {
+                        var config = usageSettings.displayConfig
+                        config.showSessionBar.toggle()
+                        usageSettings.updateDisplayConfig(config)
+                    }
+
+                    UsageToggleRow(label: "Weekly (7d)", isOn: usageSettings.displayConfig.showWeeklyBar) {
+                        var config = usageSettings.displayConfig
+                        config.showWeeklyBar.toggle()
+                        usageSettings.updateDisplayConfig(config)
+                    }
+
+                    // Per-profile plan pickers
+                    if !usageSettings.profilePlans.isEmpty {
+                        Divider()
+                            .background(Color.white.opacity(0.06))
+                            .padding(.vertical, 4)
+
+                        ForEach(Array(usageSettings.profilePlans.keys.sorted()), id: \.self) { profile in
+                            PlanPickerRow(
+                                profile: profile,
+                                currentPlan: usageSettings.profilePlans[profile] ?? .pro
+                            ) { newPlan in
+                                usageSettings.setPlan(newPlan, for: profile)
+                            }
+                        }
+                    }
+                }
+                .padding(.leading, 28)
+                .padding(.top, 4)
+            }
+        }
+    }
+
+    private var textColor: Color {
+        .white.opacity(isHovered ? 1.0 : 0.7)
+    }
+}
+
+// MARK: - Usage Toggle Row
+
+private struct UsageToggleRow: View {
+    let label: String
+    let isOn: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: isOn ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 11))
+                    .foregroundColor(isOn ? TerminalColors.green : .white.opacity(0.3))
+
+                Text(label)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.7))
+
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}
+
+// MARK: - Plan Picker Row
+
+private struct PlanPickerRow: View {
+    let profile: String
+    let currentPlan: PlanType
+    let onSelect: (PlanType) -> Void
+
+    @State private var isExpanded = false
+    @State private var isHovered = false
+
+    private let plans: [PlanType] = [.pro, .max5x, .max20x, .team]
+
+    var body: some View {
+        VStack(spacing: 2) {
+            // Profile label + current plan
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Text(profile.capitalized)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.7))
+
+                    Spacer()
+
+                    Text(currentPlan.displayName)
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.4))
+
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 9))
+                        .foregroundColor(.white.opacity(0.3))
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+
+            // Plan options
+            if isExpanded {
+                VStack(spacing: 1) {
+                    ForEach(plans, id: \.displayName) { plan in
+                        PlanOptionRow(plan: plan, isSelected: currentPlan == plan) {
+                            onSelect(plan)
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                isExpanded = false
+                            }
+                        }
+                    }
+                }
+                .padding(.leading, 12)
+            }
+        }
+    }
+}
+
+// MARK: - Plan Option Row
+
+private struct PlanOptionRow: View {
+    let plan: PlanType
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(isSelected ? TerminalColors.green : Color.white.opacity(0.2))
+                    .frame(width: 6, height: 6)
+
+                Text(plan.displayName)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.white.opacity(isHovered ? 1.0 : 0.7))
+
+                Text("$\(Int(plan.monthlyFee))/mo")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.3))
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(TerminalColors.green)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(isHovered ? Color.white.opacity(0.06) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -37,22 +37,43 @@ struct ClaudeInstancesView: View {
 
     // MARK: - Instances List
 
-    /// Priority: active (approval/processing/compacting) > waitingForInput > idle
-    /// Secondary sort: by last user message date (stable - doesn't change when agent responds)
-    /// Note: approval requests stay in their date-based position to avoid layout shift
-    private var sortedInstances: [SessionState] {
-        sessionMonitor.instances.sorted { a, b in
-            let priorityA = phasePriority(a.phase)
-            let priorityB = phasePriority(b.phase)
-            if priorityA != priorityB {
-                return priorityA < priorityB
-            }
-            // Sort by last user message date (more recent first)
-            // Fall back to lastActivity if no user messages yet
-            let dateA = a.lastUserMessageDate ?? a.lastActivity
-            let dateB = b.lastUserMessageDate ?? b.lastActivity
-            return dateA > dateB
+    /// Group sessions by profile, with ungrouped sessions in their own section
+    private var groupedSessions: [(profile: String?, sessions: [SessionState])] {
+        var groups: [String?: [SessionState]] = [:]
+        for session in sessionMonitor.instances {
+            groups[session.profile, default: []].append(session)
         }
+
+        // Sort sessions within each group
+        let sortGroup: ([SessionState]) -> [SessionState] = { sessions in
+            sessions.sorted { a, b in
+                let priorityA = phasePriority(a.phase)
+                let priorityB = phasePriority(b.phase)
+                if priorityA != priorityB {
+                    return priorityA < priorityB
+                }
+                let dateA = a.lastUserMessageDate ?? a.lastActivity
+                let dateB = b.lastUserMessageDate ?? b.lastActivity
+                return dateA > dateB
+            }
+        }
+
+        var result: [(profile: String?, sessions: [SessionState])] = []
+
+        // Named profiles first (sorted alphabetically)
+        let namedProfiles = groups.keys.compactMap { $0 }.sorted()
+        for profile in namedProfiles {
+            if let sessions = groups[profile] {
+                result.append((profile: profile, sessions: sortGroup(sessions)))
+            }
+        }
+
+        // Ungrouped sessions last
+        if let ungrouped = groups[nil], !ungrouped.isEmpty {
+            result.append((profile: nil, sessions: sortGroup(ungrouped)))
+        }
+
+        return result
     }
 
     /// Lower number = higher priority
@@ -68,16 +89,35 @@ struct ClaudeInstancesView: View {
     private var instancesList: some View {
         ScrollView(.vertical, showsIndicators: false) {
             LazyVStack(spacing: 2) {
-                ForEach(sortedInstances) { session in
-                    InstanceRow(
-                        session: session,
-                        onFocus: { focusSession(session) },
-                        onChat: { openChat(session) },
-                        onArchive: { archiveSession(session) },
-                        onApprove: { approveSession(session) },
-                        onReject: { rejectSession(session) }
-                    )
-                    .id(session.stableId)
+                let groups = groupedSessions
+                let hasMultipleGroups = groups.count > 1 || groups.first?.profile != nil
+
+                ForEach(Array(groups.enumerated()), id: \.offset) { index, group in
+                    if hasMultipleGroups {
+                        ProfileSectionHeader(
+                            profile: group.profile,
+                            usage: group.profile.flatMap { sessionMonitor.profileUsage[$0] },
+                            cost: group.profile.flatMap { sessionMonitor.profileCosts[$0] },
+                            burnRate: group.profile.flatMap { sessionMonitor.profileBurnRates[$0] },
+                            limits: group.profile.flatMap { sessionMonitor.profileLimits[$0] } ?? [],
+                            lifetimeSavings: group.profile.flatMap { sessionMonitor.profileLifetimeSavings[$0] },
+                            displayConfig: UsageSettings.shared.displayConfig,
+                            sessionCount: group.sessions.count
+                        )
+                        .padding(.top, index > 0 ? 8 : 0)
+                    }
+
+                    ForEach(group.sessions) { session in
+                        InstanceRow(
+                            session: session,
+                            onFocus: { focusSession(session) },
+                            onChat: { openChat(session) },
+                            onArchive: { archiveSession(session) },
+                            onApprove: { approveSession(session) },
+                            onReject: { rejectSession(session) }
+                        )
+                        .id(session.stableId)
+                    }
                 }
             }
             .padding(.vertical, 4)
@@ -113,6 +153,147 @@ struct ClaudeInstancesView: View {
 
     private func archiveSession(_ session: SessionState) {
         sessionMonitor.archiveSession(sessionId: session.sessionId)
+    }
+}
+
+// MARK: - Profile Section Header
+
+struct ProfileSectionHeader: View {
+    let profile: String?
+    let usage: ProfileUsage?
+    let cost: CostEstimate?
+    let burnRate: BurnRate?
+    let limits: [UsageLimitInfo]
+    let lifetimeSavings: LifetimeSavings?
+    let displayConfig: UsageDisplayConfig
+    let sessionCount: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            // Row 1: profile name + count + usage bars
+            HStack(alignment: .center, spacing: 6) {
+                Text(displayName.uppercased())
+                    .font(.system(size: 10, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.45))
+                    .tracking(0.8)
+
+                Text("\(sessionCount)")
+                    .font(.system(size: 9, weight: .bold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.3))
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(Color.white.opacity(0.08)))
+
+                Spacer()
+
+                // Inline usage bars
+                ForEach(visibleLimits) { limit in
+                    UsageLimitBarRow(limit: limit)
+                }
+            }
+
+            // Row 2: secondary metrics (cost · tokens · burn rate · savings)
+            if let usage = usage, usage.totalTokens > 0 {
+                HStack(spacing: 0) {
+                    Spacer()
+
+                    HStack(spacing: 4) {
+                        if displayConfig.showCost, let cost = cost, cost.windowCost > 0 {
+                            Text(cost.formattedWindowCost)
+                                .font(.system(size: 9, weight: .medium, design: .monospaced))
+
+                            Text("·")
+                        }
+
+                        Text("\(usage.formattedOutput) out")
+                            .font(.system(size: 9, weight: .medium, design: .monospaced))
+
+                        if displayConfig.showBurnRate, let rate = burnRate, rate.tokensPerMinute > 1 {
+                            Text("·")
+
+                            Text(String(format: "%.0f/m", rate.tokensPerMinute))
+                                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                        }
+
+                        if displayConfig.showSavings, let cost = cost, cost.monthlySavings > 0 {
+                            Text("·")
+
+                            Text("~\(cost.formattedSavings)/mo saved")
+                                .foregroundColor(TerminalColors.green.opacity(0.5))
+                        }
+
+                        if displayConfig.showLifetimeSavings, let lt = lifetimeSavings, lt.savings > 0 {
+                            Text("·")
+
+                            Text("\(lt.formattedSavings) lifetime")
+                                .foregroundColor(TerminalColors.green.opacity(0.5))
+                        }
+                    }
+                    .font(.system(size: 9))
+                    .foregroundColor(.white.opacity(0.25))
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    private var displayName: String {
+        guard let profile = profile else { return "Other" }
+        return profile == "default" ? "Default" : profile
+    }
+
+    /// Filter limits based on display config
+    private var visibleLimits: [UsageLimitInfo] {
+        limits.filter { limit in
+            switch limit.id {
+            case "session": return displayConfig.showSessionBar
+            case "weekly": return displayConfig.showWeeklyBar
+            default: return true
+            }
+        }
+    }
+}
+
+// MARK: - Usage Limit Bar Row
+
+struct UsageLimitBarRow: View {
+    let limit: UsageLimitInfo
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(limit.label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundColor(.white.opacity(0.25))
+                .frame(width: 42, alignment: .leading)
+
+            // Bar track
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.white.opacity(0.06))
+
+                    Capsule()
+                        .fill(barColor.opacity(0.7))
+                        .frame(width: max(2, geometry.size.width * limit.fraction))
+                }
+            }
+            .frame(width: 60, height: 3)
+
+            // Percentage
+            Text("\(limit.percentage)%")
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundColor(barColor.opacity(0.6))
+                .fixedSize()
+        }
+    }
+
+    private var barColor: Color {
+        switch limit.tier {
+        case .normal: return TerminalColors.green
+        case .warning: return TerminalColors.amber
+        case .critical: return Color(red: 1.0, green: 0.3, blue: 0.3)
+        }
     }
 }
 

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -15,13 +15,16 @@ import Sparkle
 
 struct NotchMenuView: View {
     @ObservedObject var viewModel: NotchViewModel
+    @ObservedObject var sessionMonitor: ClaudeSessionMonitor
     @ObservedObject private var updateManager = UpdateManager.shared
     @ObservedObject private var screenSelector = ScreenSelector.shared
     @ObservedObject private var soundSelector = SoundSelector.shared
+    @ObservedObject private var usageSettings = UsageSettings.shared
     @State private var hooksInstalled: Bool = false
     @State private var launchAtLogin: Bool = false
 
     var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
         VStack(spacing: 4) {
             // Back button
             MenuRow(
@@ -38,6 +41,8 @@ struct NotchMenuView: View {
             // Appearance settings
             ScreenPickerRow(screenSelector: screenSelector)
             SoundPickerRow(soundSelector: soundSelector)
+            UsageSettingsRow(usageSettings: usageSettings)
+            UsageHistorySection(sessionMonitor: sessionMonitor)
 
             Divider()
                 .background(Color.white.opacity(0.08))
@@ -108,6 +113,8 @@ struct NotchMenuView: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 8)
+        }
+        .scrollBounceBehavior(.basedOnSize)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear {
             refreshStates()

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -355,7 +355,7 @@ struct NotchView: View {
                     viewModel: viewModel
                 )
             case .menu:
-                NotchMenuView(viewModel: viewModel)
+                NotchMenuView(viewModel: viewModel, sessionMonitor: sessionMonitor)
             case .chat(let session):
                 ChatView(
                     sessionId: session.sessionId,


### PR DESCRIPTION
## Summary

Adds comprehensive usage monitoring for users with multiple Claude Code profiles (e.g., separate home/work accounts with different subscription plans).

- **Profile-aware session grouping** — sessions are split by profile in the instances list via a `--profile` flag in the hook script
- **Real-time usage limit bars** — session (5h) and weekly (7d) utilization from Anthropic's `rate_limits` API, sourced via Claude Code's status line system. No guessing at limits — uses the actual percentages from Anthropic's backend
- **Cost estimation** — per-session API cost calculated from JSONL conversation logs with per-model pricing and message deduplication
- **Burn rate** — tokens/min display
- **Lifetime savings** — total API cost vs subscription fees since account creation
- **Daily/monthly cost history** — expandable section in the settings menu
- **Plan auto-detection** — reads subscription type and rate limit tier from macOS Keychain (`Claude Code-credentials-*` entries). Two-pass keychain query: finds matching services first (attributes only), then fetches credential data only for Claude Code entries
- **Configurable display** — toggles for cost, burn rate, savings, lifetime savings, and individual limit bars. Per-profile plan override in settings
- **Scrollable settings menu** — prevents overflow when multiple sections are expanded

## Architecture

| File | Purpose |
|------|---------|
| `Models/UsageModels.swift` | Data types: plans, pricing, limits, costs, display config |
| `Services/State/UsageTracker.swift` | Actor for JSONL parsing, rate limit state reading, cost calculation |
| `Services/Hooks/PlanDetector.swift` | Keychain + `.claude.json` plan auto-detection |
| `Core/UsageSettings.swift` | `@MainActor ObservableObject` for display preferences and plan config |
| `UI/Components/UsageSettingsRow.swift` | Settings toggles + per-profile plan picker |
| `UI/Components/UsageHistorySection.swift` | Daily/monthly cost history + lifetime savings |

The rate limit bars require a **status line script** that writes `rate_limits` JSON from Claude Code to `~/.claude-island/{profile}.json`. This is the only way to get accurate utilization percentages — the JSONL files don't contain rate limit data, and Anthropic doesn't expose a public API for it.

## Setup

Requires configuration in each profile's `settings.json`:

```json
{
  "statusLine": {
    "type": "command",
    "command": "CLAUDE_ISLAND_PROFILE=home /path/to/claude-island-statusline.sh"
  }
}
```

The hook script also needs `--profile <name>` added to the command.

## Test plan

- [ ] Build with `xcodebuild -scheme ClaudeIsland -configuration Debug build`
- [ ] Launch app with multiple Claude Code profiles active
- [ ] Verify sessions are grouped by profile
- [ ] Verify usage bars match claude.ai/settings/usage percentages
- [ ] Open settings, toggle display options, verify UI updates
- [ ] Expand Usage History section, verify daily/monthly data
- [ ] Verify settings persist across app restarts
- [ ] Test with single profile (no grouping should appear)
- [ ] Test without status line configured (bars should not appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)