### PR TITLE
Fix hook crash when subprocess C extension fails to load

### DIFF
--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -15,13 +15,13 @@ TIMEOUT_SECONDS = 300  # 5 minutes for permission decisions
 
 def get_tty():
     """Get the TTY of the Claude process (parent)"""
-    import subprocess
-
     # Get parent PID (Claude process)
     ppid = os.getppid()
 
     # Try to get TTY from ps command for the parent process
     try:
+        import subprocess
+
         result = subprocess.run(
             ["ps", "-p", str(ppid), "-o", "tty="],
             capture_output=True,


### PR DESCRIPTION
## Summary
- `get_tty()` in `ClaudeIsland/Resources/claude-island-state.py` calls `import subprocess` at the top of the function, outside the `try/except` block that guards the rest of it.
- On macOS, if the running Python interpreter's `_posixsubprocess` C extension can't be `dlopen`'d (in my case: a Homebrew Python build whose ad-hoc-signed `.so` files got rejected by macOS's newer Gatekeeper "provenance" library-validation check), the `ImportError` propagates straight out of `get_tty()` uncaught, crashing the whole hook for every single event instead of falling back to the `os.ttyname()` methods already implemented a few lines below.
- This means a local, environment-specific Python signing issue takes down ClaudeIsland's hook entirely (every `PreToolUse`/`PostToolUse`/`Stop`/etc. invocation fails), rather than just losing the "ps-based" TTY detection.

## Fix
Move `import subprocess` inside the existing `try:` block so an import failure is caught the same way a failed `ps` invocation already is, and execution falls through to the `os.ttyname()` fallback.

## Test plan
- [x] Reproduced the original crash locally (`ImportError: ... library load denied by system policy` from a Homebrew python@3.14 install) and confirmed `get_tty()` raised uncaught before the fix.
- [x] After the fix, ran the hook with the same broken interpreter state and confirmed it no longer crashes and falls back to `os.ttyname()`.
- [x] Re-signed the local Python install separately (unrelated to this PR) and confirmed `subprocess` also works normally end-to-end when available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)