### PR TITLE
Add task board, plan tracking, and markdown table rendering

### DIFF
--- a/ClaudeIsland/Models/SessionState.swift
+++ b/ClaudeIsland/Models/SessionState.swift
@@ -43,6 +43,19 @@ struct SessionState: Equatable, Identifiable, Sendable {
     /// State for Task tools and their nested subagent tools
     var subagentState: SubagentState
 
+    // MARK: - Task Tracking
+
+    /// Tasks created via TaskCreate/TaskUpdate tool calls
+    var tasks: [TaskItem]
+
+    // MARK: - Plan Content
+
+    /// Markdown content of the current plan (from ExitPlanMode)
+    var planContent: String?
+
+    /// Path to the plan file for this session (resolved from ExitPlanMode events)
+    var planFilePath: URL?
+
     // MARK: - Conversation Info (from JSONL parsing)
 
     var conversationInfo: ConversationInfo
@@ -75,6 +88,8 @@ struct SessionState: Equatable, Identifiable, Sendable {
         chatItems: [ChatHistoryItem] = [],
         toolTracker: ToolTracker = ToolTracker(),
         subagentState: SubagentState = SubagentState(),
+        tasks: [TaskItem] = [],
+        planContent: String? = nil,
         conversationInfo: ConversationInfo = ConversationInfo(
             summary: nil, lastMessage: nil, lastMessageRole: nil,
             lastToolName: nil, firstUserMessage: nil, lastUserMessageDate: nil
@@ -93,6 +108,8 @@ struct SessionState: Equatable, Identifiable, Sendable {
         self.chatItems = chatItems
         self.toolTracker = toolTracker
         self.subagentState = subagentState
+        self.tasks = tasks
+        self.planContent = planContent
         self.conversationInfo = conversationInfo
         self.needsClearReconciliation = needsClearReconciliation
         self.lastActivity = lastActivity
@@ -347,4 +364,68 @@ struct TaskContext: Equatable, Sendable {
     var agentId: String?
     var description: String?
     var subagentTools: [SubagentToolCall]
+}
+
+// MARK: - Task Item
+
+/// A task tracked via TaskCreate/TaskUpdate tool calls
+struct TaskItem: Equatable, Identifiable, Sendable {
+    var id: String
+    var subject: String
+    var status: TaskStatus
+
+    enum TaskStatus: String, Sendable {
+        case pending
+        case inProgress = "in_progress"
+        case completed
+        case deleted
+    }
+}
+
+// MARK: - Task Management
+
+extension SessionState {
+    /// Add a new task with a temporary placeholder ID
+    mutating func addTask(subject: String) {
+        let tempId = "_t\(tasks.count)"
+        tasks.append(TaskItem(id: tempId, subject: subject, status: .pending))
+    }
+
+    /// Reset all tasks for a new prompt turn
+    mutating func resetTasks() {
+        tasks.removeAll()
+    }
+
+    /// Resolve a temp task's real ID by matching its subject
+    mutating func resolveTaskId(subject: String, realId: String) {
+        if let idx = tasks.firstIndex(where: { $0.id.hasPrefix("_t") && $0.subject == subject }) {
+            tasks[idx].id = realId
+        }
+    }
+
+    /// Update task status by ID
+    mutating func updateTask(taskId: String, status: TaskItem.TaskStatus) {
+        if let idx = tasks.firstIndex(where: { $0.id == taskId }) {
+            if status == .deleted {
+                tasks.remove(at: idx)
+            } else {
+                tasks[idx].status = status
+            }
+            return
+        }
+        // Fallback: unknown task — create entry
+        if status != .deleted {
+            tasks.append(TaskItem(id: taskId, subject: "Task #\(taskId)", status: status))
+        }
+    }
+
+    /// Remove old pending tasks with temp IDs that were never resolved
+    mutating func pruneStaleTemporaryTasks() {
+        tasks.removeAll { $0.id.hasPrefix("_t") && $0.status == .pending }
+    }
+
+    /// Remove completed tasks to keep the visible list concise
+    mutating func pruneCompletedTasks() {
+        tasks.removeAll { $0.status == .completed }
+    }
 }

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -113,6 +113,28 @@ def main():
         state["status"] = "processing"
         state["tool"] = data.get("tool_name")
         state["tool_input"] = tool_input
+        # Forward tool_result for task ID resolution
+        tool_result = data.get("tool_result")
+        if tool_result:
+            if isinstance(tool_result, str):
+                state["tool_result"] = tool_result
+            elif isinstance(tool_result, dict):
+                # tool_result can be a dict with output/message/content
+                state["tool_result"] = (
+                    tool_result.get("output")
+                    or tool_result.get("message")
+                    or tool_result.get("content")
+                    or ""
+                )
+        # Forward tool_response for structured results (e.g. TaskCreate → {task:{id:...,subject:...}})
+        tool_response = data.get("tool_response")
+        if isinstance(tool_response, dict):
+            # Extract resolved task ID for TaskCreate
+            task = tool_response.get("task")
+            if isinstance(task, dict) and "id" in task:
+                state["resolved_task_id"] = str(task["id"])
+                if "subject" in task:
+                    state["resolved_task_subject"] = task["subject"]
         # Send tool_use_id so Swift can cancel the specific pending permission
         tool_use_id_from_event = data.get("tool_use_id")
         if tool_use_id_from_event:

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -25,6 +25,9 @@ struct HookEvent: Codable, Sendable {
     let toolUseId: String?
     let notificationType: String?
     let message: String?
+    let toolResult: String?
+    let resolvedTaskId: String?
+    let resolvedTaskSubject: String?
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
@@ -33,10 +36,13 @@ struct HookEvent: Codable, Sendable {
         case toolUseId = "tool_use_id"
         case notificationType = "notification_type"
         case message
+        case toolResult = "tool_result"
+        case resolvedTaskId = "resolved_task_id"
+        case resolvedTaskSubject = "resolved_task_subject"
     }
 
     /// Create a copy with updated toolUseId
-    init(sessionId: String, cwd: String, event: String, status: String, pid: Int?, tty: String?, tool: String?, toolInput: [String: AnyCodable]?, toolUseId: String?, notificationType: String?, message: String?) {
+    init(sessionId: String, cwd: String, event: String, status: String, pid: Int?, tty: String?, tool: String?, toolInput: [String: AnyCodable]?, toolUseId: String?, notificationType: String?, message: String?, toolResult: String? = nil, resolvedTaskId: String? = nil, resolvedTaskSubject: String? = nil) {
         self.sessionId = sessionId
         self.cwd = cwd
         self.event = event
@@ -48,6 +54,9 @@ struct HookEvent: Codable, Sendable {
         self.toolUseId = toolUseId
         self.notificationType = notificationType
         self.message = message
+        self.toolResult = toolResult
+        self.resolvedTaskId = resolvedTaskId
+        self.resolvedTaskSubject = resolvedTaskSubject
     }
 
     var sessionPhase: SessionPhase {

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -1126,6 +1126,10 @@ actor SessionStore {
                 await self?.process(.clearDetected(sessionId: sessionId))
             }
 
+            // Always update conversationInfo (lastMessage, summary, etc.)
+            // even when there are no new chat messages to process
+            await self?.updateConversationInfo(sessionId: sessionId, cwd: cwd)
+
             guard !result.newMessages.isEmpty || result.clearDetected else {
                 return
             }
@@ -1142,6 +1146,18 @@ actor SessionStore {
 
             await self?.process(.fileUpdated(payload))
         }
+    }
+
+    /// Update conversationInfo (lastMessage, summary, etc.) independently of chat item processing
+    private func updateConversationInfo(sessionId: String, cwd: String) async {
+        guard var session = sessions[sessionId] else { return }
+        let conversationInfo = await ConversationParser.shared.parse(
+            sessionId: sessionId,
+            cwd: cwd
+        )
+        session.conversationInfo = conversationInfo
+        sessions[sessionId] = session
+        publishState()
     }
 
     private func cancelPendingSync(sessionId: String) {

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -162,6 +162,19 @@ actor SessionStore {
 
         processToolTracking(event: event, session: &session)
         processSubagentTracking(event: event, session: &session)
+        processTaskTracking(event: event, session: &session)
+
+        // Debug: log tool names to diagnose plan tracking
+        if let tool = event.tool {
+            Self.logger.debug("Hook event: \(event.event, privacy: .public) tool=\(tool, privacy: .public)")
+        }
+        processPlanTracking(event: event, session: &session)
+
+        if event.event == "UserPromptSubmit" {
+            session.resetTasks()
+            session.planContent = nil
+            session.planFilePath = nil
+        }
 
         if event.event == "Stop" {
             session.subagentState = SubagentState()
@@ -315,6 +328,98 @@ actor SessionStore {
 
         default:
             break
+        }
+    }
+
+    private func processTaskTracking(event: HookEvent, session: inout SessionState) {
+        switch event.event {
+        case "PreToolUse":
+            guard let toolName = event.tool else { return }
+
+            if toolName == "TaskCreate" {
+                if let subject = event.toolInput?["subject"]?.value as? String {
+                    session.addTask(subject: subject)
+                    Self.logger.debug("TaskCreate: added task '\(subject, privacy: .public)'")
+                }
+            } else if toolName == "TaskUpdate" {
+                if let taskId = event.toolInput?["taskId"]?.value as? String {
+                    let existingIds = session.tasks.map { $0.id }.joined(separator: ", ")
+                    Self.logger.debug("TaskUpdate: looking for \(taskId, privacy: .public) in [\(existingIds, privacy: .public)]")
+                    if let statusStr = event.toolInput?["status"]?.value as? String,
+                       let status = TaskItem.TaskStatus(rawValue: statusStr) {
+                        session.updateTask(taskId: taskId, status: status)
+                        Self.logger.debug("TaskUpdate: \(taskId, privacy: .public) → \(statusStr, privacy: .public)")
+                    }
+                    if let subject = event.toolInput?["subject"]?.value as? String,
+                       let idx = session.tasks.firstIndex(where: { $0.id == taskId }) {
+                        session.tasks[idx].subject = subject
+                    }
+                }
+            } else if toolName == "TaskList" {
+                session.pruneStaleTemporaryTasks()
+                session.pruneCompletedTasks()
+            }
+
+        case "PostToolUse":
+            guard event.tool == "TaskCreate" else { return }
+
+            // Primary: use resolved_task_id from tool_response (parsed by Python)
+            if let realId = event.resolvedTaskId {
+                let subject = event.resolvedTaskSubject
+                    ?? event.toolInput?["subject"]?.value as? String
+                if let subject {
+                    session.resolveTaskId(subject: subject, realId: realId)
+                } else if let idx = session.tasks.firstIndex(where: { $0.id.hasPrefix("_t") }) {
+                    session.tasks[idx].id = realId
+                }
+                Self.logger.debug("TaskCreate resolved: id=\(realId, privacy: .public)")
+            }
+            // Fallback: parse from tool_result string "Task #8 created..."
+            else if let result = event.toolResult {
+                if let range = result.range(of: #"Task #(\d+)"#, options: .regularExpression),
+                   let idRange = result[range].range(of: #"\d+"#, options: .regularExpression) {
+                    let realId = String(result[idRange])
+                    if let inputSubject = event.toolInput?["subject"]?.value as? String {
+                        session.resolveTaskId(subject: inputSubject, realId: realId)
+                    } else if let idx = session.tasks.firstIndex(where: { $0.id.hasPrefix("_t") }) {
+                        session.tasks[idx].id = realId
+                    }
+                    Self.logger.debug("TaskCreate resolved (fallback): id=\(realId, privacy: .public)")
+                }
+            }
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Plan Tracking
+
+    private func processPlanTracking(event: HookEvent, session: inout SessionState) {
+        guard let toolName = event.tool else { return }
+        let isPlanTool = toolName == "ExitPlanMode"
+            || toolName == "exit_plan_mode"
+            || toolName.lowercased().contains("exitplanmode")
+            || toolName.lowercased().contains("planmode")
+
+        guard isPlanTool else { return }
+
+        // Extract plan content and file path directly from toolInput
+        if let input = event.toolInput {
+            if let planContent = input["plan"]?.value as? String, !planContent.isEmpty {
+                session.planContent = planContent
+                Self.logger.debug("Plan loaded from toolInput (\(planContent.count) chars)")
+            }
+            if let pathStr = input["planFilePath"]?.value as? String, !pathStr.isEmpty {
+                session.planFilePath = URL(fileURLWithPath: pathStr)
+            }
+        }
+
+        // Fallback: read from known file path
+        if session.planContent == nil, let path = session.planFilePath,
+           let content = try? String(contentsOf: path, encoding: .utf8) {
+            session.planContent = content
+            Self.logger.debug("Plan loaded from file: \(path.lastPathComponent, privacy: .public)")
         }
     }
 

--- a/ClaudeIsland/UI/Components/MarkdownRenderer.swift
+++ b/ClaudeIsland/UI/Components/MarkdownRenderer.swift
@@ -99,6 +99,8 @@ private struct BlockRenderer: View {
             Divider()
                 .background(baseColor.opacity(0.3))
                 .padding(.vertical, 4)
+        } else if let table = markup as? Markdown.Table {
+            tableView(table)
         } else {
             EmptyView()
         }
@@ -180,6 +182,65 @@ private struct BlockRenderer: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func tableView(_ table: Markdown.Table) -> some View {
+        let headCells = Array(table.head.cells)
+        let bodyRows = Array(table.body.rows)
+
+        VStack(alignment: .leading, spacing: 0) {
+            // Header row
+            HStack(spacing: 0) {
+                ForEach(Array(headCells.enumerated()), id: \.offset) { i, cell in
+                    cellPlainText(cell)
+                        .fontWeight(.semibold)
+                        .foregroundColor(baseColor)
+                        .font(.system(size: fontSize - 1))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if i < headCells.count - 1 {
+                        Rectangle().fill(baseColor.opacity(0.15)).frame(width: 0.5)
+                    }
+                }
+            }
+            .background(baseColor.opacity(0.08))
+
+            Rectangle().fill(baseColor.opacity(0.2)).frame(height: 0.5)
+
+            // Body rows
+            ForEach(Array(bodyRows.enumerated()), id: \.offset) { _, row in
+                let cells = Array(row.cells)
+                HStack(spacing: 0) {
+                    ForEach(Array(cells.enumerated()), id: \.offset) { i, cell in
+                        cellPlainText(cell)
+                            .foregroundColor(baseColor.opacity(0.8))
+                            .font(.system(size: fontSize - 1))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        if i < cells.count - 1 {
+                            Rectangle().fill(baseColor.opacity(0.1)).frame(width: 0.5)
+                        }
+                    }
+                }
+
+                Rectangle().fill(baseColor.opacity(0.08)).frame(height: 0.5)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(baseColor.opacity(0.15), lineWidth: 0.5)
+        )
+    }
+
+    /// Simple plain text extraction from a table cell
+    private func cellPlainText(_ cell: Markdown.Table.Cell) -> SwiftUI.Text {
+        SwiftUI.Text(cell.plainText)
     }
 }
 

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -51,12 +51,18 @@ struct ChatView: View {
         session.phase.approvalToolName
     }
 
-    
+
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
                 // Header
                 chatHeader
+
+                // Task board (fixed above messages)
+                if !session.tasks.isEmpty {
+                    taskBoard
+                    Divider().background(Color.white.opacity(0.06))
+                }
 
                 // Messages
                 if isLoading {
@@ -191,10 +197,19 @@ struct ChatView: View {
                     .foregroundColor(.white.opacity(isHeaderHovered ? 1.0 : 0.6))
                     .frame(width: 24, height: 24)
 
-                Text(session.displayTitle)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white.opacity(isHeaderHovered ? 1.0 : 0.85))
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(session.displayTitle)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white.opacity(isHeaderHovered ? 1.0 : 0.85))
+                        .lineLimit(1)
+
+                    if session.displayTitle != session.projectName {
+                        Text(session.projectName)
+                            .font(.system(size: 11))
+                            .foregroundColor(.white.opacity(0.4))
+                            .lineLimit(1)
+                    }
+                }
 
                 Spacer()
             }
@@ -221,6 +236,133 @@ struct ChatView: View {
             .allowsHitTesting(false)
         }
         .zIndex(1) // Render above message list
+    }
+
+    // MARK: - Task Board
+
+    private var taskCompletedCount: Int {
+        session.tasks.filter { $0.status == .completed }.count
+    }
+
+    private var taskTotalCount: Int {
+        session.tasks.count
+    }
+
+    private var taskProgress: Double {
+        guard taskTotalCount > 0 else { return 0 }
+        return Double(taskCompletedCount) / Double(taskTotalCount)
+    }
+
+    @State private var isTaskBoardExpanded: Bool = true
+
+    private var taskBoard: some View {
+        HStack(alignment: .top, spacing: 6) {
+            // Dot indicator matching assistant message style
+            Circle()
+                .fill(Color.blue.opacity(0.6))
+                .frame(width: 6, height: 6)
+                .padding(.top, 5)
+
+            VStack(alignment: .leading, spacing: 6) {
+                // Header: Tasks progress — tappable to toggle
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isTaskBoardExpanded.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundColor(.white.opacity(0.3))
+                            .rotationEffect(.degrees(isTaskBoardExpanded ? 90 : 0))
+
+                        Text("Tasks")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(.white.opacity(0.8))
+
+                        Text("\(taskCompletedCount)/\(taskTotalCount)")
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundColor(.white.opacity(0.4))
+
+                        // Segmented progress bar — one segment per task
+                        HStack(spacing: 2) {
+                            ForEach(session.tasks) { t in
+                                RoundedRectangle(cornerRadius: 1.5)
+                                    .fill(t.status == .completed
+                                        ? Color.green.opacity(0.9)
+                                        : t.status == .inProgress
+                                        ? Color.yellow.opacity(0.85)
+                                        : Color.white.opacity(0.25))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 1.5)
+                                            .stroke(Color.white.opacity(t.status == .pending ? 0.35 : 0), lineWidth: 0.5)
+                                    )
+                                    .frame(height: 5)
+                            }
+                        }
+                        .frame(maxWidth: 120, minHeight: 5)
+                        .animation(.easeInOut(duration: 0.3), value: session.tasks.map(\.status))
+                    }
+                }
+                .buttonStyle(.plain)
+
+                // Task list — collapsible
+                if isTaskBoardExpanded {
+                    ForEach(session.tasks) { task in
+                        HStack(spacing: 5) {
+                            if task.status == .inProgress {
+                                TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { timeline in
+                                    let angle = timeline.date.timeIntervalSinceReferenceDate
+                                        .truncatingRemainder(dividingBy: 1.2) / 1.2 * 360
+                                    Image(systemName: "arrow.triangle.2.circlepath")
+                                        .font(.system(size: 8))
+                                        .foregroundStyle(.blue)
+                                        .frame(width: 10)
+                                        .rotationEffect(.degrees(angle))
+                                }
+                            } else {
+                                Image(systemName: taskBoardIcon(task.status))
+                                    .font(.system(size: 8))
+                                    .foregroundStyle(taskBoardColor(task.status))
+                                    .frame(width: 10)
+                            }
+
+                            Text(task.subject)
+                                .font(.system(size: 11))
+                                .foregroundStyle(task.status == .completed
+                                    ? .white.opacity(0.35)
+                                    : task.status == .inProgress
+                                    ? .white.opacity(0.85)
+                                    : .white.opacity(0.55))
+                                .strikethrough(task.status == .completed, color: .white.opacity(0.2))
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            }
+
+            Spacer(minLength: 60)
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 6)
+    }
+
+    private func taskBoardIcon(_ status: TaskItem.TaskStatus) -> String {
+        switch status {
+        case .completed: "checkmark.circle.fill"
+        case .inProgress: "arrow.triangle.2.circlepath"
+        case .pending: "circle"
+        case .deleted: "xmark.circle"
+        }
+    }
+
+    private func taskBoardColor(_ status: TaskItem.TaskStatus) -> Color {
+        switch status {
+        case .completed: .green
+        case .inProgress: .blue
+        case .pending: .white.opacity(0.3)
+        case .deleted: .red.opacity(0.3)
+        }
     }
 
     /// Whether the session is currently processing
@@ -292,7 +434,11 @@ struct ChatView: View {
                     }
 
                     ForEach(history.reversed()) { item in
-                        MessageItemView(item: item, sessionId: sessionId)
+                        MessageItemView(
+                            item: item,
+                            sessionId: sessionId,
+                            planContent: session.planContent
+                        )
                             .padding(.horizontal, 16)
                             .scaleEffect(x: 1, y: -1)
                             .transition(.asymmetric(
@@ -523,21 +669,46 @@ struct ChatView: View {
 struct MessageItemView: View {
     let item: ChatHistoryItem
     let sessionId: String
+    var planContent: String?
+
+    private var isPlanTool: Bool {
+        if case .toolCall(let tool) = item.type {
+            return tool.name == "ExitPlanMode" || tool.name == "exit_plan_mode"
+        }
+        return false
+    }
 
     var body: some View {
-        switch item.type {
-        case .user(let text):
-            UserMessageView(text: text)
-        case .assistant(let text):
-            AssistantMessageView(text: text)
-        case .toolCall(let tool):
-            ToolCallView(tool: tool, sessionId: sessionId)
-        case .thinking(let text):
-            ThinkingView(text: text)
-        case .image(let block):
-            ImageMessageView(image: block)
-        case .interrupted:
-            InterruptedMessageView()
+        VStack(alignment: .leading, spacing: 8) {
+            switch item.type {
+            case .user(let text):
+                UserMessageView(text: text)
+            case .assistant(let text):
+                AssistantMessageView(text: text)
+            case .toolCall(let tool):
+                ToolCallView(tool: tool, sessionId: sessionId)
+            case .thinking(let text):
+                ThinkingView(text: text)
+            case .image(let block):
+                ImageMessageView(image: block)
+            case .interrupted:
+                InterruptedMessageView()
+            }
+
+            // Show plan content inline after ExitPlanMode tool call
+            if isPlanTool, let planContent {
+                HStack(alignment: .top, spacing: 6) {
+                    Circle()
+                        .fill(Color.blue.opacity(0.6))
+                        .frame(width: 6, height: 6)
+                        .padding(.top, 5)
+
+                    MarkdownText(planContent, color: .white.opacity(0.9), fontSize: 13)
+                        .textSelection(.enabled)
+
+                    Spacer(minLength: 60)
+                }
+            }
         }
     }
 }

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -185,6 +185,13 @@ struct InstanceRow: View {
                     }
                 }
 
+                if session.displayTitle != session.projectName {
+                    Text(session.projectName)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.white.opacity(0.4))
+                        .lineLimit(1)
+                }
+
                 // Show tool call when waiting for approval, otherwise last activity
                 if isWaitingForApproval, let toolName = session.pendingToolName {
                     // Show tool name in amber + input on same line

--- a/ClaudeIsland/UI/Views/PlanDetailView.swift
+++ b/ClaudeIsland/UI/Views/PlanDetailView.swift
@@ -1,0 +1,23 @@
+//
+//  PlanDetailView.swift
+//  ClaudeIsland
+//
+//  Full plan content view for the standalone plan window.
+//  Uses MarkdownText (swift-markdown) for rich rendering.
+//
+
+import SwiftUI
+
+struct PlanDetailView: View {
+    var model: PlanContentModel
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            MarkdownText(model.content, color: .white.opacity(0.85), fontSize: 14)
+                .padding(32)
+                .frame(maxWidth: 680)
+                .frame(maxWidth: .infinity)
+        }
+        .background(Color(red: 0.08, green: 0.08, blue: 0.10))
+    }
+}

--- a/ClaudeIsland/UI/Views/PlanPreviewView.swift
+++ b/ClaudeIsland/UI/Views/PlanPreviewView.swift
@@ -1,0 +1,69 @@
+//
+//  PlanPreviewView.swift
+//  ClaudeIsland
+//
+//  Inline plan preview with collapse/expand.
+//  Uses MarkdownText (swift-markdown) for rendering.
+//
+
+import SwiftUI
+
+struct PlanPreviewView: View {
+    let content: String
+    var startCollapsed: Bool = false
+
+    @State private var isCollapsed: Bool?
+
+    private var collapsed: Bool {
+        isCollapsed ?? startCollapsed
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // Header — tappable toggle
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) { isCollapsed = !collapsed }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "doc.text.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.blue)
+
+                    Text("Plan")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.blue)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.3))
+                        .rotationEffect(.degrees(collapsed ? 0 : 90))
+                }
+            }
+            .buttonStyle(.plain)
+
+            // Markdown content — collapsible, scrollable, selectable
+            if !collapsed {
+                ScrollView(.vertical, showsIndicators: true) {
+                    MarkdownText(content, color: .white.opacity(0.85), fontSize: 12)
+                        .textSelection(.enabled)
+                        .padding(10)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxHeight: 360)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(.white.opacity(0.04))
+                )
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.blue.opacity(0.05))
+        )
+    }
+}

--- a/ClaudeIsland/UI/Window/PlanWindowController.swift
+++ b/ClaudeIsland/UI/Window/PlanWindowController.swift
@@ -1,0 +1,84 @@
+//
+//  PlanWindowController.swift
+//  ClaudeIsland
+//
+//  Manages a standalone window for viewing plan markdown content.
+//
+
+import AppKit
+import SwiftUI
+
+final class PlanWindowController {
+    static let shared = PlanWindowController()
+
+    private var window: NSWindow?
+    private var closeObserver: NSObjectProtocol?
+    private var contentModel = PlanContentModel()
+
+    private init() {}
+
+    func show(content: String) {
+        contentModel.content = content
+
+        if let window, window.isVisible {
+            NSApp.setActivationPolicy(.regular)
+            NSApp.activate(ignoringOtherApps: true)
+            window.makeKeyAndOrderFront(nil)
+            return
+        }
+
+        let rootView = PlanDetailView(model: contentModel)
+        let hostingView = NSHostingView(rootView: rootView)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 620, height: 560),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
+        window.center()
+        window.title = "Plan"
+        window.isReleasedWhenClosed = false
+        window.titlebarAppearsTransparent = true
+        window.backgroundColor = NSColor(red: 0.08, green: 0.08, blue: 0.10, alpha: 1.0)
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.minSize = NSSize(width: 400, height: 300)
+        window.level = .floating
+
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+
+        closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.onClose()
+            }
+        }
+
+        self.window = window
+    }
+
+    func close() {
+        window?.close()
+    }
+
+    private func onClose() {
+        if let observer = closeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            closeObserver = nil
+        }
+        window = nil
+        NSApp.setActivationPolicy(.accessory)
+    }
+}
+
+/// Observable model so the window content updates when plan changes
+@Observable
+final class PlanContentModel {
+    var content: String = ""
+}


### PR DESCRIPTION
## Summary

- **Task Board UI**: Add a collapsible task board above chat messages that tracks TaskCreate/TaskUpdate tool calls in real-time, with a segmented progress bar, status icons, and spinning animation for in-progress tasks
- **Plan Tracking**: Capture ExitPlanMode tool call content and render the plan inline below the tool call in the chat view
- **Markdown Table Rendering**: Add support for rendering `Markdown.Table` with styled headers, borders, and rounded corners
- **Project Name Subtitle**: Show project name as a subtitle in the chat header and instance list row when it differs from the session title
- **Hook Event Enhancements**: Forward `tool_result` and `tool_response` from the Python hook script to Swift for task ID resolution (temp ID → real ID)

## Changes

| File | Description |
|------|-------------|
| `SessionState.swift` | Add `TaskItem` model, `tasks`/`planContent`/`planFilePath` properties, and task lifecycle methods |
| `SessionStore.swift` | Add `processTaskTracking` and `processPlanTracking` event handlers |
| `claude-island-state.py` | Parse `tool_result`/`tool_response` to extract resolved task IDs |
| `HookSocketServer.swift` | Add `toolResult`, `resolvedTaskId`, `resolvedTaskSubject` fields to `HookEvent` |
| `ChatView.swift` | Add Task Board UI, plan inline rendering, project name subtitle in header |
| `MarkdownRenderer.swift` | Add `Markdown.Table` rendering support |
| `ClaudeInstancesView.swift` | Show project name in instance list |
| `PlanDetailView.swift` | New view for plan detail display |
| `PlanPreviewView.swift` | New view for plan preview |
| `PlanWindowController.swift` | New window controller for plan windows |

## Test plan

- [ ] Verify Task Board appears when Claude uses TaskCreate and updates live with TaskUpdate
- [ ] Verify progress bar segments change color as tasks transition between pending → in_progress → completed
- [ ] Verify collapsing/expanding the task board works smoothly
- [ ] Verify ExitPlanMode renders plan content inline in the chat
- [ ] Verify markdown tables render correctly with headers and borders
- [ ] Verify project name subtitle shows in chat header and instance list
- [ ] Verify task list resets on new user prompt submission