### PR TITLE
Don't steal focus when the notch expands

### DIFF
--- a/ClaudeIsland/UI/Window/NotchWindowController.swift
+++ b/ClaudeIsland/UI/Window/NotchWindowController.swift
@@ -71,11 +71,10 @@ class NotchWindowController: NSWindowController {
                 case .opened:
                     // Accept mouse events when opened so buttons work
                     notchWindow?.ignoresMouseEvents = false
-                    // Don't steal focus when opened by notification (task finished)
-                    if viewModel?.openReason != .notification {
-                        NSApp.activate(ignoringOtherApps: false)
-                        notchWindow?.makeKey()
-                    }
+                    // Never steal focus when the notch opens. The panel is a
+                    // non-activating NSPanel and buttons work via mouse events,
+                    // so activating the app / making the window key is unnecessary
+                    // and pulls keyboard focus away from whatever the user is doing.
                 case .closed, .popping:
                     // Ignore mouse events when closed so clicks pass through
                     notchWindow?.ignoresMouseEvents = true


### PR DESCRIPTION
When the notch expands for anything other than a task-finished notification (permission prompt, hover, manual open) it pulls keyboard focus off whatever app you're in. Pretty jarring if you're mid-typing somewhere else and it pops open.

It comes from the `.opened` handler in `ClaudeIsland/UI/Window/NotchWindowController.swift`:

```swift
NSApp.activate(ignoringOtherApps: false)
notchWindow?.makeKey()
```

The notch is a non-activating `NSPanel` and its buttons already work through mouse events (`ignoresMouseEvents = false` gets set on open), so making the app active + the window key isn't needed for approve/deny to work -> it only serves to grab focus. This just drops those two lines so the notch never takes focus when it opens.

Tested locally: built Release, buttons still click fine and focus stays with the foreground app.

One thing I wasn't sure on: some people might actually want it to grab focus so they can approve/deny from the keyboard. Perhaps this should be configurable?
