### PR TITLE
Fix notch stuck on Processing... when run_in_background:true Bash races PostToolUse after Stop

### DIFF
--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -149,8 +149,23 @@ actor SessionStore {
 
         let newPhase = event.determinePhase()
 
-        if session.phase.canTransition(to: newPhase) {
+        // PostToolUse for run_in_background:true Bash can arrive AFTER Stop
+        // (measured ~1s later in logs). Without this guard, the late PostToolUse
+        // would legally re-transition .waitingForInput → .processing and the
+        // notch would stay stuck on "Processing..." until the next user prompt.
+        // Only let PostToolUse change phase when recovering from .waitingForApproval
+        // (the terminal-side approve path that doesn't go through the socket).
+        let allowPhaseChange: Bool = {
+            if event.event == "PostToolUse" || event.event == "PostToolUseFailure" {
+                return session.phase.isWaitingForApproval
+            }
+            return true
+        }()
+
+        if allowPhaseChange, session.phase.canTransition(to: newPhase) {
             session.phase = newPhase
+        } else if !allowPhaseChange {
+            Self.logger.debug("Phase change suppressed for \(event.event, privacy: .public): keeping \(String(describing: session.phase), privacy: .public)")
         } else {
             Self.logger.debug("Invalid transition: \(String(describing: session.phase), privacy: .public) -> \(String(describing: newPhase), privacy: .public), ignoring")
         }


### PR DESCRIPTION
Fixes #98.

## Bug

When Claude Code invokes Bash with `run_in_background: true` (e.g. starting a local dev server) and immediately ends its turn, the `PostToolUse` hook for the backgrounded Bash arrives **after** the `Stop` hook (measured ~1s gap in real logs). Because `PostToolUse` is mapped to `status="processing"` and the state machine allows `.waitingForInput → .processing`, the late event re-transitions the phase back to `.processing` and the notch stays stuck on **Processing...** until the next user prompt — even though Claude is actually idle.

See the issue for the full diagnostic trace and root-cause walkthrough (file:line).

## Fix

Narrow the rule in `SessionStore.processHookEvent`: `PostToolUse` / `PostToolUseFailure` are only allowed to mutate `session.phase` when recovering from `.waitingForApproval` (the terminal-side approve path that doesn't return through the socket). In every other case the tool's status is still updated but the session phase is left alone.

```swift
let allowPhaseChange: Bool = {
    if event.event == "PostToolUse" || event.event == "PostToolUseFailure" {
        return session.phase.isWaitingForApproval
    }
    return true
}()
```

## Verification

Built locally (`xcodebuild -scheme ClaudeIsland -configuration Debug`), launched the patched app, and replayed the buggy hook sequence by piping JSON into `~/.claude/hooks/claude-island-state.py`:

```
13:36:42.963  Hooks] Received: PreToolUse  for 8bbb736d
13:36:50.879  Hooks] Received: Stop        for 8bbb736d
13:36:51.990  Hooks] Received: PostToolUse for 8bbb736d   ← 1.1s after Stop (the bug condition)
13:36:52.058  Session] Phase change suppressed for PostToolUse: keeping waitingForInput   ← fix working
```

Phase correctly stays at `.waitingForInput` instead of flipping back to `.processing`.

## Scenario matrix

| Scenario | Behavior after fix |
|---|---|
| Normal turn (Pre→Post→Stop) | Pre→.processing, Post→no-op, Stop→.waitingForInput |
| Multiple sequential tools | Pre→Post(no-op)→Pre→Post(no-op)→Stop |
| **bg bash, PostToolUse arrives after Stop (this bug)** | Pre→.processing, Stop→.waitingForInput, **Post no-op** |
| Terminal-approved permission (no socket reply) | PermissionRequest→.waitingForApproval, Post sees `.waitingForApproval`→flips to .processing (preserved) |
| User replies, Claude resumes | UserPromptSubmit→.processing via `status="processing"` path (independent of PostToolUse) |
| Permission denied then Stop | PermissionRequest→.waitingForApproval, PostToolUseFailure→.processing (recovery), Stop→.waitingForInput |

## Test plan

- [x] Build succeeds (`xcodebuild ... Debug build`)
- [x] Buggy hook sequence (Pre→Stop→PostToolUse) no longer flips phase back to `.processing`
- [x] Terminal-approved permission recovery path still works (covered by matrix row 4)
- [ ] Reviewer to verify with their own real session running a backgrounded server
