### PR TITLE
Auto-open notch for AskUserQuestion prompts

### DIFF
--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -430,9 +430,25 @@ struct NotchView: View {
            viewModel.status == .closed &&
            !TerminalVisibilityDetector.isTerminalVisibleOnCurrentSpace() {
             viewModel.notchOpen(reason: .notification)
+            autoOpenForInteractiveTool(sessions)
         }
 
         previousPendingIds = currentIds
+    }
+
+    /// Auto-open the notch and navigate to the chat view for interactive tools
+    /// like AskUserQuestion. Without this, the user only sees a small permission
+    /// icon in the closed bar and has to manually click to open the notch, then
+    /// find the right session to see the interactive prompt with option chips.
+    private func autoOpenForInteractiveTool(_ pendingSessions: [SessionState]) {
+        guard viewModel.status == .closed else { return }
+        guard let interactiveSession = pendingSessions.first(where: { $0.pendingToolName == "AskUserQuestion" }) else { return }
+
+        viewModel.notchOpen(reason: .notification)
+        // Small delay to let the open animation start before navigating to chat
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            viewModel.showChat(for: interactiveSession)
+        }
     }
 
     private func handleWaitingForInputChange(_ instances: [SessionState]) {


### PR DESCRIPTION
## Summary

When `AskUserQuestion` fires, the notch currently shows a small permission indicator icon in the closed bar. The actual interactive prompt with clickable option chips only renders inside the opened chat view, so users never see it unless they manually click to open the notch and then find the right session.

This adds an `autoOpenForInteractiveTool` helper that:
- Detects when the pending tool is specifically `AskUserQuestion`
- Opens the notch automatically
- Navigates directly to that session's chat view after a brief animation delay

The result is that AskUserQuestion prompts are immediately visible and actionable without any manual intervention.

## Changes

- `NotchView.swift`: Added `autoOpenForInteractiveTool(_:)` method and wired it into `handlePendingSessionsChange`

## Test plan

- [ ] Trigger an `AskUserQuestion` tool call from Claude Code while the notch is closed
- [ ] Verify the notch auto-opens and navigates to the correct session's chat
- [ ] Verify non-AskUserQuestion permissions still show the indicator icon without auto-opening to chat
- [ ] Verify no behavior change when the notch is already open