### PR TITLE
Add adaptive notch height and custom width controls

### DIFF
--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -72,12 +72,12 @@ class NotchViewModel: ObservableObject {
                 height: 580
             )
         case .menu:
-            // Base height covers all static rows (Back, 3 picker rows, 3 toggles,
-            // Accessibility, Update, GitHub, Quit + 4 dividers + padding).
+            // Base height covers all static rows (Back, 3 picker rows, 2 adaptive rows,
+            // 2 toggles, Accessibility, Update, GitHub, Quit + 4 dividers + padding).
             // Picker expansion deltas added on top when expanded.
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 540
+                height: 590
                     + screenSelector.expandedPickerHeight
                     + soundSelector.expandedPickerHeight
                     + claudeDirSelector.expandedPickerHeight

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -40,6 +40,8 @@ struct NotchMenuView: View {
 
                 // Appearance settings
                 ScreenPickerRow(screenSelector: screenSelector)
+                StatusBarHeightRow()
+                ClosedSizeRow()
                 SoundPickerRow(soundSelector: soundSelector)
                 ClaudeDirPickerRow()
 
@@ -484,6 +486,112 @@ struct MenuRow: View {
         return .white.opacity(isHovered ? 1.0 : 0.7)
     }
 }
+
+// MARK: - Status Bar Height Row
+
+struct StatusBarHeightRow: View {
+    @AppStorage("adaptToStatusBarHeight") private var isOn: Bool = true
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            isOn.toggle()
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "menubar.rectangle")
+                    .font(.system(size: 12))
+                    .foregroundColor(textColor)
+                    .frame(width: 16)
+
+                Text("Adapt to Status Bar")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(textColor)
+
+                Spacer()
+
+                Circle()
+                    .fill(isOn ? TerminalColors.green : Color.white.opacity(0.3))
+                    .frame(width: 6, height: 6)
+
+                Text(isOn ? "On" : "Off")
+                    .font(.system(size: 11))
+                    .foregroundColor(.white.opacity(0.4))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+    }
+
+    private var textColor: Color {
+        .white.opacity(isHovered ? 1.0 : 0.7)
+    }
+}
+
+// MARK: - Closed Size Row
+
+struct ClosedSizeRow: View {
+    @AppStorage("customClosedWidth") private var customWidth: Double = 0
+
+    @State private var widthText: String = ""
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "arrow.left.and.right")
+                .font(.system(size: 12))
+                .foregroundColor(.white.opacity(0.7))
+                .frame(width: 16)
+
+            Text("Width")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white.opacity(0.7))
+
+            Spacer()
+
+            HStack(spacing: 4) {
+                Text("W")
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.4))
+                TextField("Auto", text: $widthText)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.white)
+                    .frame(width: 44)
+                    .multilineTextAlignment(.center)
+                    .textFieldStyle(.plain)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(RoundedRectangle(cornerRadius: 5).fill(Color.white.opacity(0.1)))
+                    .onSubmit { commitWidth() }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isHovered ? Color.white.opacity(0.08) : Color.clear)
+        )
+        .onHover { isHovered = $0 }
+        .onAppear {
+            widthText = customWidth > 0 ? String(Int(customWidth)) : ""
+        }
+        .onChange(of: customWidth) { _, _ in
+            widthText = customWidth > 0 ? String(Int(customWidth)) : ""
+        }
+    }
+
+    private func commitWidth() {
+        customWidth = Double(widthText.trimmingCharacters(in: .whitespaces)) ?? 0
+    }
+}
+
+// MARK: - Toggle Row
 
 struct MenuToggleRow: View {
     let icon: String

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -22,10 +22,14 @@ struct NotchView: View {
     @ObservedObject private var updateManager = UpdateManager.shared
     @State private var previousPendingIds: Set<String> = []
     @State private var previousWaitingForInputIds: Set<String> = []
-    @State private var waitingForInputTimestamps: [String: Date] = [:]  // sessionId -> when it entered waitingForInput
+    @State private var waitingForInputTimestamps: [String: Date] = [:]
     @State private var isVisible: Bool = false
     @State private var isHovering: Bool = false
     @State private var isBouncing: Bool = false
+
+    // Settings that drive closed-state sizing — reactive via @AppStorage
+    @AppStorage("adaptToStatusBarHeight") private var adaptToStatusBarHeight: Bool = true
+    @AppStorage("customClosedWidth") private var customClosedWidth: Double = 0
 
     @Namespace private var activityNamespace
 
@@ -57,10 +61,20 @@ struct NotchView: View {
     // MARK: - Sizing
 
     private var closedNotchSize: CGSize {
-        CGSize(
-            width: viewModel.deviceNotchRect.width,
-            height: viewModel.deviceNotchRect.height
-        )
+        let nativeHeight = viewModel.deviceNotchRect.height
+        let statusBarHeight = NSStatusBar.system.thickness
+
+        let baseHeight = adaptToStatusBarHeight ? min(nativeHeight, statusBarHeight) : nativeHeight
+        let baseWidth = viewModel.deviceNotchRect.width / 2
+
+        let width = customClosedWidth > 0 ? CGFloat(customClosedWidth) : baseWidth
+
+        return CGSize(width: max(40, width), height: max(16, baseHeight))
+    }
+
+    /// Icon size scaled proportionally to the closed notch height (14pt baseline at 24pt height)
+    private var closedIconSize: CGFloat {
+        max(8, closedNotchSize.height * (14.0 / 24.0))
     }
 
     /// Extra width for expanding activities (like Dynamic Island)
@@ -181,6 +195,7 @@ struct NotchView: View {
                     .onTapGesture {
                         if viewModel.status != .opened {
                             viewModel.notchOpen(reason: .click)
+                            viewModel.contentType = .menu
                         }
                     }
             }
@@ -246,55 +261,58 @@ struct NotchView: View {
     @ViewBuilder
     private var headerRow: some View {
         HStack(spacing: 0) {
-            // Left side - crab + optional permission indicator (visible when processing, pending, or waiting for input)
-            if showClosedActivity {
-                HStack(spacing: 4) {
-                    ClaudeCrabIcon(size: 14, animateLegs: isProcessing)
-                        .matchedGeometryEffect(id: "crab", in: activityNamespace, isSource: showClosedActivity)
+            // Left: crab is ALWAYS visible, pinned to the left edge.
+            // Also shows permission indicator when pending.
+            HStack(spacing: 4) {
+                ClaudeCrabIcon(size: closedIconSize, animateLegs: isProcessing)
+                if hasPendingPermission {
+                    PermissionIndicatorIcon(size: closedIconSize, color: Color(red: 0.85, green: 0.47, blue: 0.34))
+                }
+            }
+            .frame(
+                width: viewModel.status == .opened ? nil : sideWidth + (hasPendingPermission ? closedIconSize + 4 : 0),
+                alignment: .leading
+            )
+            .padding(.leading, viewModel.status == .opened ? 8 : 0)
 
-                    // Permission indicator only (amber) - waiting for input shows checkmark on right
-                    if hasPendingPermission {
-                        PermissionIndicatorIcon(size: 14, color: Color(red: 0.85, green: 0.47, blue: 0.34))
-                            .matchedGeometryEffect(id: "status-indicator", in: activityNamespace, isSource: showClosedActivity)
+            // Center: flexible spacer when closed; header controls when opened
+            if viewModel.status == .opened {
+                openedHeaderContent
+            } else {
+                Spacer()
+            }
+
+            // Right: activity indicators when Claude is active; settings icon when idle
+            if showClosedActivity {
+                Group {
+                    if isProcessing || hasPendingPermission {
+                        ProcessingSpinner(size: closedIconSize * 0.85)
+                    } else if hasWaitingForInput {
+                        ReadyForInputIndicatorIcon(size: closedIconSize, color: TerminalColors.green)
                     }
                 }
-                .frame(width: viewModel.status == .opened ? nil : sideWidth + (hasPendingPermission ? 18 : 0))
-                .padding(.leading, viewModel.status == .opened ? 8 : 0)
-            }
-
-            // Center content
-            if viewModel.status == .opened {
-                // Opened: show header content
-                openedHeaderContent
-            } else if !showClosedActivity {
-                // Closed without activity: empty space
-                Rectangle()
-                    .fill(.clear)
-                    .frame(width: closedNotchSize.width - 20)
-            } else {
-                // Closed with activity: black spacer (with optional bounce)
-                Rectangle()
-                    .fill(.black)
-                    .frame(width: closedNotchSize.width - cornerRadiusInsets.closed.top + (isBouncing ? 16 : 0))
-            }
-
-            // Right side - spinner when processing/pending, checkmark when waiting for input
-            if showClosedActivity {
-                if isProcessing || hasPendingPermission {
-                    ProcessingSpinner()
-                        .matchedGeometryEffect(id: "spinner", in: activityNamespace, isSource: showClosedActivity)
-                        .frame(width: viewModel.status == .opened ? 20 : sideWidth)
-                        .padding(.trailing, viewModel.status == .opened ? 0 : 4)
-                } else if hasWaitingForInput {
-                    // Checkmark for waiting-for-input on the right side
-                    ReadyForInputIndicatorIcon(size: 14, color: TerminalColors.green)
-                        .matchedGeometryEffect(id: "spinner", in: activityNamespace, isSource: showClosedActivity)
-                        .frame(width: viewModel.status == .opened ? 20 : sideWidth)
-                        .padding(.trailing, viewModel.status == .opened ? 0 : 4)
+                .frame(width: viewModel.status == .opened ? 20 : sideWidth, alignment: .trailing)
+                .padding(.trailing, viewModel.status == .opened ? 0 : 4)
+            } else if viewModel.status == .closed {
+                Button {
+                    viewModel.notchOpen(reason: .click)
+                    viewModel.contentType = .menu
+                } label: {
+                    Image(systemName: "line.3.horizontal")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(.white.opacity(0.4))
+                        .frame(width: 22, height: 22)
                 }
+                .buttonStyle(.plain)
+                .frame(width: sideWidth, alignment: .trailing)
+                .padding(.trailing, -4)
             }
         }
-        .frame(height: closedNotchSize.height)
+        // Closed: fix total width so left/right icons are always at the edges
+        .frame(
+            width: viewModel.status == .opened ? nil : closedNotchSize.width,
+            height: max(16, closedNotchSize.height)
+        )
     }
 
     private var sideWidth: CGFloat {
@@ -306,13 +324,7 @@ struct NotchView: View {
     @ViewBuilder
     private var openedHeaderContent: some View {
         HStack(spacing: 12) {
-            // Show static crab only if not showing activity in headerRow
-            // (headerRow handles crab + indicator when showClosedActivity is true)
-            if !showClosedActivity {
-                ClaudeCrabIcon(size: 14)
-                    .matchedGeometryEffect(id: "crab", in: activityNamespace, isSource: !showClosedActivity)
-                    .padding(.leading, 8)
-            }
+            // Crab is always rendered in the left of headerRow; no duplicate needed here.
 
             Spacer()
 


### PR DESCRIPTION
## Summary

- Add **Adapt to Status Bar** toggle: when enabled (default on), the closed notch height automatically matches the system status bar thickness — useful on multi-monitor setups where different display resolutions result in different status bar sizes, keeping the notch visually flush across screens
- Add **custom width input** in Settings, letting users override the default half-notch width with a fixed pixel value (leave blank to reset to Auto)

## Test plan

- [ ] Toggle "Adapt to Status Bar" on/off and verify notch height changes accordingly
- [ ] Enter a custom width value and confirm the closed notch resizes; clear the field to confirm it resets to Auto
- [ ] Verify behavior on a multi-monitor setup with displays of different resolutions