### PR TITLE
Answer AskUserQuestion prompts from the notch

### DIFF
--- a/ClaudeIsland/Models/PendingQuestion.swift
+++ b/ClaudeIsland/Models/PendingQuestion.swift
@@ -1,0 +1,68 @@
+//
+//  PendingQuestion.swift
+//  ClaudeIsland
+//
+//  Models for an AskUserQuestion tool call that is still waiting for an answer.
+//
+//  Claude Code fires no PreToolUse/PermissionRequest hook for AskUserQuestion —
+//  the only real-time signal is the tool_use block landing in the session JSONL.
+//  We parse the question set from there and answer it by sending the option's
+//  number to the terminal, which is how the picker is driven (a bare digit
+//  selects and submits; no Return needed).
+//
+
+import Foundation
+
+/// A single selectable option inside a question
+struct PendingQuestionOption: Equatable, Sendable {
+    let label: String
+    let description: String
+}
+
+/// One question of an AskUserQuestion tool call
+struct PendingQuestion: Equatable, Sendable {
+    let header: String
+    let question: String
+    let multiSelect: Bool
+    let options: [PendingQuestionOption]
+}
+
+/// The full set of questions for a pending AskUserQuestion tool call
+struct PendingQuestionSet: Equatable, Sendable {
+    let toolUseId: String
+    let questions: [PendingQuestion]
+
+    /// Parse from a ToolCallItem input dictionary.
+    /// `input["questions"]` holds the raw JSON array (ConversationParser
+    /// serializes non-scalar tool inputs verbatim).
+    static func parse(toolUseId: String, input: [String: String]) -> PendingQuestionSet? {
+        guard let raw = input["questions"],
+              let data = raw.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return nil }
+
+        let questions: [PendingQuestion] = array.compactMap { dict in
+            guard let question = dict["question"] as? String else { return nil }
+
+            let options: [PendingQuestionOption] = (dict["options"] as? [[String: Any]] ?? []).compactMap { opt in
+                guard let label = opt["label"] as? String else { return nil }
+                return PendingQuestionOption(
+                    label: label,
+                    description: opt["description"] as? String ?? ""
+                )
+            }
+
+            guard !options.isEmpty else { return nil }
+
+            return PendingQuestion(
+                header: dict["header"] as? String ?? "Question",
+                question: question,
+                multiSelect: dict["multiSelect"] as? Bool ?? false,
+                options: options
+            )
+        }
+
+        guard !questions.isEmpty else { return nil }
+        return PendingQuestionSet(toolUseId: toolUseId, questions: questions)
+    }
+}

--- a/ClaudeIsland/Services/Chat/ChatHistoryManager.swift
+++ b/ClaudeIsland/Services/Chat/ChatHistoryManager.swift
@@ -132,6 +132,9 @@ struct ToolCallItem: Equatable, Sendable {
     let input: [String: String]
     var status: ToolStatus
     var result: String?
+
+    /// AskUserQuestion: options sent from the notch, one line per question
+    var answeredPicks: String = ""
     var structuredResult: ToolResultData?
 
     /// For Task tools: nested subagent tool calls
@@ -194,6 +197,7 @@ struct ToolCallItem: Equatable, Sendable {
         lhs.input == rhs.input &&
         lhs.status == rhs.status &&
         lhs.result == rhs.result &&
+        lhs.answeredPicks == rhs.answeredPicks &&
         lhs.structuredResult == rhs.structuredResult &&
         lhs.subagentTools == rhs.subagentTools
     }

--- a/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
+++ b/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
@@ -157,4 +157,12 @@ extension ClaudeSessionMonitor: JSONLInterruptWatcherDelegate {
             InterruptWatcherManager.shared.stopWatching(sessionId: sessionId)
         }
     }
+
+    nonisolated func didDetectQuestionPrompt(sessionId: String, cwd: String) {
+        // Re-read the JSONL so the question's options reach the UI — nothing
+        // else triggers a sync while the picker is waiting for an answer
+        Task { @MainActor in
+            await ChatHistoryManager.shared.syncFromFile(sessionId: sessionId, cwd: cwd)
+        }
+    }
 }

--- a/ClaudeIsland/Services/Session/ConversationParser.swift
+++ b/ClaudeIsland/Services/Session/ConversationParser.swift
@@ -641,6 +641,12 @@ actor ConversationParser {
                     input[key] = String(intValue)
                 } else if let boolValue = value as? Bool {
                     input[key] = boolValue ? "true" : "false"
+                } else if JSONSerialization.isValidJSONObject([value]),
+                          let data = try? JSONSerialization.data(withJSONObject: value),
+                          let json = String(data: data, encoding: .utf8) {
+                    // Nested arrays/objects (e.g. AskUserQuestion's `questions`) are kept
+                    // as raw JSON so callers can decode them instead of losing them
+                    input[key] = json
                 }
             }
         }

--- a/ClaudeIsland/Services/Session/JSONLInterruptWatcher.swift
+++ b/ClaudeIsland/Services/Session/JSONLInterruptWatcher.swift
@@ -14,6 +14,11 @@ private let logger = Logger(subsystem: "com.claudeisland", category: "Interrupt"
 
 protocol JSONLInterruptWatcherDelegate: AnyObject {
     func didDetectInterrupt(sessionId: String)
+
+    /// An AskUserQuestion tool call was written to the JSONL. No hook fires
+    /// while its picker waits for an answer, so this is the only live signal
+    /// that the session needs input.
+    func didDetectQuestionPrompt(sessionId: String, cwd: String)
 }
 
 /// Watches a session's JSONL file for interrupt patterns in real-time
@@ -23,6 +28,7 @@ class JSONLInterruptWatcher {
     private var source: DispatchSourceFileSystemObject?
     private var lastOffset: UInt64 = 0
     private let sessionId: String
+    private let cwd: String
     private let filePath: String
     private let queue = DispatchQueue(label: "com.claudeisland.interruptwatcher", qos: .userInteractive)
 
@@ -39,6 +45,7 @@ class JSONLInterruptWatcher {
 
     init(sessionId: String, cwd: String) {
         self.sessionId = sessionId
+        self.cwd = cwd
         let projectDir = cwd.replacingOccurrences(of: "/", with: "-")
                             .replacingOccurrences(of: ".", with: "-")
         self.filePath = ClaudePaths.projectsDir.path + "/" + projectDir + "/" + sessionId + ".jsonl"
@@ -118,6 +125,14 @@ class JSONLInterruptWatcher {
 
         let lines = newContent.components(separatedBy: "\n")
         for line in lines where !line.isEmpty {
+            if line.contains("\"AskUserQuestion\"") && line.contains("\"tool_use\"") {
+                logger.info("Detected question prompt in session: \(self.sessionId.prefix(8), privacy: .public)")
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    self.delegate?.didDetectQuestionPrompt(sessionId: self.sessionId, cwd: self.cwd)
+                }
+            }
+
             if isInterruptLine(line) {
                 logger.info("Detected interrupt in session: \(self.sessionId.prefix(8), privacy: .public)")
                 DispatchQueue.main.async { [weak self] in

--- a/ClaudeIsland/Services/Shared/NotchLog.swift
+++ b/ClaudeIsland/Services/Shared/NotchLog.swift
@@ -1,0 +1,57 @@
+//
+//  NotchLog.swift
+//  ClaudeIsland
+//
+//  Plain-text log for things worth inspecting after the fact — mainly the
+//  keystrokes sent to a tmux picker, which fail silently when they land in
+//  the wrong pane. `log show` can't be read over the user's shoulder while
+//  a picker is stuck; a file can.
+//
+
+import Foundation
+
+enum NotchLog {
+    /// ~/Library/Logs/VibeNotch/vibe-notch.log
+    static let fileURL: URL = {
+        let dir = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Logs/VibeNotch", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("vibe-notch.log")
+    }()
+
+    private static let queue = DispatchQueue(label: "com.claudeisland.notchlog")
+    private static let maxBytes = 2 * 1024 * 1024
+
+    private static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        // Fixed locale/calendar: the user's own calendar (e.g. Hijri) would
+        // otherwise make timestamps hard to line up with anything else
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.calendar = Calendar(identifier: .gregorian)
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return f
+    }()
+
+    /// Append one line. `category` groups related entries, e.g. "answer".
+    static func write(_ category: String, _ message: String) {
+        let line = "\(formatter.string(from: Date())) [\(category)] \(message)\n"
+        queue.async {
+            guard let data = line.data(using: .utf8) else { return }
+            let url = fileURL
+
+            // ponytail: truncate rather than rotate — the tail is what matters
+            if let size = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int,
+               size > maxBytes {
+                try? FileManager.default.removeItem(at: url)
+            }
+
+            if let handle = try? FileHandle(forWritingTo: url) {
+                handle.seekToEndOfFile()
+                handle.write(data)
+                try? handle.close()
+            } else {
+                try? data.write(to: url)
+            }
+        }
+    }
+}

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -187,6 +187,29 @@ actor SessionStore {
         )
     }
 
+    /// Flatten a hook's tool_input into strings. Nested arrays/objects
+    /// (e.g. AskUserQuestion's `questions`) are kept as raw JSON instead of
+    /// being dropped, so the UI can decode them.
+    private static func flattenHookInput(_ hookInput: [String: AnyCodable]?) -> [String: String] {
+        var input: [String: String] = [:]
+        guard let hookInput else { return input }
+
+        for (key, value) in hookInput {
+            if let str = value.value as? String {
+                input[key] = str
+            } else if let num = value.value as? Int {
+                input[key] = String(num)
+            } else if let bool = value.value as? Bool {
+                input[key] = bool ? "true" : "false"
+            } else if JSONSerialization.isValidJSONObject([value.value]),
+                      let data = try? JSONSerialization.data(withJSONObject: value.value),
+                      let json = String(data: data, encoding: .utf8) {
+                input[key] = json
+            }
+        }
+        return input
+    }
+
     private func processToolTracking(event: HookEvent, session: inout SessionState) {
         switch event.event {
         case "PreToolUse":
@@ -202,18 +225,7 @@ actor SessionStore {
 
                 let toolExists = session.chatItems.contains { $0.id == toolUseId }
                 if !toolExists {
-                    var input: [String: String] = [:]
-                    if let hookInput = event.toolInput {
-                        for (key, value) in hookInput {
-                            if let str = value.value as? String {
-                                input[key] = str
-                            } else if let num = value.value as? Int {
-                                input[key] = String(num)
-                            } else if let bool = value.value as? Bool {
-                                input[key] = bool ? "true" : "false"
-                            }
-                        }
-                    }
+                    let input = Self.flattenHookInput(event.toolInput)
 
                     let placeholderItem = ChatHistoryItem(
                         id: toolUseId,
@@ -688,6 +700,8 @@ actor SessionStore {
             structuredResults: payload.structuredResults
         )
 
+        updateQuestionPhase(&session)
+
         sessions[payload.sessionId] = session
 
         await emitToolCompletionEvents(
@@ -697,6 +711,43 @@ actor SessionStore {
             toolResults: payload.toolResults,
             structuredResults: payload.structuredResults
         )
+    }
+
+    /// Reflect an unanswered AskUserQuestion in the session phase.
+    ///
+    /// No hook fires while the picker is on screen (PostToolUse only arrives once
+    /// the user has answered), so the JSONL tool_use block is the only live signal.
+    /// Marking it as waitingForApproval reuses every existing "needs attention"
+    /// affordance in the UI.
+    private func updateQuestionPhase(_ session: inout SessionState) {
+        let pending = session.chatItems.last { item in
+            guard case .toolCall(let tool) = item.type else { return false }
+            return tool.name == "AskUserQuestion"
+        }
+
+        var pendingId: String?
+        if let pending, case .toolCall(let tool) = pending.type,
+           tool.result == nil, tool.status == .running || tool.status == .waitingForApproval {
+            pendingId = pending.id
+        }
+
+        if let pendingId {
+            guard session.phase.approvalToolName != "AskUserQuestion" else { return }
+            let context = PermissionContext(
+                toolUseId: pendingId,
+                toolName: "AskUserQuestion",
+                toolInput: nil,
+                receivedAt: Date()
+            )
+            if let next = session.phase.transition(to: .waitingForApproval(context)) {
+                session.phase = next
+            }
+        } else if session.phase.approvalToolName == "AskUserQuestion" {
+            // Answered (or interrupted) — hand the session back to its normal flow
+            if let next = session.phase.transition(to: .processing) {
+                session.phase = next
+            }
+        }
     }
 
     /// Populate subagent tools for Task/Agent tools using their agent JSONL files

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -435,10 +435,13 @@ actor SessionStore {
     private func processToolCompleted(sessionId: String, toolUseId: String, result: ToolCompletionResult) async {
         guard var session = sessions[sessionId] else { return }
 
-        // Check if this tool is already completed (avoid duplicate processing)
+        // Check if this tool is already completed (avoid duplicate processing).
+        // A completed tool with no result yet is still worth updating: hooks mark
+        // completion without a payload, the result only arrives from JSONL.
         if let existingItem = session.chatItems.first(where: { $0.id == toolUseId }),
            case .toolCall(let tool) = existingItem.type,
-           tool.status == .success || tool.status == .error || tool.status == .interrupted {
+           tool.status == .success || tool.status == .error || tool.status == .interrupted,
+           tool.result != nil || tool.structuredResult != nil {
             // Already completed, skip
             return
         }
@@ -702,6 +705,12 @@ actor SessionStore {
 
         updateQuestionPhase(&session)
 
+        backfillToolResults(
+            session: &session,
+            toolResults: payload.toolResults,
+            structuredResults: payload.structuredResults
+        )
+
         sessions[payload.sessionId] = session
 
         await emitToolCompletionEvents(
@@ -802,6 +811,58 @@ actor SessionStore {
     }
 
     /// Emit toolCompleted events for tools that have results in JSONL but aren't marked complete yet
+    /// Record what was sent to an AskUserQuestion picker from the notch, so the
+    /// chat keeps a record of the picks. The JSONL result for these tools does
+    /// not reliably reach the store, and the answer is worth keeping visible.
+    func recordQuestionAnswer(sessionId: String, toolUseId: String, answer: String) {
+        guard var session = sessions[sessionId],
+              let idx = session.chatItems.firstIndex(where: { $0.id == toolUseId }),
+              case .toolCall(var tool) = session.chatItems[idx].type else { return }
+
+        let previous = tool.answeredPicks
+        tool.answeredPicks = previous.isEmpty ? answer : previous + "\n" + answer
+        session.chatItems[idx] = ChatHistoryItem(
+            id: toolUseId,
+            type: .toolCall(tool),
+            timestamp: session.chatItems[idx].timestamp
+        )
+        sessions[sessionId] = session
+        publishState()
+    }
+
+    /// Fill in results for tool items that hooks created. Hook events carry no
+    /// payload, and a hook-made item is skipped by the JSONL merge (its id is
+    /// already known), so without this the result never lands anywhere.
+    private func backfillToolResults(
+        session: inout SessionState,
+        toolResults: [String: ConversationParser.ToolResult],
+        structuredResults: [String: ToolResultData]
+    ) {
+        for i in 0..<session.chatItems.count {
+            let id = session.chatItems[i].id
+            guard case .toolCall(var tool) = session.chatItems[i].type,
+                  tool.result == nil, tool.structuredResult == nil,
+                  toolResults[id] != nil || structuredResults[id] != nil else { continue }
+
+            let completion = ToolCompletionResult.from(
+                parserResult: toolResults[id],
+                structuredResult: structuredResults[id]
+            )
+            guard completion.result != nil || completion.structuredResult != nil else { continue }
+
+            tool.result = completion.result
+            tool.structuredResult = completion.structuredResult
+            if tool.status == .running || tool.status == .waitingForApproval {
+                tool.status = completion.status
+            }
+            session.chatItems[i] = ChatHistoryItem(
+                id: id,
+                type: .toolCall(tool),
+                timestamp: session.chatItems[i].timestamp
+            )
+        }
+    }
+
     private func emitToolCompletionEvents(
         sessionId: String,
         session: SessionState,
@@ -812,8 +873,12 @@ actor SessionStore {
         for item in session.chatItems {
             guard case .toolCall(let tool) = item.type else { continue }
 
-            // Only emit for tools that are running or waiting but have results in JSONL
-            guard tool.status == .running || tool.status == .waitingForApproval else { continue }
+            // Emit for tools still in flight, and for ones a hook marked done
+            // without carrying a result — JSONL is the only source for that payload
+            let isPending = tool.status == .running || tool.status == .waitingForApproval
+            let missesResult = tool.result == nil && tool.structuredResult == nil
+                && (toolResults[item.id] != nil || structuredResults[item.id] != nil)
+            guard isPending || missesResult else { continue }
             guard completedToolIds.contains(item.id) else { continue }
 
             let result = ToolCompletionResult.from(
@@ -1047,6 +1112,12 @@ actor SessionStore {
 
         // Sort by timestamp
         session.chatItems.sort { $0.timestamp < $1.timestamp }
+
+        backfillToolResults(
+            session: &session,
+            toolResults: toolResults,
+            structuredResults: structuredResults
+        )
 
         sessions[sessionId] = session
     }

--- a/ClaudeIsland/Services/State/ToolEventProcessor.swift
+++ b/ClaudeIsland/Services/State/ToolEventProcessor.swift
@@ -218,6 +218,12 @@ enum ToolEventProcessor {
                 input[key] = String(num)
             } else if let bool = value.value as? Bool {
                 input[key] = bool ? "true" : "false"
+            } else if JSONSerialization.isValidJSONObject([value.value]),
+                      let data = try? JSONSerialization.data(withJSONObject: value.value),
+                      let json = String(data: data, encoding: .utf8) {
+                // Nested arrays/objects (e.g. AskUserQuestion's `questions`) are kept
+                // as raw JSON so callers can decode them instead of losing them
+                input[key] = json
             }
         }
         return input

--- a/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
+++ b/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
@@ -48,6 +48,29 @@ actor ToolApprovalHandler {
         await sendKeys(to: target, keys: message, pressEnter: true)
     }
 
+    /// Answer an AskUserQuestion picker.
+    ///
+    /// The picker lists options as `1.`, `2.`, … and a bare digit selects and
+    /// submits immediately. For multi-select questions each digit toggles an
+    /// option and Return confirms the set.
+    func answerQuestion(optionNumbers: [Int], multiSelect: Bool, to target: TmuxTarget) async -> Bool {
+        guard !optionNumbers.isEmpty else { return false }
+
+        for number in optionNumbers {
+            guard await sendKeys(to: target, keys: String(number), pressEnter: false) else {
+                return false
+            }
+            if multiSelect {
+                try? await Task.sleep(for: .milliseconds(80))
+            }
+        }
+
+        guard multiSelect else { return true }
+
+        try? await Task.sleep(for: .milliseconds(120))
+        return await sendKeys(to: target, keys: "", pressEnter: true)
+    }
+
     // MARK: - Private Methods
 
     private func sendKeys(to target: TmuxTarget, keys: String, pressEnter: Bool) async -> Bool {

--- a/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
+++ b/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
@@ -65,8 +65,19 @@ actor ToolApprovalHandler {
     ) async -> Bool {
         guard !optionNumbers.isEmpty else { return false }
 
+        NotchLog.write("answer", "target=\(target.targetString) picks=\(optionNumbers) multi=\(multiSelect) options=\(optionCount) confirmReview=\(confirmReview)")
+
+        // A picker that isn't on screen means the keystrokes would land in a
+        // shell — the single most likely way an answer silently disappears
+        let before = await capturePane(target: target) ?? ""
+        guard before.contains("to navigate") || before.contains("Enter to select") else {
+            NotchLog.write("answer", "ABORT: no picker in pane \(target.targetString). tail=\(Self.tail(before))")
+            return false
+        }
+
         for number in optionNumbers {
             guard await sendKeys(to: target, keys: String(number), pressEnter: false) else {
+                NotchLog.write("answer", "FAIL: send-keys \(number) failed")
                 return false
             }
             if multiSelect {
@@ -89,10 +100,30 @@ actor ToolApprovalHandler {
         if confirmReview {
             await confirmReviewIfPresent(target: target)
         }
+
+        // The picker redraws on every accepted keystroke. An unchanged pane
+        // means nothing was accepted, so report failure rather than let the UI
+        // record an answer that never arrived.
+        try? await Task.sleep(for: .milliseconds(250))
+        let after = await capturePane(target: target) ?? ""
+        guard after != before else {
+            NotchLog.write("answer", "FAIL: pane unchanged after keys. tail=\(Self.tail(after))")
+            return false
+        }
+
+        NotchLog.write("answer", "OK: pane advanced. tail=\(Self.tail(after))")
         return true
     }
 
     // MARK: - Private Methods
+
+    /// Last few non-empty lines of a pane, for log context
+    private static func tail(_ pane: String, lines: Int = 4) -> String {
+        pane.components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            .suffix(lines)
+            .joined(separator: " | ")
+    }
 
     /// Confirm the final "Ready to submit your answers?" screen when it appears.
     /// The cursor already sits on "Submit answers", so Return is enough.
@@ -101,10 +132,12 @@ actor ToolApprovalHandler {
             try? await Task.sleep(for: .milliseconds(300))
             guard let pane = await capturePane(target: target) else { continue }
             if pane.contains("Ready to submit your answers?") {
-                _ = await sendKey(named: "Enter", to: target)
+                let sent = await sendKey(named: "Enter", to: target)
+                NotchLog.write("answer", "review screen confirmed (enter sent=\(sent))")
                 return
             }
         }
+        NotchLog.write("answer", "no review screen appeared within 2.4s")
     }
 
     /// Current visible text of the target pane

--- a/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
+++ b/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
@@ -50,22 +50,24 @@ actor ToolApprovalHandler {
 
     /// Answer an AskUserQuestion picker.
     ///
-    /// The picker lists options as `1.`, `2.`, … and a bare digit selects and
-    /// submits immediately. For multi-select questions each digit only toggles
-    /// an option and leaves the cursor on the first row, so Return would toggle
-    /// that row instead of submitting: the cursor has to walk down to the
-    /// `Submit` row first. After the last question the picker shows a "Ready to
-    /// submit your answers?" review screen that needs one more Return.
+    /// Digit shortcuts only work in the plain picker — the side-by-side variant
+    /// (options carrying a `preview`) ignores them, so an answer sent that way
+    /// vanished silently. Both variants respond to arrow keys and Return, so the
+    /// cursor is walked onto the wanted row instead, matched by its label.
+    ///
+    /// Return selects in a single-select question and toggles in a multi-select
+    /// one, where the `Submit` row has to be reached before the set is sent.
+    /// After the last question a "Ready to submit your answers?" review screen
+    /// takes one more Return.
     func answerQuestion(
         optionNumbers: [Int],
         multiSelect: Bool,
-        optionCount: Int,
         confirmReview: Bool,
         to target: TmuxTarget
     ) async -> Bool {
         guard !optionNumbers.isEmpty else { return false }
 
-        NotchLog.write("answer", "target=\(target.targetString) picks=\(optionNumbers) multi=\(multiSelect) options=\(optionCount) confirmReview=\(confirmReview)")
+        NotchLog.write("answer", "target=\(target.targetString) picks=\(optionNumbers) multi=\(multiSelect) confirmReview=\(confirmReview)")
 
         // A picker that isn't on screen means the keystrokes would land in a
         // shell — the single most likely way an answer silently disappears
@@ -75,24 +77,24 @@ actor ToolApprovalHandler {
             return false
         }
 
-        for number in optionNumbers {
-            guard await sendKeys(to: target, keys: String(number), pressEnter: false) else {
-                NotchLog.write("answer", "FAIL: send-keys \(number) failed")
+        for number in optionNumbers.sorted() {
+            guard await moveCursor(target: target, matches: { Self.row($0, isNumber: number) }) else {
+                NotchLog.write("answer", "FAIL: could not put cursor on option \(number)")
                 return false
             }
-            if multiSelect {
-                try? await Task.sleep(for: .milliseconds(80))
+            guard await sendKey(named: "Enter", to: target) else {
+                NotchLog.write("answer", "FAIL: Enter failed on option \(number)")
+                return false
             }
+            try? await Task.sleep(for: .milliseconds(120))
         }
 
         if multiSelect {
-            // Rows below the options: "Type something", then "Submit"
-            // ponytail: fixed step count — picker layout is stable across questions
-            for _ in 0..<(optionCount + 1) {
-                guard await sendKey(named: "Down", to: target) else { return false }
-                try? await Task.sleep(for: .milliseconds(60))
+            guard await moveCursor(target: target, matches: { $0.contains("Submit") }),
+                  await sendKey(named: "Enter", to: target) else {
+                NotchLog.write("answer", "FAIL: could not submit multi-select set")
+                return false
             }
-            guard await sendKey(named: "Enter", to: target) else { return false }
         }
 
         // Only after the last question — polling during earlier ones would leave
@@ -116,6 +118,44 @@ actor ToolApprovalHandler {
     }
 
     // MARK: - Private Methods
+
+    /// Walk the cursor down until it sits on the row `matches` accepts.
+    /// Long labels wrap onto a second line, so rows are matched by their
+    /// leading number rather than their text.
+    private func moveCursor(
+        target: TmuxTarget,
+        matches: @Sendable (String) -> Bool
+    ) async -> Bool {
+        let maxSteps = 24
+
+        for step in 0...maxSteps {
+            guard let pane = await capturePane(target: target) else { return false }
+            if let cursorLine = Self.cursorLine(pane), matches(cursorLine) {
+                return true
+            }
+            guard step < maxSteps else { break }
+            guard await sendKey(named: "Down", to: target) else { return false }
+            try? await Task.sleep(for: .milliseconds(60))
+        }
+
+        return false
+    }
+
+    /// The picker row the cursor is on. The prompt line also carries `❯`, so
+    /// only rows that look like picker entries count.
+    private static func cursorLine(_ pane: String) -> String? {
+        pane.components(separatedBy: "\n").last { line in
+            guard line.contains("❯") else { return false }
+            let body = line.drop { $0 != "❯" }.dropFirst().trimmingCharacters(in: .whitespaces)
+            return body.first?.isNumber == true || body.hasPrefix("Submit")
+        }
+    }
+
+    /// Whether a picker row is the numbered entry `number`
+    private static func row(_ line: String, isNumber number: Int) -> Bool {
+        let body = line.drop { $0 != "❯" }.dropFirst().trimmingCharacters(in: .whitespaces)
+        return body.hasPrefix("\(number).")
+    }
 
     /// Last few non-empty lines of a pane, for log context
     private static func tail(_ pane: String, lines: Int = 4) -> String {

--- a/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
+++ b/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
@@ -60,6 +60,7 @@ actor ToolApprovalHandler {
         optionNumbers: [Int],
         multiSelect: Bool,
         optionCount: Int,
+        confirmReview: Bool,
         to target: TmuxTarget
     ) async -> Bool {
         guard !optionNumbers.isEmpty else { return false }
@@ -83,7 +84,11 @@ actor ToolApprovalHandler {
             guard await sendKey(named: "Enter", to: target) else { return false }
         }
 
-        await confirmReviewIfPresent(target: target)
+        // Only after the last question — polling during earlier ones would leave
+        // two watchers racing to press Return on the same review screen
+        if confirmReview {
+            await confirmReviewIfPresent(target: target)
+        }
         return true
     }
 

--- a/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
+++ b/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
@@ -51,9 +51,17 @@ actor ToolApprovalHandler {
     /// Answer an AskUserQuestion picker.
     ///
     /// The picker lists options as `1.`, `2.`, … and a bare digit selects and
-    /// submits immediately. For multi-select questions each digit toggles an
-    /// option and Return confirms the set.
-    func answerQuestion(optionNumbers: [Int], multiSelect: Bool, to target: TmuxTarget) async -> Bool {
+    /// submits immediately. For multi-select questions each digit only toggles
+    /// an option and leaves the cursor on the first row, so Return would toggle
+    /// that row instead of submitting: the cursor has to walk down to the
+    /// `Submit` row first. After the last question the picker shows a "Ready to
+    /// submit your answers?" review screen that needs one more Return.
+    func answerQuestion(
+        optionNumbers: [Int],
+        multiSelect: Bool,
+        optionCount: Int,
+        to target: TmuxTarget
+    ) async -> Bool {
         guard !optionNumbers.isEmpty else { return false }
 
         for number in optionNumbers {
@@ -65,13 +73,58 @@ actor ToolApprovalHandler {
             }
         }
 
-        guard multiSelect else { return true }
+        if multiSelect {
+            // Rows below the options: "Type something", then "Submit"
+            // ponytail: fixed step count — picker layout is stable across questions
+            for _ in 0..<(optionCount + 1) {
+                guard await sendKey(named: "Down", to: target) else { return false }
+                try? await Task.sleep(for: .milliseconds(60))
+            }
+            guard await sendKey(named: "Enter", to: target) else { return false }
+        }
 
-        try? await Task.sleep(for: .milliseconds(120))
-        return await sendKeys(to: target, keys: "", pressEnter: true)
+        await confirmReviewIfPresent(target: target)
+        return true
     }
 
     // MARK: - Private Methods
+
+    /// Confirm the final "Ready to submit your answers?" screen when it appears.
+    /// The cursor already sits on "Submit answers", so Return is enough.
+    private func confirmReviewIfPresent(target: TmuxTarget) async {
+        for _ in 0..<8 {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard let pane = await capturePane(target: target) else { continue }
+            if pane.contains("Ready to submit your answers?") {
+                _ = await sendKey(named: "Enter", to: target)
+                return
+            }
+        }
+    }
+
+    /// Current visible text of the target pane
+    private func capturePane(target: TmuxTarget) async -> String? {
+        guard let tmuxPath = await TmuxPathFinder.shared.getTmuxPath() else { return nil }
+        return try? await ProcessExecutor.shared.run(
+            tmuxPath,
+            arguments: ["capture-pane", "-t", target.targetString, "-p"]
+        )
+    }
+
+    /// Send a named key (Down, Enter, …) rather than literal text
+    private func sendKey(named key: String, to target: TmuxTarget) async -> Bool {
+        guard let tmuxPath = await TmuxPathFinder.shared.getTmuxPath() else { return false }
+        do {
+            _ = try await ProcessExecutor.shared.run(
+                tmuxPath,
+                arguments: ["send-keys", "-t", target.targetString, key]
+            )
+            return true
+        } catch {
+            Self.logger.error("Error: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
 
     private func sendKeys(to target: TmuxTarget, keys: String, pressEnter: Bool) async -> Bool {
         guard let tmuxPath = await TmuxPathFinder.shared.getTmuxPath() else {

--- a/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
+++ b/ClaudeIsland/Services/Tmux/ToolApprovalHandler.swift
@@ -62,6 +62,7 @@ actor ToolApprovalHandler {
     func answerQuestion(
         optionNumbers: [Int],
         multiSelect: Bool,
+        optionCount: Int,
         confirmReview: Bool,
         to target: TmuxTarget
     ) async -> Bool {
@@ -69,12 +70,29 @@ actor ToolApprovalHandler {
 
         NotchLog.write("answer", "target=\(target.targetString) picks=\(optionNumbers) multi=\(multiSelect) confirmReview=\(confirmReview)")
 
-        // A picker that isn't on screen means the keystrokes would land in a
-        // shell — the single most likely way an answer silently disappears
+        // tmux copy mode swallows keys outright, so that one is always undone
+        await leaveCopyMode(target: target)
+
         let before = await capturePane(target: target) ?? ""
-        guard before.contains("to navigate") || before.contains("Enter to select") else {
-            NotchLog.write("answer", "ABORT: no picker in pane \(target.targetString). tail=\(Self.tail(before))")
-            return false
+        let pickerVisible = before.contains("to navigate") || before.contains("Enter to select")
+
+        // Scrolling Claude Code's own view (mouse wheel) pushes the picker off
+        // screen while the keys still reach it. Nothing sent over tmux scrolls
+        // it back, so send the answer without reading the screen instead of
+        // failing for a reason the user can't see from the notch.
+        if !pickerVisible {
+            guard before.contains("Jump to bottom") || before.contains("to scroll") else {
+                NotchLog.write("answer", "ABORT: no picker in pane \(target.targetString). tail=\(Self.tail(before))")
+                return false
+            }
+            NotchLog.write("answer", "picker scrolled out of view — sending blind")
+            return await answerBlind(
+                optionNumbers: optionNumbers,
+                multiSelect: multiSelect,
+                optionCount: optionCount,
+                confirmReview: confirmReview,
+                to: target
+            )
         }
 
         for number in optionNumbers.sorted() {
@@ -118,6 +136,69 @@ actor ToolApprovalHandler {
     }
 
     // MARK: - Private Methods
+
+    /// Leave copy mode (scrollback) so the pane shows and accepts live input
+    private func leaveCopyMode(target: TmuxTarget) async {
+        guard let tmuxPath = await TmuxPathFinder.shared.getTmuxPath() else { return }
+        let inMode = try? await ProcessExecutor.shared.run(
+            tmuxPath,
+            arguments: ["display-message", "-p", "-t", target.targetString, "#{pane_in_mode}"]
+        )
+        guard inMode?.trimmingCharacters(in: .whitespacesAndNewlines) == "1" else { return }
+
+        _ = try? await ProcessExecutor.shared.run(
+            tmuxPath,
+            arguments: ["send-keys", "-X", "-t", target.targetString, "cancel"]
+        )
+        try? await Task.sleep(for: .milliseconds(120))
+        NotchLog.write("answer", "left copy mode in \(target.targetString) (pane was scrolled up)")
+    }
+
+    /// Answer without reading the screen, for a picker scrolled out of view.
+    /// The cursor sits on the first row of a freshly opened question, so rows
+    /// are counted from there. Success can't be confirmed, so this trusts the
+    /// keys landed — the alternative is refusing to answer at all.
+    private func answerBlind(
+        optionNumbers: [Int],
+        multiSelect: Bool,
+        optionCount: Int,
+        confirmReview: Bool,
+        to target: TmuxTarget
+    ) async -> Bool {
+        var cursor = 1
+
+        for number in optionNumbers.sorted() {
+            for _ in 0..<max(0, number - cursor) {
+                guard await sendKey(named: "Down", to: target) else { return false }
+                try? await Task.sleep(for: .milliseconds(60))
+            }
+            cursor = number
+
+            guard await sendKey(named: "Enter", to: target) else { return false }
+            try? await Task.sleep(for: .milliseconds(120))
+
+            // A single-select answer moves on to the next question, which
+            // starts with the cursor back on its first row
+            if !multiSelect { cursor = 1 }
+        }
+
+        if multiSelect {
+            // Rows past the options: "Type something", then "Submit"
+            for _ in 0..<max(0, optionCount + 2 - cursor) {
+                guard await sendKey(named: "Down", to: target) else { return false }
+                try? await Task.sleep(for: .milliseconds(60))
+            }
+            guard await sendKey(named: "Enter", to: target) else { return false }
+        }
+
+        if confirmReview {
+            try? await Task.sleep(for: .milliseconds(400))
+            _ = await sendKey(named: "Enter", to: target)
+        }
+
+        NotchLog.write("answer", "blind send finished (unverified)")
+        return true
+    }
 
     /// Walk the cursor down until it sits on the row `matches` accepts.
     /// Long labels wrap onto a second line, so rows are matched by their

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -431,18 +431,35 @@ struct ChatView: View {
         return PendingQuestionSet.parse(toolUseId: item.id, input: tool.input)
     }
 
+    /// How many questions of the pending set were already answered from the notch.
+    /// Derived from the store rather than local state so recreating the view
+    /// doesn't rewind the picker and re-ask an answered question.
+    private var answeredQuestionCount: Int {
+        guard let set = pendingQuestionSet,
+              let item = history.first(where: { $0.id == set.toolUseId }),
+              case .toolCall(let tool) = item.type,
+              !tool.answeredPicks.isEmpty else { return 0 }
+        return tool.answeredPicks.components(separatedBy: "\n").count
+    }
+
+    /// Question currently awaiting an answer
+    private var currentQuestionIndex: Int {
+        max(questionIndex, answeredQuestionCount)
+    }
+
     /// Bar for interactive tools like AskUserQuestion that need terminal input
     @ViewBuilder
     private var interactivePromptBar: some View {
         if let set = pendingQuestionSet, session.isInTmux,
-           questionIndex < set.questions.count {
+           currentQuestionIndex < set.questions.count {
+            let index = currentQuestionIndex
             QuestionAnswerBar(
-                question: set.questions[questionIndex],
-                questionNumber: questionIndex + 1,
+                question: set.questions[index],
+                questionNumber: index + 1,
                 questionCount: set.questions.count,
                 selected: $selectedOptions,
                 onSubmit: { numbers, multiSelect in
-                    let question = set.questions[questionIndex]
+                    let question = set.questions[index]
                     let picks = numbers
                         .compactMap { question.options.indices.contains($0 - 1) ? question.options[$0 - 1].label : nil }
                         .joined(separator: ", ")
@@ -450,12 +467,13 @@ struct ChatView: View {
                         numbers: numbers,
                         multiSelect: multiSelect,
                         optionCount: question.options.count,
+                        isLastQuestion: index + 1 == set.questions.count,
                         toolUseId: set.toolUseId,
                         picks: picks
                     )
                 }
             )
-            .id("\(set.toolUseId)-\(questionIndex)")
+            .id("\(set.toolUseId)-\(index)")
             .onChange(of: set.toolUseId) { _, _ in
                 questionIndex = 0
                 selectedOptions = []
@@ -473,6 +491,7 @@ struct ChatView: View {
         numbers: [Int],
         multiSelect: Bool,
         optionCount: Int,
+        isLastQuestion: Bool,
         toolUseId: String,
         picks: String
     ) {
@@ -495,6 +514,7 @@ struct ChatView: View {
                 optionNumbers: numbers,
                 multiSelect: multiSelect,
                 optionCount: optionCount,
+                confirmReview: isLastQuestion,
                 to: target
             )
         }

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -469,6 +469,7 @@ struct ChatView: View {
                         numbers: numbers,
                         labels: labels,
                         multiSelect: multiSelect,
+                        optionCount: question.options.count,
                         isLastQuestion: index + 1 == set.questions.count,
                         toolUseId: set.toolUseId
                     )
@@ -492,6 +493,7 @@ struct ChatView: View {
         numbers: [Int],
         labels: [String],
         multiSelect: Bool,
+        optionCount: Int,
         isLastQuestion: Bool,
         toolUseId: String
     ) {
@@ -516,6 +518,7 @@ struct ChatView: View {
             let sent = await ToolApprovalHandler.shared.answerQuestion(
                 optionNumbers: numbers,
                 multiSelect: multiSelect,
+                optionCount: optionCount,
                 confirmReview: isLastQuestion,
                 to: target
             )

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -495,28 +495,40 @@ struct ChatView: View {
         toolUseId: String,
         picks: String
     ) {
-        guard let tty = session.tty else { return }
+        guard let tty = session.tty else {
+            NotchLog.write("answer", "no tty for session \(sessionId.prefix(8)) — cannot send")
+            return
+        }
 
-        Task { await SessionStore.shared.recordQuestionAnswer(
-            sessionId: sessionId,
-            toolUseId: toolUseId,
-            answer: picks
-        ) }
-
-        // Advance locally: the picker moves to the next question immediately,
-        // and the JSONL result only lands once every question is answered
-        questionIndex += 1
         selectedOptions = []
 
         Task {
-            guard let target = await findTmuxTarget(tty: tty) else { return }
-            _ = await ToolApprovalHandler.shared.answerQuestion(
+            guard let target = await findTmuxTarget(tty: tty) else {
+                NotchLog.write("answer", "no tmux pane matched tty=\(tty) — answer not sent")
+                return
+            }
+
+            let sent = await ToolApprovalHandler.shared.answerQuestion(
                 optionNumbers: numbers,
                 multiSelect: multiSelect,
                 optionCount: optionCount,
                 confirmReview: isLastQuestion,
                 to: target
             )
+
+            // Only advance once the picker actually took the keys — recording an
+            // answer that never arrived hides the question and strands the session
+            guard sent else {
+                NotchLog.write("answer", "not recorded: send failed for \(picks)")
+                return
+            }
+
+            await SessionStore.shared.recordQuestionAnswer(
+                sessionId: sessionId,
+                toolUseId: toolUseId,
+                answer: picks
+            )
+            await MainActor.run { questionIndex += 1 }
         }
     }
 

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -26,6 +26,7 @@ struct ChatView: View {
     @State private var isBottomVisible: Bool = true
     @State private var questionIndex: Int = 0
     @State private var selectedOptions: Set<Int> = []
+    @State private var isSendingAnswer: Bool = false
     @FocusState private var isInputFocused: Bool
 
     init(sessionId: String, initialSession: SessionState, sessionMonitor: ClaudeSessionMonitor, viewModel: NotchViewModel) {
@@ -458,18 +459,18 @@ struct ChatView: View {
                 questionNumber: index + 1,
                 questionCount: set.questions.count,
                 selected: $selectedOptions,
+                isSending: isSendingAnswer,
                 onSubmit: { numbers, multiSelect in
                     let question = set.questions[index]
-                    let picks = numbers
-                        .compactMap { question.options.indices.contains($0 - 1) ? question.options[$0 - 1].label : nil }
-                        .joined(separator: ", ")
+                    let labels = numbers.sorted().compactMap {
+                        question.options.indices.contains($0 - 1) ? question.options[$0 - 1].label : nil
+                    }
                     answerQuestion(
                         numbers: numbers,
+                        labels: labels,
                         multiSelect: multiSelect,
-                        optionCount: question.options.count,
                         isLastQuestion: index + 1 == set.questions.count,
-                        toolUseId: set.toolUseId,
-                        picks: picks
+                        toolUseId: set.toolUseId
                     )
                 }
             )
@@ -489,20 +490,24 @@ struct ChatView: View {
     /// Send the chosen option numbers to the terminal picker
     private func answerQuestion(
         numbers: [Int],
+        labels: [String],
         multiSelect: Bool,
-        optionCount: Int,
         isLastQuestion: Bool,
-        toolUseId: String,
-        picks: String
+        toolUseId: String
     ) {
+        guard !isSendingAnswer else { return }
         guard let tty = session.tty else {
             NotchLog.write("answer", "no tty for session \(sessionId.prefix(8)) — cannot send")
             return
         }
 
+        let picks = labels.joined(separator: ", ")
         selectedOptions = []
+        isSendingAnswer = true
 
         Task {
+            defer { Task { @MainActor in isSendingAnswer = false } }
+
             guard let target = await findTmuxTarget(tty: tty) else {
                 NotchLog.write("answer", "no tmux pane matched tty=\(tty) — answer not sent")
                 return
@@ -511,7 +516,6 @@ struct ChatView: View {
             let sent = await ToolApprovalHandler.shared.answerQuestion(
                 optionNumbers: numbers,
                 multiSelect: multiSelect,
-                optionCount: optionCount,
                 confirmReview: isLastQuestion,
                 to: target
             )
@@ -1190,6 +1194,7 @@ struct QuestionAnswerBar: View {
     let questionNumber: Int
     let questionCount: Int
     @Binding var selected: Set<Int>
+    let isSending: Bool
     let onSubmit: ([Int], Bool) -> Void
 
     var body: some View {
@@ -1207,7 +1212,11 @@ struct QuestionAnswerBar: View {
 
                 Spacer()
 
-                if question.multiSelect && !selected.isEmpty {
+                if isSending {
+                    Text("Gönderiliyor…")
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.5))
+                } else if question.multiSelect && !selected.isEmpty {
                     Button {
                         onSubmit(selected.sorted(), true)
                     } label: {
@@ -1243,6 +1252,7 @@ struct QuestionAnswerBar: View {
         let isSelected = selected.contains(number)
 
         return Button {
+            guard !isSending else { return }
             if question.multiSelect {
                 if isSelected { selected.remove(number) } else { selected.insert(number) }
             } else {

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -24,6 +24,8 @@ struct ChatView: View {
     @State private var newMessageCount: Int = 0
     @State private var previousHistoryCount: Int = 0
     @State private var isBottomVisible: Bool = true
+    @State private var questionIndex: Int = 0
+    @State private var selectedOptions: Set<Int> = []
     @FocusState private var isInputFocused: Bool
 
     init(sessionId: String, initialSession: SessionState, sessionMonitor: ClaudeSessionMonitor, viewModel: NotchViewModel) {
@@ -419,12 +421,60 @@ struct ChatView: View {
 
     // MARK: - Interactive Prompt Bar
 
+    /// The unanswered AskUserQuestion of this session, if any
+    private var pendingQuestionSet: PendingQuestionSet? {
+        guard let item = history.last(where: { item in
+            guard case .toolCall(let tool) = item.type else { return false }
+            return tool.name == "AskUserQuestion"
+        }), case .toolCall(let tool) = item.type, tool.result == nil else { return nil }
+
+        return PendingQuestionSet.parse(toolUseId: item.id, input: tool.input)
+    }
+
     /// Bar for interactive tools like AskUserQuestion that need terminal input
+    @ViewBuilder
     private var interactivePromptBar: some View {
-        ChatInteractivePromptBar(
-            isInTmux: session.isInTmux,
-            onGoToTerminal: { focusTerminal() }
-        )
+        if let set = pendingQuestionSet, session.isInTmux,
+           questionIndex < set.questions.count {
+            QuestionAnswerBar(
+                question: set.questions[questionIndex],
+                questionNumber: questionIndex + 1,
+                questionCount: set.questions.count,
+                selected: $selectedOptions,
+                onSubmit: { numbers, multiSelect in
+                    answerQuestion(numbers: numbers, multiSelect: multiSelect)
+                }
+            )
+            .id("\(set.toolUseId)-\(questionIndex)")
+            .onChange(of: set.toolUseId) { _, _ in
+                questionIndex = 0
+                selectedOptions = []
+            }
+        } else {
+            ChatInteractivePromptBar(
+                isInTmux: session.isInTmux,
+                onGoToTerminal: { focusTerminal() }
+            )
+        }
+    }
+
+    /// Send the chosen option numbers to the terminal picker
+    private func answerQuestion(numbers: [Int], multiSelect: Bool) {
+        guard let tty = session.tty else { return }
+
+        // Advance locally: the picker moves to the next question immediately,
+        // and the JSONL result only lands once every question is answered
+        questionIndex += 1
+        selectedOptions = []
+
+        Task {
+            guard let target = await findTmuxTarget(tty: tty) else { return }
+            _ = await ToolApprovalHandler.shared.answerQuestion(
+                optionNumbers: numbers,
+                multiSelect: multiSelect,
+                to: target
+            )
+        }
     }
 
     // MARK: - Autoscroll Management
@@ -505,8 +555,10 @@ struct ChatView: View {
 
                 let target = parts[0]
                 let paneTty = parts[1].replacingOccurrences(of: "/dev/", with: "")
+                // Hook-reported TTYs carry the /dev/ prefix, pane TTYs may not
+                let sessionTty = tty.replacingOccurrences(of: "/dev/", with: "")
 
-                if paneTty == tty {
+                if paneTty == sessionTty {
                     return TmuxTarget(from: target)
                 }
             }
@@ -1043,6 +1095,109 @@ struct InterruptedMessageView: View {
                 .foregroundColor(.red)
             Spacer()
         }
+    }
+}
+
+// MARK: - Question Answer Bar
+
+/// Clickable options for a pending AskUserQuestion, answered straight from the notch
+struct QuestionAnswerBar: View {
+    let question: PendingQuestion
+    let questionNumber: Int
+    let questionCount: Int
+    @Binding var selected: Set<Int>
+    let onSubmit: ([Int], Bool) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Text(question.header)
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundColor(TerminalColors.amber)
+
+                if questionCount > 1 {
+                    Text("\(questionNumber)/\(questionCount)")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundColor(.white.opacity(0.35))
+                }
+
+                Spacer()
+
+                if question.multiSelect && !selected.isEmpty {
+                    Button {
+                        onSubmit(selected.sorted(), true)
+                    } label: {
+                        Text("Send \(selected.count)")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(.black)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 5)
+                            .background(Capsule().fill(Color.white.opacity(0.95)))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            Text(question.question)
+                .font(.system(size: 12))
+                .foregroundColor(.white.opacity(0.85))
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 4) {
+                ForEach(Array(question.options.enumerated()), id: \.offset) { index, option in
+                    optionRow(index: index, option: option)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color.black.opacity(0.2))
+    }
+
+    private func optionRow(index: Int, option: PendingQuestionOption) -> some View {
+        let number = index + 1
+        let isSelected = selected.contains(number)
+
+        return Button {
+            if question.multiSelect {
+                if isSelected { selected.remove(number) } else { selected.insert(number) }
+            } else {
+                onSubmit([number], false)
+            }
+        } label: {
+            HStack(alignment: .top, spacing: 8) {
+                Text("\(number)")
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundColor(isSelected ? .black : .white.opacity(0.5))
+                    .frame(width: 18, height: 18)
+                    .background(Circle().fill(isSelected ? Color.white.opacity(0.95) : Color.white.opacity(0.08)))
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(option.label)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(.white.opacity(0.9))
+                        .multilineTextAlignment(.leading)
+
+                    if !option.description.isEmpty {
+                        Text(option.description)
+                            .font(.system(size: 11))
+                            .foregroundColor(.white.opacity(0.45))
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? Color.white.opacity(0.12) : Color.white.opacity(0.05))
+            )
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -442,7 +442,17 @@ struct ChatView: View {
                 questionCount: set.questions.count,
                 selected: $selectedOptions,
                 onSubmit: { numbers, multiSelect in
-                    answerQuestion(numbers: numbers, multiSelect: multiSelect)
+                    let question = set.questions[questionIndex]
+                    let picks = numbers
+                        .compactMap { question.options.indices.contains($0 - 1) ? question.options[$0 - 1].label : nil }
+                        .joined(separator: ", ")
+                    answerQuestion(
+                        numbers: numbers,
+                        multiSelect: multiSelect,
+                        optionCount: question.options.count,
+                        toolUseId: set.toolUseId,
+                        picks: picks
+                    )
                 }
             )
             .id("\(set.toolUseId)-\(questionIndex)")
@@ -459,8 +469,20 @@ struct ChatView: View {
     }
 
     /// Send the chosen option numbers to the terminal picker
-    private func answerQuestion(numbers: [Int], multiSelect: Bool) {
+    private func answerQuestion(
+        numbers: [Int],
+        multiSelect: Bool,
+        optionCount: Int,
+        toolUseId: String,
+        picks: String
+    ) {
         guard let tty = session.tty else { return }
+
+        Task { await SessionStore.shared.recordQuestionAnswer(
+            sessionId: sessionId,
+            toolUseId: toolUseId,
+            answer: picks
+        ) }
 
         // Advance locally: the picker moves to the next question immediately,
         // and the JSONL result only lands once every question is answered
@@ -472,6 +494,7 @@ struct ChatView: View {
             _ = await ToolApprovalHandler.shared.answerQuestion(
                 optionNumbers: numbers,
                 multiSelect: multiSelect,
+                optionCount: optionCount,
                 to: target
             )
         }
@@ -777,7 +800,16 @@ struct ToolCallView: View {
     }
 
     private var showContent: Bool {
-        tool.name == "Edit" || isExpanded
+        // AskUserQuestion always shows its answers — what was picked matters
+        // after the fact, and hiding it behind a tap loses the record
+        tool.name == "Edit" || tool.name == "AskUserQuestion" || isExpanded
+    }
+
+    /// Question texts of an AskUserQuestion call
+    private var askedQuestions: [String] {
+        guard tool.name == "AskUserQuestion" else { return [] }
+        return PendingQuestionSet.parse(toolUseId: tool.name, input: tool.input)?
+            .questions.map(\.question) ?? []
     }
 
     private var agentDescription: String? {
@@ -822,6 +854,12 @@ struct ToolCallView: View {
                         .foregroundColor(textColor.opacity(0.7))
                         .lineLimit(1)
                         .truncationMode(.tail)
+                } else if tool.name == "AskUserQuestion", let asked = askedQuestions.first {
+                    Text(asked)
+                        .font(.system(size: 11))
+                        .foregroundColor(textColor.opacity(0.7))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                 } else if MCPToolFormatter.isMCPTool(tool.name) && !tool.input.isEmpty {
                     Text(MCPToolFormatter.formatArgs(tool.input))
                         .font(.system(size: 11))
@@ -846,6 +884,20 @@ struct ToolCallView: View {
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
                         .animation(.spring(response: 0.25, dampingFraction: 0.8), value: isExpanded)
                 }
+            }
+
+            // Options sent from the notch — kept visible after the picker closes
+            if !tool.answeredPicks.isEmpty {
+                VStack(alignment: .leading, spacing: 1) {
+                    ForEach(Array(tool.answeredPicks.components(separatedBy: "\n").enumerated()), id: \.offset) { _, pick in
+                        Text("→ \(pick)")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(.green.opacity(0.75))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .padding(.leading, 12)
+                .padding(.top, 2)
             }
 
             // Subagent tools list (for Task/Agent tools)
@@ -1166,11 +1218,19 @@ struct QuestionAnswerBar: View {
             }
         } label: {
             HStack(alignment: .top, spacing: 8) {
-                Text("\(number)")
-                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                    .foregroundColor(isSelected ? .black : .white.opacity(0.5))
-                    .frame(width: 18, height: 18)
-                    .background(Circle().fill(isSelected ? Color.white.opacity(0.95) : Color.white.opacity(0.08)))
+                Group {
+                    if question.multiSelect {
+                        Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                            .font(.system(size: 14))
+                            .foregroundColor(isSelected ? .white.opacity(0.95) : .white.opacity(0.4))
+                    } else {
+                        Text("\(number)")
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            .foregroundColor(isSelected ? .black : .white.opacity(0.5))
+                            .background(Circle().fill(isSelected ? Color.white.opacity(0.95) : Color.white.opacity(0.08)).frame(width: 18, height: 18))
+                    }
+                }
+                .frame(width: 18, height: 18)
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(option.label)

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -432,7 +432,31 @@ struct NotchView: View {
             viewModel.notchOpen(reason: .notification)
         }
 
+        if !newPendingIds.isEmpty {
+            autoOpenForInteractiveTool(sessions)
+        }
+
         previousPendingIds = currentIds
+    }
+
+    /// Auto-open the notch and jump to the chat view for an AskUserQuestion.
+    /// Its options are only clickable inside the chat view, so a closed-bar icon
+    /// alone would leave the question unanswerable without hunting for it.
+    /// Unlike plain permissions this opens even when the terminal is visible —
+    /// answering from the notch is the whole point.
+    private func autoOpenForInteractiveTool(_ pendingSessions: [SessionState]) {
+        guard let interactiveSession = pendingSessions.first(where: {
+            $0.pendingToolName == "AskUserQuestion"
+        }) else { return }
+
+        if viewModel.status == .closed {
+            viewModel.notchOpen(reason: .notification)
+        }
+
+        // Let the open animation start before navigating to chat
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            viewModel.showChat(for: interactiveSession)
+        }
     }
 
     private func handleWaitingForInputChange(_ instances: [SessionState]) {

--- a/ClaudeIsland/UI/Views/ToolResultViews.swift
+++ b/ClaudeIsland/UI/Views/ToolResultViews.swift
@@ -473,8 +473,8 @@ struct AskUserQuestionResultContent: View {
                         .font(.system(size: 11))
                         .foregroundColor(.white.opacity(0.6))
 
-                    // Answer
-                    if let answer = result.answers["\(index)"] {
+                    // Answer — keyed by question text, older payloads keyed by index
+                    if let answer = result.answers[question.question] ?? result.answers["\(index)"] {
                         HStack(spacing: 4) {
                             Image(systemName: "arrow.turn.down.right")
                                 .font(.system(size: 9))


### PR DESCRIPTION
Adds answering of `AskUserQuestion` prompts straight from the notch, instead of forcing a trip to the terminal.

### What it does
- The notch auto-opens on a pending question and jumps to the chat view.
- Options are clickable rows; single-select submits on click, multi-select toggles and submits with a Send button.
- Answers are sent to the picker over `tmux send-keys`. Sessions not running under tmux keep the existing "go to terminal" bar.
- Picked options stay visible in the chat after the picker closes.

### Multi-select mechanics
A bare digit in the picker only *toggles* a row and leaves the cursor on the first one, so sending Return after the digits toggled option 1 instead of submitting. The cursor now walks down past every option plus the "Type something" row onto `Submit`, and the trailing "Ready to submit your answers?" review screen is confirmed once it appears in the pane. Verified against a live picker in a scratch tmux session.

Multi-select rows render a checkbox rather than a number badge, since clicking them toggles rather than submits.

### Keeping the answer in the chat
Hooks create the tool item without a payload (`PostToolUse` marks success with no result), and the JSONL merge skips ids it already knows — so the result never reached the store and the chat showed an `AskUserQuestion` row with nothing under it. Two changes:
- `ToolCallItem` carries what was sent from the notch, recorded at submit time.
- `backfillToolResults` fills in results for hook-created items when JSONL does carry them, and `processToolCompleted` no longer treats a payload-less completion as final.

Also: `AskUserQuestionResult.answers` is keyed by question text, but the view looked it up by index, so the answer never rendered even when the structured result was present. Fixed, with the index lookup kept as a fallback.

Tested on macOS with Claude Code running under tmux, single- and multi-select, including multi-question sets.