### PR TITLE
fix: resolve LazyVStack CPU thrashing (100% CPU / 48s unresponsive)

### DIFF
--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -291,7 +291,7 @@ struct ChatView: View {
                             ))
                     }
 
-                    ForEach(history.reversed()) { item in
+                    ForEach(Array(history.lazy.reversed())) { item in
                         MessageItemView(item: item, sessionId: sessionId)
                             .padding(.horizontal, 16)
                             .scaleEffect(x: 1, y: -1)
@@ -304,7 +304,6 @@ struct ChatView: View {
                 .padding(.top, 20)
                 .padding(.bottom, 20)
                 .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isProcessing)
-                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: history.count)
             }
             .scaleEffect(x: 1, y: -1)
             .onScrollGeometryChange(for: Bool.self) { geometry in
@@ -648,8 +647,7 @@ struct ProcessingIndicatorView: View {
     private let color = Color(red: 0.85, green: 0.47, blue: 0.34) // Claude orange
     private let baseText: String
 
-    @State private var dotCount: Int = 1
-    private let timer = Timer.publish(every: 0.4, on: .main, in: .common).autoconnect()
+    @State private var isAnimating = false
 
     /// Use a turnId to select text consistently per user turn
     init(turnId: String = "") {
@@ -658,23 +656,36 @@ struct ProcessingIndicatorView: View {
         baseText = baseTexts[index]
     }
 
-    private var dots: String {
-        String(repeating: ".", count: dotCount)
-    }
-
     var body: some View {
         HStack(alignment: .center, spacing: 6) {
             ProcessingSpinner()
                 .frame(width: 6)
 
-            Text(baseText + dots)
+            Text(baseText)
                 .font(.system(size: 13))
                 .foregroundColor(color)
 
+            // Animated dots using opacity instead of timer-driven state updates.
+            // Each dot fades in with a stagger, avoiding layout recalculation.
+            HStack(spacing: 1) {
+                ForEach(0..<3, id: \.self) { i in
+                    Text(".")
+                        .font(.system(size: 13))
+                        .foregroundColor(color)
+                        .opacity(isAnimating ? 1 : 0)
+                        .animation(
+                            .easeInOut(duration: 0.4)
+                            .repeatForever(autoreverses: true)
+                            .delay(Double(i) * 0.2),
+                            value: isAnimating
+                        )
+                }
+            }
+
             Spacer()
         }
-        .onReceive(timer) { _ in
-            dotCount = (dotCount % 3) + 1
+        .onAppear {
+            isAnimating = true
         }
     }
 }

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -5,7 +5,6 @@
 //  Minimal instances list matching Dynamic Island aesthetic
 //
 
-import Combine
 import SwiftUI
 
 struct ClaudeInstancesView: View {
@@ -51,7 +50,11 @@ struct ClaudeInstancesView: View {
             // Fall back to lastActivity if no user messages yet
             let dateA = a.lastUserMessageDate ?? a.lastActivity
             let dateB = b.lastUserMessageDate ?? b.lastActivity
-            return dateA > dateB
+            if dateA != dateB {
+                return dateA > dateB
+            }
+            // Tertiary sort by sessionId for deterministic ordering when dates tie
+            return a.sessionId < b.sessionId
         }
     }
 
@@ -127,12 +130,10 @@ struct InstanceRow: View {
     let onReject: () -> Void
 
     @State private var isHovered = false
-    @State private var spinnerPhase = 0
     @State private var isYabaiAvailable = false
+    @State private var isSpinnerAnimating = false
 
     private let claudeOrange = Color(red: 0.85, green: 0.47, blue: 0.34)
-    private let spinnerSymbols = ["·", "✢", "✳", "∗", "✻", "✽"]
-    private let spinnerTimer = Timer.publish(every: 0.15, on: .main, in: .common).autoconnect()
 
     /// Whether we're showing the approval UI
     private var isWaitingForApproval: Bool {
@@ -329,19 +330,27 @@ struct InstanceRow: View {
     private var stateIndicator: some View {
         switch session.phase {
         case .processing, .compacting:
-            Text(spinnerSymbols[spinnerPhase % spinnerSymbols.count])
+            Text("✳")
                 .font(.system(size: 12, weight: .bold))
                 .foregroundColor(claudeOrange)
-                .onReceive(spinnerTimer) { _ in
-                    spinnerPhase = (spinnerPhase + 1) % spinnerSymbols.count
-                }
+                .rotationEffect(.degrees(isSpinnerAnimating ? 360 : 0))
+                .animation(
+                    .linear(duration: 1.0).repeatForever(autoreverses: false),
+                    value: isSpinnerAnimating
+                )
+                .onAppear { isSpinnerAnimating = true }
+                .onDisappear { isSpinnerAnimating = false }
         case .waitingForApproval:
-            Text(spinnerSymbols[spinnerPhase % spinnerSymbols.count])
+            Text("✳")
                 .font(.system(size: 12, weight: .bold))
                 .foregroundColor(TerminalColors.amber)
-                .onReceive(spinnerTimer) { _ in
-                    spinnerPhase = (spinnerPhase + 1) % spinnerSymbols.count
-                }
+                .rotationEffect(.degrees(isSpinnerAnimating ? 360 : 0))
+                .animation(
+                    .linear(duration: 1.0).repeatForever(autoreverses: false),
+                    value: isSpinnerAnimating
+                )
+                .onAppear { isSpinnerAnimating = true }
+                .onDisappear { isSpinnerAnimating = false }
         case .waitingForInput:
             Circle()
                 .fill(TerminalColors.green)


### PR DESCRIPTION
## Problem

Claude Island occasionally consumes 100% CPU and becomes unresponsive for up to 48 seconds. macOS generates `cpu_resource.diag` reports pointing to layout thrashing in SwiftUI's `LazyVStack`:

```
CPU: 90 seconds cpu time over 90 seconds (100% cpu average)
process was unresponsive for 48 seconds before sampling
```

**Heaviest stack trace:**
```
LazySubviewPlacements.updateValue()
  → LazyLayoutViewCache.commitPlacedSubviews()
    → _LazyLayoutViewCache.initialPlacement() / finalPlacement()
```

## Root Cause

Three issues combine to create a layout thrashing feedback loop inside the `LazyVStack`:

### 1. `.animation(value: history.count)` on the LazyVStack (ChatView.swift:307)

During streaming, every new message increments `history.count`, which triggers a spring animation on the **entire** `LazyVStack`. This forces SwiftUI to recalculate the layout of all visible cells mid-animation. Since streaming adds messages rapidly, animations pile up and the layout engine can never settle.

### 2. Timer-driven `ProcessingIndicatorView` (ChatView.swift:652)

A `Timer.publish(every: 0.4)` updates `@State var dotCount` to cycle "Processing.", "Processing..", "Processing...". Each state mutation triggers a view update **inside** the already-thrashing `LazyVStack`, compounding the layout invalidation.

### 3. Timer-driven spinner in `InstanceRow` (ClaudeInstancesView.swift:135)

A `Timer.publish(every: 0.15)` updates `@State var spinnerPhase` to cycle through 6 symbol characters. At 6.7 updates/second **per row**, with multiple active sessions, this generates constant layout invalidation in the instances `LazyVStack`.

**Secondary issue:** `sortedInstances` produces unstable ordering when two sessions have the same priority and date, causing the `LazyVStack` to unnecessarily shuffle items.

## Fix

### ChatView.swift

| Change | Why |
|--------|-----|
| Remove `.animation(value: history.count)` | This was the primary thrashing trigger. The `.animation(value: isProcessing)` modifier already handles the only transition that needs animation (processing indicator appear/disappear). Individual message insertion is handled by the per-item `.transition()` modifiers. |
| Replace timer-driven dot animation with opacity-based animation | Instead of mutating `dotCount` via `Timer`, use three `Text(".")` views with staggered `.opacity` animations via `.repeatForever()`. This produces the same visual effect but uses Core Animation (GPU-composited) with zero state mutations. |

### ClaudeInstancesView.swift

| Change | Why |
|--------|-----|
| Replace `Timer.publish(every: 0.15)` spinner with `.rotationEffect` animation | Uses a single `✳` character with `.linear(duration: 1.0).repeatForever()` rotation. Same visual feel, zero state updates. Removes the `Combine` import entirely. |
| Add tertiary sort key (`sessionId`) | When two sessions have the same priority and date, the sort was non-deterministic, causing `LazyVStack` to see items "move" and invalidate its layout cache. `sessionId` is immutable and unique, making the sort stable. |

## Testing

1. Open Claude Island with 2+ active Claude Code sessions
2. Have at least one session actively streaming a response
3. Monitor CPU in Activity Monitor — should stay well below 50%
4. Previously this scenario would spike to 100% within ~90 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)